### PR TITLE
Add comprehensive Madin-METPO reconciliation tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,21 @@ generated/bacdive_oxygen_phenotype_mappings.tsv: sparql/bacdive_oxygen_phenotype
 		--query $(word 1,$^) $@ \
 		--input $(word 2,$^)
 
+reports/synonym-sources.tsv: src/ontology/metpo.owl src/sparql/synonym-sources.sparql
+	mkdir -p $(dir $@)
+	robot query \
+		--input $< \
+		--query $(word 2,$^) $@
+
+.PHONY: reconcile-madin
+reconcile-madin: reports/madin-metpo-reconciliation.yaml
+
+reports/madin-metpo-reconciliation.yaml: reports/synonym-sources.tsv
+	uv run python src/scripts/reconcile_madin_coverage.py \
+		--mode integrated \
+		--format yaml \
+		--output $@
+
 # =====================================================
 # Google Sheets Download Targets
 # =====================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "click>=8.0",
+    "pymongo>=4.15.2",
     "pyyaml>=6.0.2",
 ]
 

--- a/reports/madin-metpo-reconciliation.yaml
+++ b/reports/madin-metpo-reconciliation.yaml
@@ -1,0 +1,468 @@
+madin_metpo_reconciliation:
+  summary:
+    total_fields: 35
+    fields_with_name_mapping: 8
+    fields_with_full_value_coverage: 7
+    total_metpo_madin_synonyms: 70
+    verified_synonyms: 62
+    false_synonym_claims: 0
+  fields:
+  - field: carbon_substrates
+    field_mapped: false
+    unique_values: 3977
+  - field: cell_shape
+    field_mapped: true
+    field_metpo_id: METPO:1000666
+    field_metpo_label: cell shape
+    field_entity_type: owl:Class
+    total_values: 19
+    covered_values_count: 19
+    missing_values_count: 0
+    value_coverage_percentage: 100.0
+    covered_values:
+    - value: bacillus
+      metpo_id: METPO:1000667
+      label: bacillus shaped
+      entity_type: owl:Class
+    - value: branced
+      metpo_id: METPO:1000687
+      label: branched shaped
+      entity_type: owl:Class
+    - value: coccobacillus
+      metpo_id: METPO:1000688
+      label: coccobacillus shaped
+      entity_type: owl:Class
+    - value: coccus
+      metpo_id: METPO:1000668
+      label: coccus shaped
+      entity_type: owl:Class
+    - value: 'disc '
+      metpo_id: METPO:1000689
+      label: disc shaped
+      entity_type: owl:Class
+    - value: filament
+      metpo_id: METPO:1000674
+      label: filament shaped
+      entity_type: owl:Class
+    - value: flask
+      metpo_id: METPO:1000675
+      label: flask shaped
+      entity_type: owl:Class
+    - value: fusiform
+      metpo_id: METPO:1000690
+      label: fusiform shaped
+      entity_type: owl:Class
+    - value: irregular
+      metpo_id: METPO:1000691
+      label: irregular shaped
+      entity_type: owl:Class
+    - value: pleomorphic
+      metpo_id: METPO:1000679
+      label: pleomorphic shaped
+      entity_type: owl:Class
+    - value: ring
+      metpo_id: METPO:1000680
+      label: ring shaped
+      entity_type: owl:Class
+    - value: spindle
+      metpo_id: METPO:1000692
+      label: spindle shaped
+      entity_type: owl:Class
+    - value: spiral
+      metpo_id: METPO:1000684
+      label: spiral shaped
+      entity_type: owl:Class
+    - value: spirochete
+      metpo_id: METPO:1000693
+      label: spirochete shaped
+      entity_type: owl:Class
+    - value: square
+      metpo_id: METPO:1000694
+      label: square shaped
+      entity_type: owl:Class
+    - value: star
+      metpo_id: METPO:1000685
+      label: star shaped
+      entity_type: owl:Class
+    - value: tailed
+      metpo_id: METPO:1000695
+      label: tailed shaped
+      entity_type: owl:Class
+    - value: triangular
+      metpo_id: METPO:1000696
+      label: triangular shaped
+      entity_type: owl:Class
+    - value: vibrio
+      metpo_id: METPO:1000686
+      label: vibrio shaped
+      entity_type: owl:Class
+    missing_values: []
+    values_truncated: false
+  - field: class
+    field_mapped: false
+    unique_values: 94
+  - field: coding_genes
+    field_mapped: false
+    unique_values: 5888
+  - field: d1_lo
+    field_mapped: false
+    unique_values: 150
+  - field: d1_up
+    field_mapped: false
+    unique_values: 71
+  - field: d2_lo
+    field_mapped: false
+    unique_values: 245
+  - field: d2_up
+    field_mapped: false
+    unique_values: 120
+  - field: data_source
+    field_mapped: false
+    unique_values: 26
+  - field: doubling_h
+    field_mapped: false
+    unique_values: 650
+  - field: family
+    field_mapped: false
+    unique_values: 480
+  - field: gc_content
+    field_mapped: false
+    unique_values: 9752
+  - field: genome_size
+    field_mapped: false
+    unique_values: 87039
+  - field: genus
+    field_mapped: false
+    unique_values: 2884
+  - field: gram_stain
+    field_mapped: true
+    field_metpo_id: METPO:1000697
+    field_metpo_label: gram stain
+    field_entity_type: owl:Class
+    total_values: 2
+    covered_values_count: 2
+    missing_values_count: 0
+    value_coverage_percentage: 100.0
+    covered_values:
+    - value: negative
+      metpo_id: METPO:1000699
+      label: gram negative
+      entity_type: owl:Class
+    - value: positive
+      metpo_id: METPO:1000698
+      label: gram positive
+      entity_type: owl:Class
+    missing_values: []
+    values_truncated: false
+  - field: growth_tmp
+    field_mapped: false
+    unique_values: 340
+  - field: isolation_source
+    field_mapped: false
+    unique_values: 74
+  - field: metabolism
+    field_mapped: true
+    field_metpo_id: METPO:1000601
+    field_metpo_label: oxygen preference
+    field_entity_type: owl:Class
+    total_values: 7
+    covered_values_count: 7
+    missing_values_count: 0
+    value_coverage_percentage: 100.0
+    covered_values:
+    - value: aerobic
+      metpo_id: METPO:1000602
+      label: aerobic
+      entity_type: owl:Class
+    - value: anaerobic
+      metpo_id: METPO:1000603
+      label: anaerobic
+      entity_type: owl:Class
+    - value: facultative
+      metpo_id: METPO:1000605
+      label: facultatively anaerobic
+      entity_type: owl:Class
+    - value: microaerophilic
+      metpo_id: METPO:1000604
+      label: microaerophilic
+      entity_type: owl:Class
+    - value: obligate aerobic
+      metpo_id: METPO:1000606
+      label: obligately aerobic
+      entity_type: owl:Class
+    - value: obligate anaerobic
+      metpo_id: METPO:1000607
+      label: obligately anaerobic
+      entity_type: owl:Class
+    - value: strictly anaerobic
+      metpo_id: METPO:1000611
+      label: strictly anaerobic
+      entity_type: owl:Class
+    missing_values: []
+    values_truncated: false
+  - field: motility
+    field_mapped: true
+    field_metpo_id: METPO:1000701
+    field_metpo_label: motility
+    field_entity_type: owl:Class
+    total_values: 5
+    covered_values_count: 5
+    missing_values_count: 0
+    value_coverage_percentage: 100.0
+    covered_values:
+    - value: axial filament
+      metpo_id: METPO:1000705
+      label: axially filamented
+      entity_type: owl:Class
+    - value: flagella
+      metpo_id: METPO:1000704
+      label: flagellated
+      entity_type: owl:Class
+    - value: gliding
+      metpo_id: METPO:1000706
+      label: gliding
+      entity_type: owl:Class
+    - value: 'no'
+      metpo_id: METPO:1000703
+      label: non motile
+      entity_type: owl:Class
+    - value: 'yes'
+      metpo_id: METPO:1000702
+      label: motile
+      entity_type: owl:Class
+    missing_values: []
+    values_truncated: false
+  - field: optimum_ph
+    field_mapped: false
+    unique_values: 130
+  - field: optimum_tmp
+    field_mapped: false
+    unique_values: 187
+  - field: order
+    field_mapped: false
+    unique_values: 211
+  - field: org_name
+    field_mapped: false
+    unique_values: 116703
+  - field: pathways
+    field_mapped: true
+    field_metpo_id: METPO:1000631
+    field_metpo_label: trophic type
+    field_entity_type: owl:Class
+    total_values: 103
+    covered_values_count: 15
+    missing_values_count: 88
+    value_coverage_percentage: 14.6
+    covered_values:
+    - value: acetogenesis
+      metpo_id: METPO:1000845
+      label: Acetogenesis
+      entity_type: owl:Class
+    - value: aerobic_anoxygenic_phototrophy
+      metpo_id: METPO:1000660
+      label: phototrophic
+      entity_type: owl:Class
+    - value: aerobic_chemo_heterotrophy
+      metpo_id: METPO:1000636
+      label: chemoheterotrophic
+      entity_type: owl:Class
+    - value: aerobic_heterotrophy
+      metpo_id: METPO:1000644
+      label: heterotrophic
+      entity_type: owl:Class
+    - value: anoxygenic_photoautotrophy
+      metpo_id: METPO:1000656
+      label: photoautotrophic
+      entity_type: owl:Class
+    - value: anoxygenic_photoautotrophy_hydrogen_oxidation
+      metpo_id: METPO:1000656
+      label: photoautotrophic
+      entity_type: owl:Class
+    - value: anoxygenic_photoautotrophy_iron_oxidation
+      metpo_id: METPO:1000656
+      label: photoautotrophic
+      entity_type: owl:Class
+    - value: anoxygenic_photoautotrophy_sulfur_oxidation
+      metpo_id: METPO:1000656
+      label: photoautotrophic
+      entity_type: owl:Class
+    - value: autotrophy
+      metpo_id: METPO:1000632
+      label: autotrophic
+      entity_type: owl:Class
+    - value: fermentation
+      metpo_id: METPO:1002005
+      label: Fermentation
+      entity_type: owl:Class
+    - value: heterotrophic
+      metpo_id: METPO:1000644
+      label: heterotrophic
+      entity_type: owl:Class
+    - value: methanogenesis
+      metpo_id: METPO:1000844
+      label: Methanogenesis
+      entity_type: owl:Class
+    - value: methylotrophy
+      metpo_id: METPO:1000651
+      label: methylotrophic
+      entity_type: owl:Class
+    - value: photoautotrophy
+      metpo_id: METPO:1000656
+      label: photoautotrophic
+      entity_type: owl:Class
+    - value: photoheterotrophy
+      metpo_id: METPO:1000657
+      label: photoheterotrophic
+      entity_type: owl:Class
+    missing_values:
+    - DMSP_degradation
+    - Denitrification
+    - EDTA_degradation
+    - MTBE_degradation
+    - PAH_degradation
+    - PCB_degradation
+    - RDX_degradation
+    - Selenate_reduction
+    - aliphatic_non_methane_hydrocarbon_degradation
+    - aminoacid_degradation
+    - annamox
+    - aromatic_compound_degradation
+    - aromatic_hydrocarbon_degradation
+    - arsenate_reduction
+    - arsenite_oxidation
+    - carbon_monoxide_oxidation
+    - carbonmonoxide_oxidation
+    - carbonmonoxide_reduction
+    - carbonylsulfide_oxidation
+    - carbonylsulfide_reduction
+    values_truncated: true
+  - field: phylum
+    field_mapped: false
+    unique_values: 74
+  - field: rRNA16S_genes
+    field_mapped: false
+    unique_values: 17
+  - field: range_salinity
+    field_mapped: true
+    field_metpo_id: METPO:1000629
+    field_metpo_label: halophily preference
+    field_entity_type: owl:Class
+    total_values: 7
+    covered_values_count: 7
+    missing_values_count: 0
+    value_coverage_percentage: 100.0
+    covered_values:
+    - value: euryhaline
+      metpo_id: METPO:1000627
+      label: euryhaline
+      entity_type: owl:Class
+    - value: extreme-halophilic
+      metpo_id: METPO:1000628
+      label: extremely halophilic
+      entity_type: owl:Class
+    - value: halophilic
+      metpo_id: METPO:1000620
+      label: halophilic
+      entity_type: owl:Class
+    - value: halotolerant
+      metpo_id: METPO:1000622
+      label: halotolerant
+      entity_type: owl:Class
+    - value: moderate-halophilic
+      metpo_id: METPO:1000623
+      label: moderately halophilic
+      entity_type: owl:Class
+    - value: non-halophilic
+      metpo_id: METPO:1000624
+      label: non halophilic
+      entity_type: owl:Class
+    - value: stenohaline
+      metpo_id: METPO:1000626
+      label: stenohaline
+      entity_type: owl:Class
+    missing_values: []
+    values_truncated: false
+  - field: range_tmp
+    field_mapped: true
+    field_metpo_id: METPO:1000613
+    field_metpo_label: temperature preference
+    field_entity_type: owl:Class
+    total_values: 7
+    covered_values_count: 7
+    missing_values_count: 0
+    value_coverage_percentage: 100.0
+    covered_values:
+    - value: extreme thermophilic
+      metpo_id: METPO:1000617
+      label: hyperthermophilic
+      entity_type: owl:Class
+    - value: facultative psychrophilic
+      metpo_id: METPO:1000720
+      label: facultative psychrophilic
+      entity_type: owl:Class
+    - value: mesophilic
+      metpo_id: METPO:1000615
+      label: mesophilic
+      entity_type: owl:Class
+    - value: psychrophilic
+      metpo_id: METPO:1000614
+      label: psychrophilic
+      entity_type: owl:Class
+    - value: psychrotolerant
+      metpo_id: METPO:1000618
+      label: psychrotolerant
+      entity_type: owl:Class
+    - value: thermophilic
+      metpo_id: METPO:1000616
+      label: thermophilic
+      entity_type: owl:Class
+    - value: thermotolerant
+      metpo_id: METPO:1000619
+      label: thermotolerant
+      entity_type: owl:Class
+    missing_values: []
+    values_truncated: false
+  - field: ref_id
+    field_mapped: false
+    unique_values: 20276
+  - field: species
+    field_mapped: false
+    unique_values: 21500
+  - field: species_tax_id
+    field_mapped: false
+    unique_values: 21500
+  - field: sporulation
+    field_mapped: true
+    field_metpo_id: METPO:1000870
+    field_metpo_label: sporulation
+    field_entity_type: owl:Class
+    total_values: 2
+    covered_values_count: 2
+    missing_values_count: 0
+    value_coverage_percentage: 100.0
+    covered_values:
+    - value: 'no'
+      metpo_id: METPO:1000703
+      label: non motile
+      entity_type: owl:Class
+    - value: 'yes'
+      metpo_id: METPO:1000702
+      label: motile
+      entity_type: owl:Class
+    missing_values: []
+    values_truncated: false
+  - field: superkingdom
+    field_mapped: false
+    unique_values: 2
+  - field: tRNA_genes
+    field_mapped: false
+    unique_values: 150
+  - field: tax_id
+    field_mapped: false
+    unique_values: 49155
+  high_value_unmapped_fields:
+  - field: rRNA16S_genes
+    unique_values: 17
+  - field: superkingdom
+    unique_values: 2
+  false_synonym_claims: []

--- a/reports/synonym-sources.tsv
+++ b/reports/synonym-sources.tsv
@@ -1,0 +1,725 @@
+?entity	?entityType	?synonymPred	?synValue	?lang	?synType	?xref	?src	?prov
+<https://w3id.org/metpo/1000441>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Psychrophile"	""				
+<https://w3id.org/metpo/1000442>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Psychrophile"	""				
+<https://w3id.org/metpo/1000442>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Psychrotolerant"	""				
+<https://w3id.org/metpo/1000443>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Mesophilie"	""				
+<https://w3id.org/metpo/1000444>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Mesophilie"	""				
+<https://w3id.org/metpo/1000445>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Mesophilie"	""				
+<https://w3id.org/metpo/1000446>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Mesophilie"	""				
+<https://w3id.org/metpo/1000447>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Thermophile"	""				
+<https://w3id.org/metpo/1000448>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Psychrophile"	""				
+<https://w3id.org/metpo/1000449>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Psychrophile"	""				
+<https://w3id.org/metpo/1000449>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Psychrotolerant"	""				
+<https://w3id.org/metpo/1000450>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Mesophilie"	""				
+<https://w3id.org/metpo/1000451>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Mesophilie"	""				
+<https://w3id.org/metpo/1000452>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Mesophilie"	""				
+<https://w3id.org/metpo/1000453>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Mesophilie"	""				
+<https://w3id.org/metpo/1000454>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Thermophile"	""				
+<https://w3id.org/metpo/1000455>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Acid Tolerant"	""				
+<https://w3id.org/metpo/1000455>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Acidophile"	""				
+<https://w3id.org/metpo/1000455>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Extreme Acidophile"	""				
+<https://w3id.org/metpo/1000455>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Facultative acidophile"	""				
+<https://w3id.org/metpo/1000455>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Obligative acidophile"	""				
+<https://w3id.org/metpo/1000456>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkali Tolerant"	""				
+<https://w3id.org/metpo/1000456>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Neutrophile"	""				
+<https://w3id.org/metpo/1000457>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkali Tolerant"	""				
+<https://w3id.org/metpo/1000457>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkaliphile"	""				
+<https://w3id.org/metpo/1000457>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Neutrophile"	""				
+<https://w3id.org/metpo/1000458>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkali Tolerant"	""				
+<https://w3id.org/metpo/1000458>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkaliphile"	""				
+<https://w3id.org/metpo/1000458>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Extreme Alkaliphile"	""				
+<https://w3id.org/metpo/1000459>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Acid Tolerant"	""				
+<https://w3id.org/metpo/1000459>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Acidophile"	""				
+<https://w3id.org/metpo/1000459>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Extreme Acidophile"	""				
+<https://w3id.org/metpo/1000459>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Facultative acidophile"	""				
+<https://w3id.org/metpo/1000459>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Obligative acidophile"	""				
+<https://w3id.org/metpo/1000460>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Acid Tolerant"	""				
+<https://w3id.org/metpo/1000460>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Acidophile"	""				
+<https://w3id.org/metpo/1000460>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Facultative acidophile"	""				
+<https://w3id.org/metpo/1000460>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Obligative acidophile"	""				
+<https://w3id.org/metpo/1000461>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkali Tolerant"	""				
+<https://w3id.org/metpo/1000461>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Facultative acidophile"	""				
+<https://w3id.org/metpo/1000461>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Neutrophile"	""				
+<https://w3id.org/metpo/1000462>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkali Tolerant"	""				
+<https://w3id.org/metpo/1000462>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkaliphile"	""				
+<https://w3id.org/metpo/1000462>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Facultative acidophile"	""				
+<https://w3id.org/metpo/1000462>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Neutrophile"	""				
+<https://w3id.org/metpo/1000463>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkali Tolerant"	""				
+<https://w3id.org/metpo/1000463>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkaliphile"	""				
+<https://w3id.org/metpo/1000463>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Extreme Alkaliphile"	""				
+<https://w3id.org/metpo/1000463>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Facultative acidophile"	""				
+<https://w3id.org/metpo/1000464>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkali Tolerant"	""				
+<https://w3id.org/metpo/1000464>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Alkaliphile"	""				
+<https://w3id.org/metpo/1000464>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Extreme Alkaliphile"	""				
+<https://w3id.org/metpo/1000465>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Halotolerant"	""				
+<https://w3id.org/metpo/1000465>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Non-halophile"	""				
+<https://w3id.org/metpo/1000466>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Halotolerant"	""				
+<https://w3id.org/metpo/1000466>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Slight halophile"	""				
+<https://w3id.org/metpo/1000467>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Halotolerant"	""				
+<https://w3id.org/metpo/1000467>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Moderate halophile"	""				
+<https://w3id.org/metpo/1000468>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Extreme halophile"	""				
+<https://w3id.org/metpo/1000469>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Halotolerant"	""				
+<https://w3id.org/metpo/1000469>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Non-halophile"	""				
+<https://w3id.org/metpo/1000470>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Halotolerant"	""				
+<https://w3id.org/metpo/1000470>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Slight halophile"	""				
+<https://w3id.org/metpo/1000471>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Halotolerant"	""				
+<https://w3id.org/metpo/1000471>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Moderate halophile"	""				
+<https://w3id.org/metpo/1000472>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"Extreme halophile"	""				
+<https://w3id.org/metpo/1003001>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"neutralophile"	""				
+<https://w3id.org/metpo/1003001>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"neutralophilic"	""				
+<https://w3id.org/metpo/1003001>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"neutrophile"	""				
+<https://w3id.org/metpo/1003002>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"alkaliphile"	""				
+<https://w3id.org/metpo/1003002>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"alkaliphilic"	""				
+<https://w3id.org/metpo/1003002>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"alkalophile"	""				
+<https://w3id.org/metpo/1003002>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"alkalophilic"	""				
+<https://w3id.org/metpo/1003003>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"acidophil"	""				
+<https://w3id.org/metpo/1003003>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"acidophile"	""				
+<https://w3id.org/metpo/1003004>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"obligate alkaliphile"	""				
+<https://w3id.org/metpo/1003004>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"obligate alkaphilic"	""				
+<https://w3id.org/metpo/1003004>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"obligately alkaliphilic"	""				
+<https://w3id.org/metpo/1003005>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"facultative alkaliphile"	""				
+<https://w3id.org/metpo/1003005>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"facultative alkaphilic"	""				
+<https://w3id.org/metpo/1003005>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"facultatively alkaliphilic"	""				
+<https://w3id.org/metpo/1003006>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"obligate acidophile"	""				
+<https://w3id.org/metpo/1003006>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"obligately acidophilic"	""				
+<https://w3id.org/metpo/1003007>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"facultative acidophile"	""				
+<https://w3id.org/metpo/1003007>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"facultatively acidophilic"	""				
+<https://w3id.org/metpo/1003008>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"aciduric"	""				
+<https://w3id.org/metpo/1003009>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>	"alkalitolerant"	""				
+<https://w3id.org/metpo/1000429>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"GC_<42.65"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000430>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"GC_42.65_57.0"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000431>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"GC_57.0_66.3"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000432>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"GC_>66.3"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000441>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TO_<10"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000442>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TO_10_to_22"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000443>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TO_22_to_27"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000444>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TO_27_to_30"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000445>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TO_30_to_34"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000446>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TO_34_to_40"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000447>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TO_>40"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000448>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TR_<10"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000449>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TR_10_to_22"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000450>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TR_22_to_27"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000451>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TR_27_to_30"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000452>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TR_30_to_34"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000453>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TR_34_to_40"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000454>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"TR_>40"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000455>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHO_0_to_6"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000456>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHO_6_to_7"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000457>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHO_7_to_8"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000458>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHO_8_to_14"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000459>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHR_0_to_4"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000460>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHR_4_to_6"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000461>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHR_6_to_7"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000462>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHR_7_to_8"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000463>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHR_8_to_10"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000464>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"10_to_14"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000465>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"NaR_<1"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000466>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"NaR_1_to_3"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000467>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"NaR_3_to_8"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000468>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"NaR_>8"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000469>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"NaO_<1"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000470>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"NaO_1_to_3"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000471>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"NaO_3_to_8"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000472>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"NaO_>8"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000473>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHd_<1"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000474>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHd_1_2"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000475>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHd_2_3"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000476>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHd_3_4"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000477>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHd_4_5"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000478>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pHd_5_9"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000479>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Nad_<1"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000480>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Nad_1_3"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000481>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Nad_3_8"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000482>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Nad_>8"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000483>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Td_1_5"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000484>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Td_5_10"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000485>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Td_10_20"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000486>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Td_20_30"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000487>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Td_>30"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000601>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000601>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Physiology and metabolism.oxygen tolerance.oxygen tolerance"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000601>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"metabolism"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000602>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Ox_aerobic"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000602>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobe"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000602>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000603>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Ox_anaerobic"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000603>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobe"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000603>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000604>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Ox_microerophile"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000604>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"microaerophile"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000604>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"microaerophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000605>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"facultative"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000605>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"facultative anaerobe"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000606>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"obligate aerobe"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000606>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"obligate aerobic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000607>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"obligate anaerobe"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000607>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"obligate anaerobic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000608>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"facultative"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000608>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"facultative aerobe"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000609>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerotolerant"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000610>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"microaerotolerant"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000611>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"strictly anaerobic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000612>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Ox_facultative_aerobe_anaerobe"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000613>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000613>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Physiology and metabolism.culture temp.temperature"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000613>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"range_tmp"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000614>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"psychrophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000614>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"psychrophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000615>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"mesophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000615>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"mesophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000616>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"thermophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000616>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"thermophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000617>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"extreme thermophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000617>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"hyperthermophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000618>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"psychrotolerant"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000619>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"thermotolerant"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000620>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"halophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000620>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"halophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000621>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"haloalkaliphilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000622>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"halotolerant"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000622>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"halotolerant"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000623>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"moderate-halophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000623>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"moderately halophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000624>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"non-halophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000624>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"non-halophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000625>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"slightly halophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000626>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"stenohaline"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000627>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"euryhaline"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000628>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"extreme-halophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000628>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"extremely halophilic"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000629>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000629>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Physiology and metabolism.halophily.halophily level"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000629>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"range_salinity"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000631>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000631>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Physiology and metabolism.nutrition type.type"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000631>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"nutritional type"	""				
+<https://w3id.org/metpo/1000631>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pathways"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000632>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"autotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000632>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"autotrophy"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000634>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemoautolithotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000635>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemoautotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000636>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobic_chemo_heterotrophy"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000636>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemoheterotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000637>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemolithoautotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000638>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemolithoheterotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000639>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemolithotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000640>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemoorganoheterotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000641>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000642>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"copiotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000644>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobic_heterotrophy"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000644>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"heterotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000644>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"heterotrophic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000647>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"lithoautotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000648>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"lithoheterotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000649>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"lithotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000650>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"methanotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000651>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"methylotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000651>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"methylotrophy"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000652>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"mixotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000654>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"oligotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000655>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"organotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000656>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anoxygenic_photoautotrophy"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000656>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anoxygenic_photoautotrophy_hydrogen_oxidation"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000656>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anoxygenic_photoautotrophy_iron_oxidation"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000656>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anoxygenic_photoautotrophy_sulfur_oxidation"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000656>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"photoautotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000656>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"photoautotrophy"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000657>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"photoheterotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000657>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"photoheterotrophy"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000658>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"photolithotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000659>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"photoorganoheterotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000660>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobic_anoxygenic_phototrophy"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000660>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"phototroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000663>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"chemoorganotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000664>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"organoheterotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000665>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"photolithoautotroph"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000666>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000666>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Morphology.cell morphology.cell shape"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000666>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"cell_shape"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000667>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"bacillus"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000668>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"coccus"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000668>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"coccus-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000669>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"crescent-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000670>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"curved-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000670>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_curved_spiral"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000671>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"diplococcus-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000672>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"dumbbell-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000672>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_star_dumbbell_pleomorphic"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000673>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"ellipsoidal"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000674>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"filament"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000674>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"filament-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000674>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_filament"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000675>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"flask"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000675>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"flask-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000676>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"helical-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000677>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"ovoid-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000677>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_ovoid"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000678>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"oval-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000679>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pleomorphic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000679>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pleomorphic-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000679>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_star_dumbbell_pleomorphic"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000680>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"ring"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000680>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"ring-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000681>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"rod-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000681>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_rod"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000682>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"spore-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000683>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_sphere"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000683>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"sphere-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000684>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_curved_spiral"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000684>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"spiral"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000684>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"spiral-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000685>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"s_star_dumbbell_pleomorphic"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000685>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"star"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000685>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"star-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000686>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"vibrio"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000686>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"vibrio-shaped"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000687>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"branced"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000688>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"coccobacillus"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000689>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"disc"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000690>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"fusiform"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000691>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"irregular"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000692>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"spindle"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000693>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"spirochete"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000694>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"square"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000695>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"tailed"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000696>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"triangular"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000697>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000697>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Morphology.cell morphology.gram stain"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000697>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"gram_stain"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000698>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"G_positive"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000698>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"positive"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000698>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"positive"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000699>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"G_negative"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000699>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"negative"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000699>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"negative"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000700>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"variable"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000701>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000701>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Morphology.cell morphology.motility"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000701>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"motility"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000702>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"motile"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000702>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"yes"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000702>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"yes"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000703>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"no"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/1000703>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"no"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000703>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"non- motile"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1000704>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"flagella"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000705>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"axial filament"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000706>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"gliding"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000720>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"facultative psychrophile"	""				
+<https://w3id.org/metpo/1000720>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"facultative psychrophilic"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000721>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"extreme hyperthermophile"	""				
+<https://w3id.org/metpo/1000721>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"extremely hyperthermophilic"	""				
+<https://w3id.org/metpo/1000800>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"pathways"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000801>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Oxic respiration"	""				
+<https://w3id.org/metpo/1000801>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Oxygen respiration"	""				
+<https://w3id.org/metpo/1000802>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Anoxic respiration"	""				
+<https://w3id.org/metpo/1000802>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Dissimilatory respiration (non-O₂)"	""				
+<https://w3id.org/metpo/1000844>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Biological methanation"	""				
+<https://w3id.org/metpo/1000844>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Biomethanation"	""				
+<https://w3id.org/metpo/1000844>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Carbonate respiration"	""				
+<https://w3id.org/metpo/1000844>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"methanogenesis"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000845>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Acetate fermentation"	""				
+<https://w3id.org/metpo/1000845>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"acetogenesis"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000846>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Reductive acetyl-CoA pathway"	""				
+<https://w3id.org/metpo/1000846>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Wood-Ljungdahl pathway"	""				
+<https://w3id.org/metpo/1000870>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""				
+<https://w3id.org/metpo/1000870>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Physiology and metabolism.spore formation.spore formation"	""				
+<https://w3id.org/metpo/1000870>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"sporulation"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000871>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"yes"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000872>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"no"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1002005>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"fermentation"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000059>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"phenotype"	""				
+<https://w3id.org/metpo/1000060>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"metabolism"	""				
+<https://w3id.org/metpo/1000127>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"GC content"	""				
+<https://w3id.org/metpo/1000186>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"material entity"	""				
+<https://w3id.org/metpo/1000188>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"quality"	""				
+<https://w3id.org/metpo/1000232>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH delta"	""				
+<https://w3id.org/metpo/1000233>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH optimum (growth range)"	""				
+<https://w3id.org/metpo/1000235>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range (growth tolerance)"	""				
+<https://w3id.org/metpo/1000236>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH tolerance"	""				
+<https://w3id.org/metpo/1000303>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature delta"	""				
+<https://w3id.org/metpo/1000304>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum (growth range)"	""				
+<https://w3id.org/metpo/1000306>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range (growth tolerance)"	""				
+<https://w3id.org/metpo/1000329>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum (metabolic activity)"	""				
+<https://w3id.org/metpo/1000330>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range (metabolic viability)"	""				
+<https://w3id.org/metpo/1000331>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH optimum (metabolic efficiency)"	""				
+<https://w3id.org/metpo/1000332>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range (cellular homeostasis)"	""				
+<https://w3id.org/metpo/1000333>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl optimum"	""				
+<https://w3id.org/metpo/1000334>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl range"	""				
+<https://w3id.org/metpo/1000335>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl delta"	""				
+<https://w3id.org/metpo/1000429>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"GC low"	""				
+<https://w3id.org/metpo/1000430>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"GC mid1"	""				
+<https://w3id.org/metpo/1000431>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"GC mid2"	""				
+<https://w3id.org/metpo/1000432>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"GC high"	""				
+<https://w3id.org/metpo/1000441>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum very low"	""				
+<https://w3id.org/metpo/1000442>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum low"	""				
+<https://w3id.org/metpo/1000443>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum mid1"	""				
+<https://w3id.org/metpo/1000444>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum mid2"	""				
+<https://w3id.org/metpo/1000445>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum mid3"	""				
+<https://w3id.org/metpo/1000446>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum mid4"	""				
+<https://w3id.org/metpo/1000447>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature optimum high"	""				
+<https://w3id.org/metpo/1000448>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range very low"	""				
+<https://w3id.org/metpo/1000449>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range low"	""				
+<https://w3id.org/metpo/1000450>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range mid1"	""				
+<https://w3id.org/metpo/1000451>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range mid2"	""				
+<https://w3id.org/metpo/1000452>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range mid3"	""				
+<https://w3id.org/metpo/1000453>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range mid4"	""				
+<https://w3id.org/metpo/1000454>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range high"	""				
+<https://w3id.org/metpo/1000455>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH optimum low"	""				
+<https://w3id.org/metpo/1000456>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH optimum mid1"	""				
+<https://w3id.org/metpo/1000457>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH optimum mid2"	""				
+<https://w3id.org/metpo/1000458>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH optimum high"	""				
+<https://w3id.org/metpo/1000459>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range very low"	""				
+<https://w3id.org/metpo/1000460>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range low"	""				
+<https://w3id.org/metpo/1000461>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range mid1"	""				
+<https://w3id.org/metpo/1000462>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range mid2"	""				
+<https://w3id.org/metpo/1000463>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range mid3"	""				
+<https://w3id.org/metpo/1000464>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range high"	""				
+<https://w3id.org/metpo/1000465>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl optimum low"	""				
+<https://w3id.org/metpo/1000466>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl optimum mid1"	""				
+<https://w3id.org/metpo/1000467>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl optimum mid2"	""				
+<https://w3id.org/metpo/1000468>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl optimum high"	""				
+<https://w3id.org/metpo/1000469>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl range low"	""				
+<https://w3id.org/metpo/1000470>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl range mid1"	""				
+<https://w3id.org/metpo/1000471>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl range mid2"	""				
+<https://w3id.org/metpo/1000472>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl range high"	""				
+<https://w3id.org/metpo/1000473>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH delta very low"	""				
+<https://w3id.org/metpo/1000474>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH delta low"	""				
+<https://w3id.org/metpo/1000475>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH delta mid1"	""				
+<https://w3id.org/metpo/1000476>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH delta mid2"	""				
+<https://w3id.org/metpo/1000477>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH delta mid3"	""				
+<https://w3id.org/metpo/1000478>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH delta high"	""				
+<https://w3id.org/metpo/1000479>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl delta low"	""				
+<https://w3id.org/metpo/1000480>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl delta mid1"	""				
+<https://w3id.org/metpo/1000481>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl delta mid2"	""				
+<https://w3id.org/metpo/1000482>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl delta high"	""				
+<https://w3id.org/metpo/1000483>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature delta very low"	""				
+<https://w3id.org/metpo/1000484>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature delta low"	""				
+<https://w3id.org/metpo/1000485>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature delta mid1"	""				
+<https://w3id.org/metpo/1000486>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature delta mid2"	""				
+<https://w3id.org/metpo/1000487>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature delta high"	""				
+<https://w3id.org/metpo/1000511>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH adaptation"	""				
+<https://w3id.org/metpo/1000525>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"microbe"	""				
+<https://w3id.org/metpo/1000526>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemical entity"	""				
+<https://w3id.org/metpo/1000601>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"oxygen preference"	""				
+<https://w3id.org/metpo/1000602>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"aerobic"	""				
+<https://w3id.org/metpo/1000603>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"anaerobic"	""				
+<https://w3id.org/metpo/1000604>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"microaerophilic"	""				
+<https://w3id.org/metpo/1000605>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"facultatively anaerobic"	""				
+<https://w3id.org/metpo/1000606>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"obligately aerobic"	""				
+<https://w3id.org/metpo/1000607>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"obligately anaerobic"	""				
+<https://w3id.org/metpo/1000608>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"facultatively aerobic"	""				
+<https://w3id.org/metpo/1000609>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"aerotolerant"	""				
+<https://w3id.org/metpo/1000610>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"microaerotolerant"	""				
+<https://w3id.org/metpo/1000611>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"strictly anaerobic"	""				
+<https://w3id.org/metpo/1000612>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"facultative oxygen preference"	""				
+<https://w3id.org/metpo/1000613>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature preference"	""				
+<https://w3id.org/metpo/1000614>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"psychrophilic"	""				
+<https://w3id.org/metpo/1000615>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"mesophilic"	""				
+<https://w3id.org/metpo/1000616>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"thermophilic"	""				
+<https://w3id.org/metpo/1000617>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"hyperthermophilic"	""				
+<https://w3id.org/metpo/1000618>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"psychrotolerant"	""				
+<https://w3id.org/metpo/1000619>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"thermotolerant"	""				
+<https://w3id.org/metpo/1000620>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"halophilic"	""				
+<https://w3id.org/metpo/1000621>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"haloalkaliphilic"	""				
+<https://w3id.org/metpo/1000622>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"halotolerant"	""				
+<https://w3id.org/metpo/1000623>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"moderately halophilic"	""				
+<https://w3id.org/metpo/1000624>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"non halophilic"	""				
+<https://w3id.org/metpo/1000625>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"slightly halophilic"	""				
+<https://w3id.org/metpo/1000626>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"stenohaline"	""				
+<https://w3id.org/metpo/1000627>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"euryhaline"	""				
+<https://w3id.org/metpo/1000628>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"extremely halophilic"	""				
+<https://w3id.org/metpo/1000629>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"halophily preference"	""				
+<https://w3id.org/metpo/1000630>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"biological process"	""				
+<https://w3id.org/metpo/1000631>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"trophic type"	""				
+<https://w3id.org/metpo/1000632>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"autotrophic"	""				
+<https://w3id.org/metpo/1000633>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"carboxydotrophic"	""				
+<https://w3id.org/metpo/1000634>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemoautolithotrophic"	""				
+<https://w3id.org/metpo/1000635>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemoautotrophic"	""				
+<https://w3id.org/metpo/1000636>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemoheterotrophic"	""				
+<https://w3id.org/metpo/1000637>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemolithoautotrophic"	""				
+<https://w3id.org/metpo/1000638>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemolithoheterotrophic"	""				
+<https://w3id.org/metpo/1000639>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemolithotrophic"	""				
+<https://w3id.org/metpo/1000640>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemoorganoheterotrophic"	""				
+<https://w3id.org/metpo/1000641>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemotrophic"	""				
+<https://w3id.org/metpo/1000642>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"copiotrophic"	""				
+<https://w3id.org/metpo/1000644>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"heterotrophic"	""				
+<https://w3id.org/metpo/1000646>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"hydrogenotrophic"	""				
+<https://w3id.org/metpo/1000647>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"lithoautotrophic"	""				
+<https://w3id.org/metpo/1000648>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"lithoheterotrophic"	""				
+<https://w3id.org/metpo/1000649>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"lithotrophic"	""				
+<https://w3id.org/metpo/1000650>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"methanotrophic"	""				
+<https://w3id.org/metpo/1000651>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"methylotrophic"	""				
+<https://w3id.org/metpo/1000652>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"mixotrophic"	""				
+<https://w3id.org/metpo/1000654>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"oligotrophic"	""				
+<https://w3id.org/metpo/1000655>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"organotrophic"	""				
+<https://w3id.org/metpo/1000656>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"photoautotrophic"	""				
+<https://w3id.org/metpo/1000657>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"photoheterotrophic"	""				
+<https://w3id.org/metpo/1000658>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"photolithotrophic"	""				
+<https://w3id.org/metpo/1000659>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"photoorganoheterotrophic"	""				
+<https://w3id.org/metpo/1000660>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"phototrophic"	""				
+<https://w3id.org/metpo/1000663>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"chemoorganotrophic"	""				
+<https://w3id.org/metpo/1000664>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"organoheterotrophic"	""				
+<https://w3id.org/metpo/1000665>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"photolithoautotrophic"	""				
+<https://w3id.org/metpo/1000666>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"cell shape"	""				
+<https://w3id.org/metpo/1000667>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"bacillus shaped"	""				
+<https://w3id.org/metpo/1000668>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"coccus shaped"	""				
+<https://w3id.org/metpo/1000669>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"crescent shaped"	""				
+<https://w3id.org/metpo/1000670>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"curved shaped"	""				
+<https://w3id.org/metpo/1000671>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"diplococcus shaped"	""				
+<https://w3id.org/metpo/1000672>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"dumbbell shaped"	""				
+<https://w3id.org/metpo/1000673>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"ellipsoidal"	""				
+<https://w3id.org/metpo/1000674>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"filament shaped"	""				
+<https://w3id.org/metpo/1000675>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"flask shaped"	""				
+<https://w3id.org/metpo/1000676>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"helical shaped"	""				
+<https://w3id.org/metpo/1000677>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"ovoid shaped"	""				
+<https://w3id.org/metpo/1000678>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"oval shaped"	""				
+<https://w3id.org/metpo/1000679>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pleomorphic shaped"	""				
+<https://w3id.org/metpo/1000680>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"ring shaped"	""				
+<https://w3id.org/metpo/1000681>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"rod shaped"	""				
+<https://w3id.org/metpo/1000682>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"spore shaped"	""				
+<https://w3id.org/metpo/1000683>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"sphere shaped"	""				
+<https://w3id.org/metpo/1000684>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"spiral shaped"	""				
+<https://w3id.org/metpo/1000685>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"star shaped"	""				
+<https://w3id.org/metpo/1000686>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"vibrio shaped"	""				
+<https://w3id.org/metpo/1000687>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"branched shaped"	""				
+<https://w3id.org/metpo/1000688>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"coccobacillus shaped"	""				
+<https://w3id.org/metpo/1000689>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"disc shaped"	""				
+<https://w3id.org/metpo/1000690>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"fusiform shaped"	""				
+<https://w3id.org/metpo/1000691>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"irregular shaped"	""				
+<https://w3id.org/metpo/1000692>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"spindle shaped"	""				
+<https://w3id.org/metpo/1000693>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"spirochete shaped"	""				
+<https://w3id.org/metpo/1000694>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"square shaped"	""				
+<https://w3id.org/metpo/1000695>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"tailed shaped"	""				
+<https://w3id.org/metpo/1000696>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"triangular shaped"	""				
+<https://w3id.org/metpo/1000697>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"gram stain"	""				
+<https://w3id.org/metpo/1000698>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"gram positive"	""				
+<https://w3id.org/metpo/1000699>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"gram negative"	""				
+<https://w3id.org/metpo/1000700>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"gram variable"	""				
+<https://w3id.org/metpo/1000701>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"motility"	""				
+<https://w3id.org/metpo/1000702>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"motile"	""				
+<https://w3id.org/metpo/1000703>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"non motile"	""				
+<https://w3id.org/metpo/1000704>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"flagellated"	""				
+<https://w3id.org/metpo/1000705>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"axially filamented"	""				
+<https://w3id.org/metpo/1000706>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"gliding"	""				
+<https://w3id.org/metpo/1000720>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"facultative psychrophilic"	""				
+<https://w3id.org/metpo/1000721>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"extreme hyperthermophilic"	""				
+<https://w3id.org/metpo/1000731>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"nutrient adaptation"	""				
+<https://w3id.org/metpo/1000800>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"respiration"	""				
+<https://w3id.org/metpo/1000801>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Aerobic respiration"	""				
+<https://w3id.org/metpo/1000802>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Anaerobic respiration"	""				
+<https://w3id.org/metpo/1000803>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Oxidative phosphorylation"	""				
+<https://w3id.org/metpo/1000804>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Substrate-level phosphorylation"	""				
+<https://w3id.org/metpo/1000805>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Electron transfer"	""				
+<https://w3id.org/metpo/1000806>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Disproportionation"	""				
+<https://w3id.org/metpo/1000844>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Methanogenesis"	""				
+<https://w3id.org/metpo/1000845>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Acetogenesis"	""				
+<https://w3id.org/metpo/1000846>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Homoacetogenesis"	""				
+<https://w3id.org/metpo/1000870>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"sporulation"	""				
+<https://w3id.org/metpo/1000871>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"spore forming"	""				
+<https://w3id.org/metpo/1000872>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"non-spore forming"	""				
+<https://w3id.org/metpo/1001000>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"observation"	""				
+<https://w3id.org/metpo/1001001>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"optimum temperature observation"	""				
+<https://w3id.org/metpo/1001002>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"growth temperature observation"	""				
+<https://w3id.org/metpo/1001003>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature range observation"	""				
+<https://w3id.org/metpo/1001004>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"temperature delta observation"	""				
+<https://w3id.org/metpo/1001007>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"growth NaCl observation"	""				
+<https://w3id.org/metpo/1001008>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl delta observation"	""				
+<https://w3id.org/metpo/1001009>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"NaCl range observation"	""				
+<https://w3id.org/metpo/1001010>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"optimum NaCl observation"	""				
+<https://w3id.org/metpo/1001012>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"growth pH observation"	""				
+<https://w3id.org/metpo/1001013>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"optimum pH observation"	""				
+<https://w3id.org/metpo/1001014>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH delta observation"	""				
+<https://w3id.org/metpo/1001015>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH range observation"	""				
+<https://w3id.org/metpo/1001101>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"biosafety level"	""				
+<https://w3id.org/metpo/1001102>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"biosafety level 1"	""				
+<https://w3id.org/metpo/1001103>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"biosafety level 2"	""				
+<https://w3id.org/metpo/1001104>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"biosafety level 3"	""				
+<https://w3id.org/metpo/1001105>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"biosafety level 4"	""				
+<https://w3id.org/metpo/1002003>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Cable bacteria metabolism"	""				
+<https://w3id.org/metpo/1002005>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Fermentation"	""				
+<https://w3id.org/metpo/1002006>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"Syntrophy"	""				
+<https://w3id.org/metpo/1003000>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pH growth preference"	""				
+<https://w3id.org/metpo/1003001>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"neutrophilic"	""				
+<https://w3id.org/metpo/1003002>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"alkaphilic"	""				
+<https://w3id.org/metpo/1003003>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"acidophilic"	""				
+<https://w3id.org/metpo/1003004>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"obligately alkaphilic"	""				
+<https://w3id.org/metpo/1003005>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"facultatively alkaphilic"	""				
+<https://w3id.org/metpo/1003006>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"obligately acidophilic"	""				
+<https://w3id.org/metpo/1003007>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"facultatively acidophilic"	""				
+<https://w3id.org/metpo/1003008>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"acidotolerant"	""				
+<https://w3id.org/metpo/1003009>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"alkalotolerant"	""				
+<https://w3id.org/metpo/2000002>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"assimilation"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000003>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"builds acid from"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000004>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"builds base from"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000005>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"builds gas from"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000006>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"carbon source"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000007>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"degradation"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000008>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"electron acceptor"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000009>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"electron donor"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000010>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"energy source"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000011>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"fermentation"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000012>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"growth"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000013>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"hydrolysis"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000014>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"nitrogen source"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000015>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"other"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000016>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"oxidation"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000017>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"reduction"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000018>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"required for growth"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000019>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"respiration"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000020>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"sulfur source"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000021>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobic catabolization"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000022>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobic growth"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000023>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic catabolization"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000024>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic growth"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000025>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic growth in the dark"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000026>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic growth with light"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000027>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"assimilation"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000028>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"builds acid from"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000029>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"builds base from"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000030>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"builds gas from"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000031>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"carbon source"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000032>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobic catabolization"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000033>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"degradation"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000034>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"electron acceptor"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000035>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"electron donor"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000036>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"energy source"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000037>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"fermentation"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000038>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"growth"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000039>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"hydrolysis"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000040>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"nitrogen source"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000041>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"other"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000042>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"oxidation"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000043>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"aerobic growth"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000044>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"reduction"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000045>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"required for growth"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000046>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"respiration"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000047>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"sulfur source"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000048>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic catabolization"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000049>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic growth"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000050>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic growth in the dark"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000051>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anaerobic growth with light"	""			<https://bacdive.dsmz.de/>	
+<https://w3id.org/metpo/2000200>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"dismutates"	""				
+<https://w3id.org/metpo/2000202>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"anabolizes"	""				
+<https://w3id.org/metpo/2000202>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"produces"	""				
+<http://purl.obolibrary.org/obo/IAO_0000115>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"definition"	""				
+<http://purl.obolibrary.org/obo/IAO_0000119>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"definition source"	""				
+<http://purl.org/dc/terms/description>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"description"	""				
+<http://purl.org/dc/terms/license>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"license"	""				
+<http://purl.org/dc/terms/title>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"title"	""				
+<https://w3id.org/metpo/2000001>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"organism interacts with chemical"	""				
+<https://w3id.org/metpo/2000002>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"assimilates"	""				
+<https://w3id.org/metpo/2000003>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"builds acid from"	""				
+<https://w3id.org/metpo/2000004>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"builds base from"	""				
+<https://w3id.org/metpo/2000005>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"builds gas from"	""				
+<https://w3id.org/metpo/2000006>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses as carbon source"	""				
+<https://w3id.org/metpo/2000007>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"degrades"	""				
+<https://w3id.org/metpo/2000008>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses as electron acceptor"	""				
+<https://w3id.org/metpo/2000009>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses as electron donor"	""				
+<https://w3id.org/metpo/2000010>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses as energy source"	""				
+<https://w3id.org/metpo/2000011>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"ferments"	""				
+<https://w3id.org/metpo/2000012>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses for growth"	""				
+<https://w3id.org/metpo/2000013>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"hydrolyzes"	""				
+<https://w3id.org/metpo/2000014>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses as nitrogen source"	""				
+<https://w3id.org/metpo/2000015>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses in other way"	""				
+<https://w3id.org/metpo/2000016>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"oxidizes"	""				
+<https://w3id.org/metpo/2000017>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"reduces"	""				
+<https://w3id.org/metpo/2000018>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"requires for growth"	""				
+<https://w3id.org/metpo/2000019>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses for respiration"	""				
+<https://w3id.org/metpo/2000020>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses as sulfur source"	""				
+<https://w3id.org/metpo/2000021>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use for aerobic catabolization"	""				
+<https://w3id.org/metpo/2000022>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use for aerobic growth"	""				
+<https://w3id.org/metpo/2000023>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use for anaerobic catabolization"	""				
+<https://w3id.org/metpo/2000024>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use for anaerobic growth"	""				
+<https://w3id.org/metpo/2000025>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use for anaerobic growth in the dark"	""				
+<https://w3id.org/metpo/2000026>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use for anaerobic growth with light"	""				
+<https://w3id.org/metpo/2000027>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not assimilate"	""				
+<https://w3id.org/metpo/2000028>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not build acid from"	""				
+<https://w3id.org/metpo/2000029>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not build base from"	""				
+<https://w3id.org/metpo/2000030>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not build gas from"	""				
+<https://w3id.org/metpo/2000031>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use as carbon source"	""				
+<https://w3id.org/metpo/2000032>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses for aerobic catabolization"	""				
+<https://w3id.org/metpo/2000033>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not degrade"	""				
+<https://w3id.org/metpo/2000034>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use as electron acceptor"	""				
+<https://w3id.org/metpo/2000035>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use as electron donor"	""				
+<https://w3id.org/metpo/2000036>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use as energy source"	""				
+<https://w3id.org/metpo/2000037>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not ferment"	""				
+<https://w3id.org/metpo/2000038>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use for growth"	""				
+<https://w3id.org/metpo/2000039>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not hydrolyze"	""				
+<https://w3id.org/metpo/2000040>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use as nitrogen source"	""				
+<https://w3id.org/metpo/2000041>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use in other way"	""				
+<https://w3id.org/metpo/2000042>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not oxidize"	""				
+<https://w3id.org/metpo/2000043>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses for aerobic growth"	""				
+<https://w3id.org/metpo/2000044>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not reduce"	""				
+<https://w3id.org/metpo/2000045>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"is not required for growth"	""				
+<https://w3id.org/metpo/2000046>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use for respiration"	""				
+<https://w3id.org/metpo/2000047>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not use as sulfur source"	""				
+<https://w3id.org/metpo/2000048>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses for anaerobic catabolization"	""				
+<https://w3id.org/metpo/2000049>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses for anaerobic growth"	""				
+<https://w3id.org/metpo/2000050>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses for anaerobic growth in the dark"	""				
+<https://w3id.org/metpo/2000051>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"uses for anaerobic growth with light"	""				
+<https://w3id.org/metpo/2000052>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has temperature observation"	""				
+<https://w3id.org/metpo/2000053>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has optimum temperature observation"	""				
+<https://w3id.org/metpo/2000054>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has growth temperature observation"	""				
+<https://w3id.org/metpo/2000055>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has range temperature observation"	""				
+<https://w3id.org/metpo/2000056>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has temperature delta observation"	""				
+<https://w3id.org/metpo/2000058>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has spot value"	""				
+<https://w3id.org/metpo/2000059>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has minimum value"	""				
+<https://w3id.org/metpo/2000060>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has maximum value"	""				
+<https://w3id.org/metpo/2000061>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has value comments"	""				
+<https://w3id.org/metpo/2000062>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"is negative data"	""				
+<https://w3id.org/metpo/2000063>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"observation data property"	""				
+<https://w3id.org/metpo/2000101>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has quality"	""				
+<https://w3id.org/metpo/2000102>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has phenotype"	""				
+<https://w3id.org/metpo/2000103>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"capable of"	""				
+<https://w3id.org/metpo/2000104>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has observation"	""				
+<https://w3id.org/metpo/2000200>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"disproportionates"	""				
+<https://w3id.org/metpo/2000201>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"lyses"	""				
+<https://w3id.org/metpo/2000202>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"synthesizes"	""				
+<https://w3id.org/metpo/2000203>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"fixes"	""				
+<https://w3id.org/metpo/2000204>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"catabolizes"	""				
+<https://w3id.org/metpo/2000205>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"mineralizes"	""				
+<https://w3id.org/metpo/2000206>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"conjugates"	""				
+<https://w3id.org/metpo/2000207>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"transports"	""				
+<https://w3id.org/metpo/2000208>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"imports"	""				
+<https://w3id.org/metpo/2000209>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"exports"	""				
+<https://w3id.org/metpo/2000210>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"accumulates"	""				
+<https://w3id.org/metpo/2000211>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"sequesters"	""				
+<https://w3id.org/metpo/2000212>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"compartmentalizes"	""				
+<https://w3id.org/metpo/2000213>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"binds"	""				
+<https://w3id.org/metpo/2000214>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"chelates"	""				
+<https://w3id.org/metpo/2000215>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"precipitates"	""				
+<https://w3id.org/metpo/2000216>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"solubilizes"	""				
+<https://w3id.org/metpo/2000217>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"volatilizes"	""				
+<https://w3id.org/metpo/2000218>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"crystallizes"	""				
+<https://w3id.org/metpo/2000219>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"adsorbs"	""				
+<https://w3id.org/metpo/2000220>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not disproportionate"	""				
+<https://w3id.org/metpo/2000221>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not lyse"	""				
+<https://w3id.org/metpo/2000222>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not produce"	""				
+<https://w3id.org/metpo/2000223>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not fix"	""				
+<https://w3id.org/metpo/2000224>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not catabolize"	""				
+<https://w3id.org/metpo/2000225>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not mineralize"	""				
+<https://w3id.org/metpo/2000226>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not conjugate"	""				
+<https://w3id.org/metpo/2000227>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not transport"	""				
+<https://w3id.org/metpo/2000228>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not import"	""				
+<https://w3id.org/metpo/2000229>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not export"	""				
+<https://w3id.org/metpo/2000230>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not accumulate"	""				
+<https://w3id.org/metpo/2000231>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not sequester"	""				
+<https://w3id.org/metpo/2000232>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not compartmentalize"	""				
+<https://w3id.org/metpo/2000233>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not bind"	""				
+<https://w3id.org/metpo/2000234>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not chelate"	""				
+<https://w3id.org/metpo/2000235>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not precipitate"	""				
+<https://w3id.org/metpo/2000236>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not solubilize"	""				
+<https://w3id.org/metpo/2000237>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not volatilize"	""				
+<https://w3id.org/metpo/2000238>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"does not crystallize"	""				
+<https://w3id.org/metpo/2000239>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has pH observation"	""				
+<https://w3id.org/metpo/2000501>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has optimum pH observation"	""				
+<https://w3id.org/metpo/2000502>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has growth pH observation"	""				
+<https://w3id.org/metpo/2000503>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has range pH observation"	""				
+<https://w3id.org/metpo/2000504>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has pH delta observation"	""				
+<https://w3id.org/metpo/2000506>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has NaCl observation"	""				
+<https://w3id.org/metpo/2000507>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has optimum NaCl observation"	""				
+<https://w3id.org/metpo/2000508>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has growth NaCl observation"	""				
+<https://w3id.org/metpo/2000509>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has range NaCl observation"	""				
+<https://w3id.org/metpo/2000510>	"property"	<http://www.w3.org/2000/01/rdf-schema#label>	"has NaCl delta observation"	""				

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -682,4 +682,9 @@ Tricks:
 endef
 export data
 
+reports/synonym-sources.tsv: $(ONT).owl $(SPARQLDIR)/synonym-sources.sparql
+	$(ROBOT) query \
+		--input $< \
+		--query $(SPARQLDIR)/synonym-sources.sparql $@
+
 include metpo.Makefile

--- a/src/ontology/components/metpo-properties.owl
+++ b/src/ontology/components/metpo-properties.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<https://w3id.org/metpo/metpo/components/metpo-properties.owl>
-<https://w3id.org/metpo/metpo/releases/2025-10-03/components/metpo-properties.owl>
-Annotation(owl:versionInfo "2025-10-03")
+<https://w3id.org/metpo/metpo/releases/2025-10-07/components/metpo-properties.owl>
+Annotation(owl:versionInfo "2025-10-07")
 
 Declaration(Class(<https://w3id.org/metpo/1000059>))
 Declaration(Class(<https://w3id.org/metpo/1000188>))
@@ -20,13 +20,10 @@ Declaration(Class(<https://w3id.org/metpo/1001001>))
 Declaration(Class(<https://w3id.org/metpo/1001002>))
 Declaration(Class(<https://w3id.org/metpo/1001003>))
 Declaration(Class(<https://w3id.org/metpo/1001004>))
-Declaration(Class(<https://w3id.org/metpo/1001005>))
-Declaration(Class(<https://w3id.org/metpo/1001006>))
 Declaration(Class(<https://w3id.org/metpo/1001007>))
 Declaration(Class(<https://w3id.org/metpo/1001008>))
 Declaration(Class(<https://w3id.org/metpo/1001009>))
 Declaration(Class(<https://w3id.org/metpo/1001010>))
-Declaration(Class(<https://w3id.org/metpo/1001011>))
 Declaration(Class(<https://w3id.org/metpo/1001012>))
 Declaration(Class(<https://w3id.org/metpo/1001013>))
 Declaration(Class(<https://w3id.org/metpo/1001014>))
@@ -87,10 +84,10 @@ Declaration(ObjectProperty(<https://w3id.org/metpo/2000053>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000054>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000055>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000056>))
-Declaration(ObjectProperty(<https://w3id.org/metpo/2000057>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000101>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000102>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000103>))
+Declaration(ObjectProperty(<https://w3id.org/metpo/2000104>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000200>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000201>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000202>))
@@ -135,13 +132,11 @@ Declaration(ObjectProperty(<https://w3id.org/metpo/2000501>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000502>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000503>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000504>))
-Declaration(ObjectProperty(<https://w3id.org/metpo/2000505>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000506>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000507>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000508>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000509>))
 Declaration(ObjectProperty(<https://w3id.org/metpo/2000510>))
-Declaration(ObjectProperty(<https://w3id.org/metpo/2000511>))
 Declaration(DataProperty(<https://w3id.org/metpo/2000058>))
 Declaration(DataProperty(<https://w3id.org/metpo/2000059>))
 Declaration(DataProperty(<https://w3id.org/metpo/2000060>))
@@ -514,14 +509,6 @@ SubObjectPropertyOf(<https://w3id.org/metpo/2000056> <https://w3id.org/metpo/200
 ObjectPropertyDomain(<https://w3id.org/metpo/2000056> <https://w3id.org/metpo/1000525>)
 ObjectPropertyRange(<https://w3id.org/metpo/2000056> <https://w3id.org/metpo/1001004>)
 
-# Object Property: <https://w3id.org/metpo/2000057> (has culture temperature observation)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/2000057> "Relates a microbe to a culture temperature observation (e.g., from BacDive).")
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000057> "has culture temperature observation")
-SubObjectPropertyOf(<https://w3id.org/metpo/2000057> <https://w3id.org/metpo/2000052>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000057> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000057> <https://w3id.org/metpo/1001005>)
-
 # Object Property: <https://w3id.org/metpo/2000101> (has quality)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000101> "has quality")
@@ -543,63 +530,54 @@ AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#closeMatch> <https://w3
 ObjectPropertyDomain(<https://w3id.org/metpo/2000103> <https://w3id.org/metpo/1000525>)
 ObjectPropertyRange(<https://w3id.org/metpo/2000103> <https://w3id.org/metpo/1000630>)
 
+# Object Property: <https://w3id.org/metpo/2000104> (has observation)
+
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000104> "has observation")
+ObjectPropertyDomain(<https://w3id.org/metpo/2000104> <https://w3id.org/metpo/1000525>)
+ObjectPropertyRange(<https://w3id.org/metpo/2000104> <https://w3id.org/metpo/1001000>)
+
 # Object Property: <https://w3id.org/metpo/2000200> (disproportionates)
 
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/2000200> "dismutates")
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000200> "disproportionates")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000200> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000200> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000200> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000201> (lyses)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000201> "lyses")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000201> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000201> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000201> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000202> (synthesizes)
 
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/2000202> "anabolizes")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/2000202> "produces")
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000202> "synthesizes")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000202> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000202> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000202> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000203> (fixes)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000203> "fixes")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000203> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000203> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000203> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000204> (catabolizes)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000204> "catabolizes")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000204> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000204> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000204> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000205> (mineralizes)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000205> "mineralizes")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000205> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000205> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000205> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000206> (conjugates)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000206> "conjugates")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000206> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000206> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000206> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000207> (transports)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000207> "transports")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000207> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000207> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000207> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000208> (imports)
 
@@ -619,8 +597,6 @@ ObjectPropertyRange(<https://w3id.org/metpo/2000209> <https://w3id.org/metpo/100
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000210> "accumulates")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000210> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000210> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000210> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000211> (sequesters)
 
@@ -640,106 +616,76 @@ ObjectPropertyRange(<https://w3id.org/metpo/2000212> <https://w3id.org/metpo/100
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000213> "binds")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000213> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000213> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000213> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000214> (chelates)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000214> "chelates")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000214> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000214> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000214> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000215> (precipitates)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000215> "precipitates")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000215> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000215> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000215> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000216> (solubilizes)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000216> "solubilizes")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000216> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000216> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000216> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000217> (volatilizes)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000217> "volatilizes")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000217> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000217> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000217> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000218> (crystallizes)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000218> "crystallizes")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000218> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000218> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000218> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000219> (adsorbs)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000219> "adsorbs")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000219> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000219> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000219> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000220> (does not disproportionate)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000220> "does not disproportionate")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000220> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000220> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000220> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000221> (does not lyse)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000221> "does not lyse")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000221> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000221> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000221> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000222> (does not produce)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000222> "does not produce")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000222> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000222> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000222> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000223> (does not fix)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000223> "does not fix")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000223> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000223> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000223> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000224> (does not catabolize)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000224> "does not catabolize")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000224> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000224> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000224> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000225> (does not mineralize)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000225> "does not mineralize")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000225> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000225> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000225> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000226> (does not conjugate)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000226> "does not conjugate")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000226> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000226> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000226> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000227> (does not transport)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000227> "does not transport")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000227> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000227> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000227> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000228> (does not import)
 
@@ -759,8 +705,6 @@ ObjectPropertyRange(<https://w3id.org/metpo/2000229> <https://w3id.org/metpo/100
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000230> "does not accumulate")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000230> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000230> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000230> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000231> (does not sequester)
 
@@ -780,49 +724,37 @@ ObjectPropertyRange(<https://w3id.org/metpo/2000232> <https://w3id.org/metpo/100
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000233> "does not bind")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000233> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000233> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000233> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000234> (does not chelate)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000234> "does not chelate")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000234> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000234> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000234> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000235> (does not precipitate)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000235> "does not precipitate")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000235> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000235> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000235> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000236> (does not solubilize)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000236> "does not solubilize")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000236> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000236> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000236> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000237> (does not volatilize)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000237> "does not volatilize")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000237> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000237> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000237> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000238> (does not crystallize)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000238> "does not crystallize")
 SubObjectPropertyOf(<https://w3id.org/metpo/2000238> <https://w3id.org/metpo/2000001>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000238> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000238> <https://w3id.org/metpo/1000526>)
 
 # Object Property: <https://w3id.org/metpo/2000239> (has pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/2000239> "Relates a microbe to a pH observation.")
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000239> "has pH observation")
-SubObjectPropertyOf(<https://w3id.org/metpo/2000239> <https://w3id.org/metpo/2000001>)
+SubObjectPropertyOf(<https://w3id.org/metpo/2000239> <https://w3id.org/metpo/2000104>)
 ObjectPropertyDomain(<https://w3id.org/metpo/2000239> <https://w3id.org/metpo/1000525>)
 ObjectPropertyRange(<https://w3id.org/metpo/2000239> <https://w3id.org/metpo/1001000>)
 
@@ -858,19 +790,11 @@ SubObjectPropertyOf(<https://w3id.org/metpo/2000504> <https://w3id.org/metpo/200
 ObjectPropertyDomain(<https://w3id.org/metpo/2000504> <https://w3id.org/metpo/1000525>)
 ObjectPropertyRange(<https://w3id.org/metpo/2000504> <https://w3id.org/metpo/1001014>)
 
-# Object Property: <https://w3id.org/metpo/2000505> (has culture pH observation)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/2000505> "Relates a microbe to a culture pH observation (e.g., from BacDive).")
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000505> "has culture pH observation")
-SubObjectPropertyOf(<https://w3id.org/metpo/2000505> <https://w3id.org/metpo/2000239>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000505> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000505> <https://w3id.org/metpo/1001011>)
-
 # Object Property: <https://w3id.org/metpo/2000506> (has NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/2000506> "Relates a microbe to a NaCl observation.")
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000506> "has NaCl observation")
-SubObjectPropertyOf(<https://w3id.org/metpo/2000506> <https://w3id.org/metpo/2000506>)
+SubObjectPropertyOf(<https://w3id.org/metpo/2000506> <https://w3id.org/metpo/2000104>)
 ObjectPropertyDomain(<https://w3id.org/metpo/2000506> <https://w3id.org/metpo/1000525>)
 ObjectPropertyRange(<https://w3id.org/metpo/2000506> <https://w3id.org/metpo/1001000>)
 
@@ -905,14 +829,6 @@ AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000510> "has NaCl delta 
 SubObjectPropertyOf(<https://w3id.org/metpo/2000510> <https://w3id.org/metpo/2000506>)
 ObjectPropertyDomain(<https://w3id.org/metpo/2000510> <https://w3id.org/metpo/1000525>)
 ObjectPropertyRange(<https://w3id.org/metpo/2000510> <https://w3id.org/metpo/1001008>)
-
-# Object Property: <https://w3id.org/metpo/2000511> (has culture NaCl observation)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/2000511> "Relates a microbe to a culture NaCl observation (e.g., from BacDive).")
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000511> "has culture NaCl observation")
-SubObjectPropertyOf(<https://w3id.org/metpo/2000511> <https://w3id.org/metpo/2000506>)
-ObjectPropertyDomain(<https://w3id.org/metpo/2000511> <https://w3id.org/metpo/1000525>)
-ObjectPropertyRange(<https://w3id.org/metpo/2000511> <https://w3id.org/metpo/1001006>)
 
 
 ############################
@@ -1009,14 +925,6 @@ AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001003> "temperature ran
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001004> "temperature delta observation")
 
-# Class: <https://w3id.org/metpo/1001005> (culture temperature observation)
-
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001005> "culture temperature observation")
-
-# Class: <https://w3id.org/metpo/1001006> (culture NaCl observation)
-
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001006> "culture NaCl observation")
-
 # Class: <https://w3id.org/metpo/1001007> (growth NaCl observation)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001007> "growth NaCl observation")
@@ -1032,10 +940,6 @@ AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001009> "NaCl range obse
 # Class: <https://w3id.org/metpo/1001010> (optimum NaCl observation)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001010> "optimum NaCl observation")
-
-# Class: <https://w3id.org/metpo/1001011> (culture pH observation)
-
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001011> "culture pH observation")
 
 # Class: <https://w3id.org/metpo/1001012> (growth pH observation)
 

--- a/src/ontology/components/metpo-synonyms.owl
+++ b/src/ontology/components/metpo-synonyms.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<https://w3id.org/metpo/metpo/components/metpo-synonyms.owl>
-<https://w3id.org/metpo/metpo/releases/2025-10-03/components/metpo-synonyms.owl>
-Annotation(owl:versionInfo "2025-10-03")
+<https://w3id.org/metpo/metpo/releases/2025-10-07/components/metpo-synonyms.owl>
+Annotation(owl:versionInfo "2025-10-07")
 
 
 

--- a/src/ontology/components/metpo_sheet.owl
+++ b/src/ontology/components/metpo_sheet.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<https://w3id.org/metpo/metpo/components/metpo_sheet.owl>
-<https://w3id.org/metpo/metpo/releases/2025-10-03/components/metpo_sheet.owl>
-Annotation(owl:versionInfo "2025-10-03")
+<https://w3id.org/metpo/metpo/releases/2025-10-07/components/metpo_sheet.owl>
+Annotation(owl:versionInfo "2025-10-07")
 
 Declaration(Class(<https://w3id.org/metpo/1000059>))
 Declaration(Class(<https://w3id.org/metpo/1000060>))
@@ -205,13 +205,10 @@ Declaration(Class(<https://w3id.org/metpo/1001001>))
 Declaration(Class(<https://w3id.org/metpo/1001002>))
 Declaration(Class(<https://w3id.org/metpo/1001003>))
 Declaration(Class(<https://w3id.org/metpo/1001004>))
-Declaration(Class(<https://w3id.org/metpo/1001005>))
-Declaration(Class(<https://w3id.org/metpo/1001006>))
 Declaration(Class(<https://w3id.org/metpo/1001007>))
 Declaration(Class(<https://w3id.org/metpo/1001008>))
 Declaration(Class(<https://w3id.org/metpo/1001009>))
 Declaration(Class(<https://w3id.org/metpo/1001010>))
-Declaration(Class(<https://w3id.org/metpo/1001011>))
 Declaration(Class(<https://w3id.org/metpo/1001012>))
 Declaration(Class(<https://w3id.org/metpo/1001013>))
 Declaration(Class(<https://w3id.org/metpo/1001014>))
@@ -1629,17 +1626,6 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.o
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001004> "temperature delta observation")
 SubClassOf(<https://w3id.org/metpo/1001004> <https://w3id.org/metpo/1001000>)
 
-# Class: <https://w3id.org/metpo/1001005> (culture temperature observation)
-
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1001005> "An observation specializing temperature observation for culture temperature data (e.g., reported culture conditions).")
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001005> "culture temperature observation")
-SubClassOf(<https://w3id.org/metpo/1001005> <https://w3id.org/metpo/1001000>)
-
-# Class: <https://w3id.org/metpo/1001006> (culture NaCl observation)
-
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001006> "culture NaCl observation")
-SubClassOf(<https://w3id.org/metpo/1001006> <https://w3id.org/metpo/1001000>)
-
 # Class: <https://w3id.org/metpo/1001007> (growth NaCl observation)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001007> "growth NaCl observation")
@@ -1659,11 +1645,6 @@ SubClassOf(<https://w3id.org/metpo/1001009> <https://w3id.org/metpo/1001000>)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001010> "optimum NaCl observation")
 SubClassOf(<https://w3id.org/metpo/1001010> <https://w3id.org/metpo/1001000>)
-
-# Class: <https://w3id.org/metpo/1001011> (culture pH observation)
-
-AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001011> "culture pH observation")
-SubClassOf(<https://w3id.org/metpo/1001011> <https://w3id.org/metpo/1001000>)
 
 # Class: <https://w3id.org/metpo/1001012> (growth pH observation)
 

--- a/src/scripts/reconcile_madin_coverage.py
+++ b/src/scripts/reconcile_madin_coverage.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+"""
+Reconcile Madin MongoDB field values against METPO synonyms attributed to Madin source.
+
+This script:
+1. Connects to MongoDB and extracts unique values from a specified Madin field
+2. Reads the SPARQL synonym-sources.tsv report
+3. Filters for synonyms attributed to https://github.com/jmadin/bacteria_archaea_traits
+4. Reports which Madin values are covered/missing in METPO
+"""
+
+import click
+import csv
+import re
+import sys
+import yaml
+from typing import Dict, List, Set
+
+from pymongo import MongoClient
+
+
+MADIN_SOURCE_URI = "https://github.com/jmadin/bacteria_archaea_traits"
+
+# Entity type mappings to OWL CURIEs
+ENTITY_TYPE_MAP = {
+    'class': 'owl:Class',
+    'property': 'owl:ObjectProperty'  # Default for properties
+}
+
+def get_entity_curie(entity_uri: str) -> str:
+    """
+    Convert entity URI to CURIE format.
+
+    :param entity_uri: Full URI like 'https://w3id.org/metpo/1000602'
+    :return: CURIE like 'METPO:1000602'
+    """
+    if entity_uri.startswith('https://w3id.org/metpo/'):
+        return 'METPO:' + entity_uri.split('/')[-1]
+    return entity_uri
+
+
+def normalize_whitespace(text: str) -> str:
+    """
+    Normalize whitespace: trim left/right and collapse internal whitespace.
+
+    :param text: Input text
+    :return: Normalized text
+    """
+    return re.sub(r'\s+', ' ', text.strip())
+
+
+def get_madin_field_values(field_path: str, db_name: str = "madin", collection_name: str = "madin") -> Dict[str, str]:
+    """
+    Extract unique values from a Madin MongoDB field.
+
+    :param field_path: MongoDB field path (e.g., 'gram_stain', 'metabolism')
+    :param db_name: MongoDB database name
+    :param collection_name: MongoDB collection name
+    :return: Dict mapping normalized values to original values (to track if normalization occurred)
+    """
+    client = MongoClient()
+    db = client[db_name]
+    collection = db[collection_name]
+
+    values = collection.distinct(field_path)
+
+    value_map = {}
+    for v in values:
+        if v and v != "NA":
+            normalized = normalize_whitespace(v)
+            value_map[normalized] = v
+
+    return value_map
+
+
+def load_madin_synonyms(tsv_path: str) -> Dict[str, Dict[str, str]]:
+    """
+    Load synonyms attributed to Madin source from synonym-sources.tsv.
+
+    :param tsv_path: Path to reports/synonym-sources.tsv
+    :return: Dictionary mapping normalized synonym values to their METPO entity and predicate info
+    """
+    madin_synonyms = {}
+    entity_labels = {}
+
+    with open(tsv_path, 'r') as f:
+        reader = csv.DictReader(f, delimiter='\t')
+
+        for row in reader:
+            entity = row.get('?entity', '').strip('<>')
+            entity_type = row.get('?entityType', '').strip('"')
+            pred = row.get('?synonymPred', '').strip('<>')
+            syn_value = row.get('?synValue', '').strip('"')
+            src = row.get('?src', '').strip('<>')
+
+            if entity and pred and syn_value:
+                if pred == 'http://www.w3.org/2000/01/rdf-schema#label':
+                    entity_labels[entity] = syn_value
+
+                if src == MADIN_SOURCE_URI:
+                    normalized_syn = normalize_whitespace(syn_value)
+                    if normalized_syn not in madin_synonyms:
+                        madin_synonyms[normalized_syn] = {
+                            'entity': entity,
+                            'entity_type': entity_type,
+                            'predicate': pred,
+                            'source': src,
+                            'label': None
+                        }
+
+    for syn_value, info in madin_synonyms.items():
+        entity = info['entity']
+        if entity in entity_labels:
+            info['label'] = entity_labels[entity]
+
+    return madin_synonyms
+
+
+def get_all_madin_fields(db_name: str = "madin", collection_name: str = "madin") -> List[str]:
+    """
+    Get all field names from the Madin MongoDB collection.
+
+    :param db_name: MongoDB database name
+    :param collection_name: MongoDB collection name
+    :return: List of all field names
+    """
+    client = MongoClient()
+    db = client[db_name]
+    collection = db[collection_name]
+
+    sample_doc = collection.find_one()
+
+    if sample_doc:
+        return [key for key in sample_doc.keys() if key != '_id']
+    return []
+
+
+def get_all_madin_values_with_fields(db_name: str = "madin", collection_name: str = "madin") -> Dict[str, List[str]]:
+    """
+    Get ALL unique values from ALL fields in the Madin MongoDB collection.
+
+    :param db_name: MongoDB database name
+    :param collection_name: MongoDB collection name
+    :return: Dict mapping normalized values to list of field names where they appear
+    """
+    client = MongoClient()
+    db = client[db_name]
+    collection = db[collection_name]
+
+    value_to_fields = {}
+    fields = get_all_madin_fields(db_name, collection_name)
+
+    for field in fields:
+        values = collection.distinct(field)
+        for v in values:
+            if v and v != "NA":
+                normalized = normalize_whitespace(str(v))
+                if normalized not in value_to_fields:
+                    value_to_fields[normalized] = []
+                value_to_fields[normalized].append(field)
+
+    return value_to_fields
+
+
+def reconcile_all_field_names(tsv_path: str, output_format: str = "text", output_file: str = None) -> None:
+    """
+    Check if ALL Madin field names are synonyms in METPO.
+
+    :param tsv_path: Path to synonym-sources.tsv report
+    :param output_format: Output format ('text' or 'yaml')
+    """
+    madin_fields = get_all_madin_fields()
+    madin_synonyms = load_madin_synonyms(tsv_path)
+
+    # Get value counts for each field
+    client = MongoClient()
+    db = client["madin"]
+    collection = db["madin"]
+
+    field_value_counts = {}
+    for field in madin_fields:
+        values = collection.distinct(field)
+        non_na_count = sum(1 for v in values if v and v != "NA")
+        field_value_counts[field] = non_na_count
+
+    covered_entries = []
+    missing_entries = []
+
+    for field_path in sorted(madin_fields):
+        field_name = normalize_whitespace(field_path.replace('_', ' '))
+        field_path_normalized = normalize_whitespace(field_path)
+        value_count = field_value_counts[field_path]
+
+        if field_path_normalized in madin_synonyms or field_name in madin_synonyms:
+            if field_path_normalized in madin_synonyms:
+                info = madin_synonyms[field_path_normalized]
+            else:
+                info = madin_synonyms[field_name]
+
+            metpo_curie = get_entity_curie(info['entity'])
+            label = info.get('label', '')
+            entity_type_raw = info.get('entity_type', 'unknown')
+            entity_type = ENTITY_TYPE_MAP.get(entity_type_raw, entity_type_raw)
+
+            covered_entries.append({
+                'field': field_path,
+                'metpo_id': metpo_curie,
+                'label': label,
+                'entity_type': entity_type,
+                'unique_values': value_count
+            })
+        else:
+            missing_entries.append({
+                'field': field_path,
+                'unique_values': value_count
+            })
+
+    # Sort missing entries by value count (descending) to highlight high-value missing fields
+    missing_entries.sort(key=lambda x: x['unique_values'], reverse=True)
+
+    total = len(madin_fields)
+    covered_count = len(covered_entries)
+    missing_count = len(missing_entries)
+    coverage_pct = 100 * covered_count / total if total > 0 else 0
+
+    if output_format == "yaml":
+        # Create separate copies for high_value_missing_fields to avoid YAML anchors/aliases
+        # High-value = fields with small controlled vocabularies (2-20 values) that could be ontology classes
+        high_value_missing = [
+            {'field': e['field'], 'unique_values': e['unique_values']}
+            for e in missing_entries if 2 <= e['unique_values'] <= 20
+        ]
+
+        result = {
+            'field_name_reconciliation': {
+                'summary': {
+                    'total_fields': total,
+                    'covered': covered_count,
+                    'missing': missing_count,
+                    'coverage_percentage': round(coverage_pct, 1)
+                },
+                'covered_fields': covered_entries,
+                'missing_fields': missing_entries,
+                'high_value_missing_fields': high_value_missing
+            }
+        }
+        print(yaml.dump(result, default_flow_style=False, sort_keys=False, allow_unicode=True))
+    else:
+        print(f"\n{'='*80}")
+        print(f"Checking ALL Madin field names against METPO synonyms")
+        print(f"{'='*80}\n")
+        print(f"Total Madin fields: {total}\n")
+        print(f"COVERED ({covered_count}/{total} = {coverage_pct:.1f}%):")
+        print("-" * 80)
+        for entry in covered_entries:
+            if entry['label']:
+                print(f"  ✓ '{entry['field']}' → {entry['metpo_id']} ({entry['label']}) [{entry['unique_values']} unique values]")
+            else:
+                print(f"  ✓ '{entry['field']}' → {entry['metpo_id']} [{entry['unique_values']} unique values]")
+
+        if missing_entries:
+            print(f"\nMISSING ({missing_count}/{total} = {100*missing_count/total:.1f}%):")
+            print("-" * 80)
+            for entry in missing_entries:
+                print(f"  ✗ '{entry['field']}' [{entry['unique_values']} unique values]")
+
+            # High-value = small controlled vocabularies (2-20 values) that could be ontology classes
+            high_value_missing = [e for e in missing_entries if 2 <= e['unique_values'] <= 20]
+            if high_value_missing:
+                print(f"\nHIGH-VALUE MISSING FIELDS ({len(high_value_missing)} fields with 2-20 unique values - good ontology class candidates):")
+                print("-" * 80)
+                for entry in high_value_missing:
+                    print(f"  ⚠ '{entry['field']}' [{entry['unique_values']} unique values]")
+
+        print(f"\n{'='*80}\n")
+
+
+def reconcile_coverage(field_path: str, tsv_path: str, output_format: str = "text", output_file: str = None) -> None:
+    """
+    Reconcile Madin field values against METPO synonyms.
+
+    :param field_path: MongoDB field path to check
+    :param tsv_path: Path to synonym-sources.tsv report
+    :param output_format: Output format ('text' or 'yaml')
+    """
+    madin_value_map = get_madin_field_values(field_path)
+    madin_synonyms = load_madin_synonyms(tsv_path)
+
+    covered_entries = []
+    missing_entries = []
+
+    for normalized_value in sorted(madin_value_map.keys()):
+        original_value = madin_value_map[normalized_value]
+        was_normalized = (normalized_value != original_value)
+
+        if normalized_value in madin_synonyms:
+            info = madin_synonyms[normalized_value]
+            metpo_curie = get_entity_curie(info['entity'])
+            label = info.get('label', '')
+            entity_type_raw = info.get('entity_type', 'unknown')
+            entity_type = ENTITY_TYPE_MAP.get(entity_type_raw, entity_type_raw)
+
+            covered_entries.append({
+                'value': normalized_value,
+                'original_value': original_value if was_normalized else None,
+                'metpo_id': metpo_curie,
+                'label': label,
+                'entity_type': entity_type
+            })
+        else:
+            missing_entries.append({
+                'value': normalized_value,
+                'original_value': original_value if was_normalized else None
+            })
+
+    total = len(madin_value_map)
+    covered_count = len(covered_entries)
+    missing_count = len(missing_entries)
+    coverage_pct = 100 * covered_count / total if total > 0 else 0
+
+    if output_format == "yaml":
+        result = {
+            'field_value_reconciliation': {
+                'field': field_path,
+                'summary': {
+                    'total_values': total,
+                    'covered': covered_count,
+                    'missing': missing_count,
+                    'coverage_percentage': round(coverage_pct, 1)
+                },
+                'covered_values': covered_entries,
+                'missing_values': missing_entries
+            }
+        }
+        print(yaml.dump(result, default_flow_style=False, sort_keys=False, allow_unicode=True))
+    else:
+        print(f"\n{'='*80}")
+        print(f"Reconciling Madin field: {field_path}")
+        print(f"{'='*80}\n")
+        print(f"MongoDB values found: {total} (excluding 'NA')")
+        print(f"Madin synonyms in METPO: {len(madin_synonyms)}\n")
+        print(f"COVERED ({covered_count}/{total} = {coverage_pct:.1f}%):")
+        print("-" * 80)
+        for entry in covered_entries:
+            normalization_note = f" [NORMALIZED from '{entry['original_value']}']" if entry['original_value'] else ""
+            if entry['label']:
+                print(f"  ✓ '{entry['value']}' → {entry['metpo_id']} ({entry['label']}){normalization_note}")
+            else:
+                print(f"  ✓ '{entry['value']}' → {entry['metpo_id']}{normalization_note}")
+
+        if missing_entries:
+            print(f"\nMISSING ({missing_count}/{total} = {100*missing_count/total:.1f}%):")
+            print("-" * 80)
+            for entry in missing_entries:
+                normalization_note = f" [NORMALIZED from '{entry['original_value']}']" if entry['original_value'] else ""
+                print(f"  ✗ '{entry['value']}'{normalization_note}")
+
+        print(f"\n{'='*80}\n")
+
+
+def verify_madin_synonyms(tsv_path: str, output_format: str = "text", output_file: str = None) -> None:
+    """
+    Verify that all METPO synonyms attributed to Madin actually exist in the Madin MongoDB.
+
+    This checks the reverse direction: do the synonyms claimed in METPO actually appear
+    in the source data?
+
+    :param tsv_path: Path to synonym-sources.tsv report
+    :param output_format: Output format ('text' or 'yaml')
+    """
+    value_to_fields = get_all_madin_values_with_fields()
+    madin_synonyms = load_madin_synonyms(tsv_path)
+
+    verified_entries = []
+    unverified_entries = []
+
+    for syn_value, info in madin_synonyms.items():
+        metpo_curie = get_entity_curie(info['entity'])
+        entity_type_raw = info.get('entity_type', 'unknown')
+        entity_type = ENTITY_TYPE_MAP.get(entity_type_raw, entity_type_raw)
+        label = info.get('label', '')
+
+        if syn_value in value_to_fields:
+            fields = value_to_fields[syn_value]
+            verified_entries.append({
+                'synonym': syn_value,
+                'metpo_id': metpo_curie,
+                'entity_type': entity_type,
+                'label': label,
+                'found_in_fields': fields,
+                'field_count': len(fields)
+            })
+        else:
+            unverified_entries.append({
+                'synonym': syn_value,
+                'metpo_id': metpo_curie,
+                'entity_type': entity_type,
+                'label': label
+            })
+
+    total_madin_values = len(value_to_fields)
+    total_synonyms = len(madin_synonyms)
+    verified_count = len(verified_entries)
+    unverified_count = len(unverified_entries)
+    verification_pct = 100 * verified_count / total_synonyms if total_synonyms > 0 else 0
+
+    if output_format == "yaml":
+        result = {
+            'synonym_verification': {
+                'summary': {
+                    'total_madin_values': total_madin_values,
+                    'total_metpo_madin_synonyms': total_synonyms,
+                    'verified': verified_count,
+                    'unverified': unverified_count,
+                    'verification_percentage': round(verification_pct, 1)
+                },
+                'verified_synonyms': verified_entries,
+                'unverified_synonyms': unverified_entries,
+                'false_synonym_claims': unverified_entries  # Highlight false claims
+            }
+        }
+        print(yaml.dump(result, default_flow_style=False, sort_keys=False, allow_unicode=True))
+    else:
+        print(f"\n{'='*80}")
+        print(f"Verifying METPO Madin synonyms against actual Madin data")
+        print(f"{'='*80}\n")
+        print("Loading all Madin values from MongoDB...")
+        print(f"Total unique Madin values found: {total_madin_values}\n")
+        print("Loading METPO synonyms attributed to Madin...")
+        print(f"Total METPO synonyms attributed to Madin: {total_synonyms}\n")
+        print(f"VERIFIED ({verified_count}/{total_synonyms} = {verification_pct:.1f}%):")
+        print("-" * 80)
+        for entry in sorted(verified_entries, key=lambda x: x['synonym']):
+            fields_str = ', '.join(entry['found_in_fields']) if entry['field_count'] <= 3 else f"{', '.join(entry['found_in_fields'][:3])}, ..."
+            if entry['label']:
+                print(f"  ✓ '{entry['synonym']}' ({entry['metpo_id']} [{entry['entity_type']}] - {entry['label']}) in {entry['field_count']} field(s): [{fields_str}]")
+            else:
+                print(f"  ✓ '{entry['synonym']}' ({entry['metpo_id']} [{entry['entity_type']}]) in {entry['field_count']} field(s): [{fields_str}]")
+
+        if unverified_entries:
+            print(f"\nUNVERIFIED ({unverified_count}/{total_synonyms} = {100*unverified_count/total_synonyms:.1f}%):")
+            print("-" * 80)
+            print("These synonyms are attributed to Madin in METPO but NOT found in Madin field VALUES:")
+            print("⚠ FALSE SYNONYM CLAIMS - METPO incorrectly attributes these to Madin source")
+            print()
+            for entry in sorted(unverified_entries, key=lambda x: x['synonym']):
+                if entry['label']:
+                    print(f"  ✗ '{entry['synonym']}' ({entry['metpo_id']} [{entry['entity_type']}] - {entry['label']})")
+                else:
+                    print(f"  ✗ '{entry['synonym']}' ({entry['metpo_id']} [{entry['entity_type']}])")
+
+        print(f"\n{'='*80}\n")
+
+
+def generate_integrated_report(tsv_path: str, output_format: str = "yaml", output_file: str = None) -> None:
+    """
+    Generate integrated reconciliation report combining field mappings, value coverage, and false claims.
+
+    :param tsv_path: Path to synonym-sources.tsv report
+    :param output_format: Output format ('text' or 'yaml')
+    :param output_file: Output file path (None = stdout)
+    """
+    madin_synonyms = load_madin_synonyms(tsv_path)
+    value_to_fields = get_all_madin_values_with_fields()
+    madin_fields = get_all_madin_fields()
+
+    client = MongoClient()
+    db = client["madin"]
+    collection = db["madin"]
+
+    # Build integrated field analysis
+    field_analysis = []
+
+    for field_name in sorted(madin_fields):
+        field_values = collection.distinct(field_name)
+        non_na_values = [v for v in field_values if v and v != "NA"]
+        total_values = len(non_na_values)
+
+        # Check if field name itself is mapped
+        field_name_normalized = normalize_whitespace(field_name)
+        field_name_alt = normalize_whitespace(field_name.replace('_', ' '))
+
+        field_mapped = False
+        field_metpo_id = None
+        field_metpo_label = None
+        field_entity_type = None
+
+        if field_name_normalized in madin_synonyms or field_name_alt in madin_synonyms:
+            field_mapped = True
+            info = madin_synonyms.get(field_name_normalized) or madin_synonyms.get(field_name_alt)
+            field_metpo_id = get_entity_curie(info['entity'])
+            field_metpo_label = info.get('label', '')
+            field_entity_type = ENTITY_TYPE_MAP.get(info.get('entity_type', 'unknown'), 'unknown')
+
+        # Check value coverage
+        # Special handling for pathways field which contains comma-separated lists
+        if field_name == 'pathways':
+            # For pathways, we need to extract individual pathway values
+            all_pathway_values = set()
+            for v in non_na_values:
+                # Split on comma and normalize each pathway
+                pathways_in_value = [normalize_whitespace(p.strip()) for p in str(v).split(',')]
+                all_pathway_values.update(pathways_in_value)
+
+            # Check coverage for individual pathways
+            covered_pathways = []
+            missing_pathways = []
+
+            for pathway in sorted(all_pathway_values):
+                if pathway in madin_synonyms:
+                    info = madin_synonyms[pathway]
+                    covered_pathways.append({
+                        'value': pathway,
+                        'metpo_id': get_entity_curie(info['entity']),
+                        'label': info.get('label', ''),
+                        'entity_type': ENTITY_TYPE_MAP.get(info.get('entity_type', 'unknown'), 'unknown')
+                    })
+                else:
+                    missing_pathways.append(pathway)
+
+            covered_values = covered_pathways
+            missing_values = missing_pathways
+            total_values = len(all_pathway_values)
+            value_coverage_pct = 100 * len(covered_pathways) / total_values if total_values > 0 else 0
+        else:
+            # Normal handling for other fields
+            covered_values = []
+            missing_values = []
+
+            for v in non_na_values:
+                normalized_v = normalize_whitespace(str(v))
+                if normalized_v in madin_synonyms:
+                    info = madin_synonyms[normalized_v]
+                    covered_values.append({
+                        'value': v,
+                        'metpo_id': get_entity_curie(info['entity']),
+                        'label': info.get('label', ''),
+                        'entity_type': ENTITY_TYPE_MAP.get(info.get('entity_type', 'unknown'), 'unknown')
+                    })
+                else:
+                    missing_values.append(v)
+
+            value_coverage_pct = 100 * len(covered_values) / total_values if total_values > 0 else 0
+
+        if field_mapped:
+            # For mapped fields, show full details
+            field_entry = {
+                'field': field_name,
+                'field_mapped': True,
+                'field_metpo_id': field_metpo_id,
+                'field_metpo_label': field_metpo_label,
+                'field_entity_type': field_entity_type,
+                'total_values': total_values,
+                'covered_values_count': len(covered_values),
+                'missing_values_count': len(missing_values),
+                'value_coverage_percentage': round(value_coverage_pct, 1),
+                'covered_values': covered_values if len(covered_values) <= 20 else covered_values[:20],
+                'missing_values': missing_values if len(missing_values) <= 20 else missing_values[:20],
+                'values_truncated': len(covered_values) > 20 or len(missing_values) > 20
+            }
+        else:
+            # For unmapped fields, just show field name and unique value count
+            field_entry = {
+                'field': field_name,
+                'field_mapped': False,
+                'unique_values': total_values
+            }
+
+        field_analysis.append(field_entry)
+
+    # Identify false claims (METPO synonyms not in Madin data)
+    # Build set of normalized field names to exclude from false claims
+    normalized_field_names = set()
+    for field_name in madin_fields:
+        normalized_field_names.add(normalize_whitespace(field_name))
+        normalized_field_names.add(normalize_whitespace(field_name.replace('_', ' ')))
+
+    false_claims = []
+    verified_synonyms = []
+
+    for syn_value, info in madin_synonyms.items():
+        metpo_curie = get_entity_curie(info['entity'])
+        entity_type = ENTITY_TYPE_MAP.get(info.get('entity_type', 'unknown'), 'unknown')
+        label = info.get('label', '')
+
+        # If synonym not found in field values AND not a field name itself, it's a false claim
+        if syn_value not in value_to_fields:
+            if syn_value not in normalized_field_names:
+                false_claims.append({
+                    'synonym': syn_value,
+                    'metpo_id': metpo_curie,
+                    'entity_type': entity_type,
+                    'label': label
+                })
+        else:
+            verified_synonyms.append({
+                'synonym': syn_value,
+                'metpo_id': metpo_curie,
+                'entity_type': entity_type,
+                'label': label,
+                'found_in_fields': value_to_fields[syn_value]
+            })
+
+    # Generate output
+    if output_format == "yaml":
+        result = {
+            'madin_metpo_reconciliation': {
+                'summary': {
+                    'total_fields': len(madin_fields),
+                    'fields_with_name_mapping': sum(1 for f in field_analysis if f['field_mapped']),
+                    'fields_with_full_value_coverage': sum(1 for f in field_analysis if f.get('value_coverage_percentage') == 100),
+                    'total_metpo_madin_synonyms': len(madin_synonyms),
+                    'verified_synonyms': len(verified_synonyms),
+                    'false_synonym_claims': len(false_claims)
+                },
+                'fields': field_analysis,
+                'high_value_unmapped_fields': [
+                    {'field': f['field'], 'unique_values': f['unique_values']}
+                    for f in field_analysis
+                    if not f['field_mapped'] and 2 <= f['unique_values'] <= 20
+                ],
+                'false_synonym_claims': false_claims
+            }
+        }
+        output_content = yaml.dump(result, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+        if output_file:
+            with open(output_file, 'w') as f:
+                f.write(output_content)
+            print(f"Report written to {output_file}")
+        else:
+            print(output_content)
+    else:
+        print(f"\n{'='*80}")
+        print(f"Integrated Madin-METPO Reconciliation Report")
+        print(f"{'='*80}\n")
+
+        total_fields = len(madin_fields)
+        fields_mapped = sum(1 for f in field_analysis if f['field_mapped'])
+        fields_full_coverage = sum(1 for f in field_analysis if f.get('value_coverage_percentage') == 100)
+
+        print(f"SUMMARY:")
+        print(f"  Total Madin fields: {total_fields}")
+        print(f"  Fields with name mapping: {fields_mapped} ({100*fields_mapped/total_fields:.1f}%)")
+        print(f"  Fields with 100% value coverage: {fields_full_coverage} ({100*fields_full_coverage/total_fields:.1f}%)")
+        print(f"  Total METPO Madin synonyms: {len(madin_synonyms)}")
+        print(f"  Verified synonyms: {len(verified_synonyms)} ({100*len(verified_synonyms)/len(madin_synonyms):.1f}%)")
+        print(f"  False synonym claims: {len(false_claims)} ({100*len(false_claims)/len(madin_synonyms):.1f}%)\n")
+
+        print(f"FIELD ANALYSIS:")
+        print("-" * 80)
+        for field in field_analysis:
+            status = "✓ MAPPED" if field['field_mapped'] else "✗ UNMAPPED"
+            print(f"\n{status}: {field['field']}")
+
+            if field['field_mapped']:
+                coverage = f"{field['value_coverage_percentage']:.1f}%"
+                print(f"  → {field['field_metpo_id']} ({field['field_metpo_label']}) [{field['field_entity_type']}]")
+                print(f"  Values: {field['covered_values_count']}/{field['total_values']} covered ({coverage})")
+
+                if field['covered_values'] and len(field['covered_values']) <= 10:
+                    print(f"  Covered values:")
+                    for val in field['covered_values'][:5]:
+                        print(f"    • {val['value']} → {val['metpo_id']}")
+
+                if field['missing_values'] and len(field['missing_values']) <= 10:
+                    print(f"  Missing values: {', '.join(str(v) for v in field['missing_values'][:5])}")
+            else:
+                print(f"  Unique values: {field['unique_values']}")
+
+        if false_claims:
+            print(f"\n\nFALSE SYNONYM CLAIMS ({len(false_claims)}):")
+            print("-" * 80)
+            for claim in false_claims:
+                print(f"  ✗ '{claim['synonym']}' ({claim['metpo_id']} [{claim['entity_type']}] - {claim['label']})")
+
+        print(f"\n{'='*80}\n")
+
+
+@click.command()
+@click.option(
+    '--mode',
+    type=click.Choice(['values', 'field_names', 'verify_synonyms', 'integrated'], case_sensitive=False),
+    default='values',
+    help="Reconciliation mode: 'values' checks field values, 'field_names' checks ALL field names, 'verify_synonyms' verifies METPO synonyms exist in Madin data, 'integrated' shows comprehensive analysis"
+)
+@click.option(
+    '--field',
+    type=str,
+    help="MongoDB field path to reconcile (e.g., 'gram_stain', 'metabolism'). Required for 'values' mode."
+)
+@click.option(
+    '--tsv',
+    type=click.Path(exists=True),
+    default='reports/synonym-sources.tsv',
+    help="Path to synonym-sources.tsv report"
+)
+@click.option(
+    '--format',
+    'output_format',
+    type=click.Choice(['text', 'yaml'], case_sensitive=False),
+    default='text',
+    help="Output format: 'text' for console output, 'yaml' for structured YAML"
+)
+@click.option(
+    '--output',
+    type=click.Path(),
+    help="Output file path. If not specified, prints to stdout."
+)
+def main(mode, field, tsv, output_format, output):
+    """Reconcile Madin MongoDB field values against METPO synonyms."""
+    try:
+        if mode == "field_names":
+            reconcile_all_field_names(tsv, output_format, output)
+        elif mode == "verify_synonyms":
+            verify_madin_synonyms(tsv, output_format, output)
+        elif mode == "integrated":
+            generate_integrated_report(tsv, output_format, output)
+        else:  # values mode
+            if not field:
+                raise click.UsageError("--field is required for 'values' mode")
+            reconcile_coverage(field, tsv, output_format, output)
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/reconcile_madin_coverage.py.bak
+++ b/src/scripts/reconcile_madin_coverage.py.bak
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""
+Reconcile Madin MongoDB field values against METPO synonyms attributed to Madin source.
+
+This script:
+1. Connects to MongoDB and extracts unique values from a specified Madin field
+2. Reads the SPARQL synonym-sources.tsv report
+3. Filters for synonyms attributed to https://github.com/jmadin/bacteria_archaea_traits
+4. Reports which Madin values are covered/missing in METPO
+"""
+
+import click
+import csv
+import re
+import sys
+import yaml
+from typing import Dict, List, Set
+
+from pymongo import MongoClient
+
+
+MADIN_SOURCE_URI = "https://github.com/jmadin/bacteria_archaea_traits"
+
+# Entity type mappings to OWL CURIEs
+ENTITY_TYPE_MAP = {
+    'class': 'owl:Class',
+    'property': 'owl:ObjectProperty'  # Default for properties
+}
+
+def get_entity_curie(entity_uri: str) -> str:
+    """
+    Convert entity URI to CURIE format.
+
+    :param entity_uri: Full URI like 'https://w3id.org/metpo/1000602'
+    :return: CURIE like 'METPO:1000602'
+    """
+    if entity_uri.startswith('https://w3id.org/metpo/'):
+        return 'METPO:' + entity_uri.split('/')[-1]
+    return entity_uri
+
+
+def normalize_whitespace(text: str) -> str:
+    """
+    Normalize whitespace: trim left/right and collapse internal whitespace.
+
+    :param text: Input text
+    :return: Normalized text
+    """
+    return re.sub(r'\s+', ' ', text.strip())
+
+
+def get_madin_field_values(field_path: str, db_name: str = "madin", collection_name: str = "madin") -> Dict[str, str]:
+    """
+    Extract unique values from a Madin MongoDB field.
+
+    :param field_path: MongoDB field path (e.g., 'gram_stain', 'metabolism')
+    :param db_name: MongoDB database name
+    :param collection_name: MongoDB collection name
+    :return: Dict mapping normalized values to original values (to track if normalization occurred)
+    """
+    client = MongoClient()
+    db = client[db_name]
+    collection = db[collection_name]
+
+    values = collection.distinct(field_path)
+
+    value_map = {}
+    for v in values:
+        if v and v != "NA":
+            normalized = normalize_whitespace(v)
+            value_map[normalized] = v
+
+    return value_map
+
+
+def load_madin_synonyms(tsv_path: str) -> Dict[str, Dict[str, str]]:
+    """
+    Load synonyms attributed to Madin source from synonym-sources.tsv.
+
+    :param tsv_path: Path to reports/synonym-sources.tsv
+    :return: Dictionary mapping normalized synonym values to their METPO entity and predicate info
+    """
+    madin_synonyms = {}
+    entity_labels = {}
+
+    with open(tsv_path, 'r') as f:
+        reader = csv.DictReader(f, delimiter='\t')
+
+        for row in reader:
+            entity = row.get('?entity', '').strip('<>')
+            entity_type = row.get('?entityType', '').strip('"')
+            pred = row.get('?synonymPred', '').strip('<>')
+            syn_value = row.get('?synValue', '').strip('"')
+            src = row.get('?src', '').strip('<>')
+
+            if entity and pred and syn_value:
+                if pred == 'http://www.w3.org/2000/01/rdf-schema#label':
+                    entity_labels[entity] = syn_value
+
+                if src == MADIN_SOURCE_URI:
+                    normalized_syn = normalize_whitespace(syn_value)
+                    if normalized_syn not in madin_synonyms:
+                        madin_synonyms[normalized_syn] = {
+                            'entity': entity,
+                            'entity_type': entity_type,
+                            'predicate': pred,
+                            'source': src,
+                            'label': None
+                        }
+
+    for syn_value, info in madin_synonyms.items():
+        entity = info['entity']
+        if entity in entity_labels:
+            info['label'] = entity_labels[entity]
+
+    return madin_synonyms
+
+
+def get_all_madin_fields(db_name: str = "madin", collection_name: str = "madin") -> List[str]:
+    """
+    Get all field names from the Madin MongoDB collection.
+
+    :param db_name: MongoDB database name
+    :param collection_name: MongoDB collection name
+    :return: List of all field names
+    """
+    client = MongoClient()
+    db = client[db_name]
+    collection = db[collection_name]
+
+    sample_doc = collection.find_one()
+
+    if sample_doc:
+        return [key for key in sample_doc.keys() if key != '_id']
+    return []
+
+
+def get_all_madin_values_with_fields(db_name: str = "madin", collection_name: str = "madin") -> Dict[str, List[str]]:
+    """
+    Get ALL unique values from ALL fields in the Madin MongoDB collection.
+
+    :param db_name: MongoDB database name
+    :param collection_name: MongoDB collection name
+    :return: Dict mapping normalized values to list of field names where they appear
+    """
+    client = MongoClient()
+    db = client[db_name]
+    collection = db[collection_name]
+
+    value_to_fields = {}
+    fields = get_all_madin_fields(db_name, collection_name)
+
+    for field in fields:
+        values = collection.distinct(field)
+        for v in values:
+            if v and v != "NA":
+                normalized = normalize_whitespace(str(v))
+                if normalized not in value_to_fields:
+                    value_to_fields[normalized] = []
+                value_to_fields[normalized].append(field)
+
+    return value_to_fields
+
+
+def reconcile_all_field_names(tsv_path: str, output_format: str = "text") -> None:
+    """
+    Check if ALL Madin field names are synonyms in METPO.
+
+    :param tsv_path: Path to synonym-sources.tsv report
+    :param output_format: Output format ('text' or 'yaml')
+    """
+    madin_fields = get_all_madin_fields()
+    madin_synonyms = load_madin_synonyms(tsv_path)
+
+    # Get value counts for each field
+    client = MongoClient()
+    db = client["madin"]
+    collection = db["madin"]
+
+    field_value_counts = {}
+    for field in madin_fields:
+        values = collection.distinct(field)
+        non_na_count = sum(1 for v in values if v and v != "NA")
+        field_value_counts[field] = non_na_count
+
+    covered_entries = []
+    missing_entries = []
+
+    for field_path in sorted(madin_fields):
+        field_name = normalize_whitespace(field_path.replace('_', ' '))
+        field_path_normalized = normalize_whitespace(field_path)
+        value_count = field_value_counts[field_path]
+
+        if field_path_normalized in madin_synonyms or field_name in madin_synonyms:
+            if field_path_normalized in madin_synonyms:
+                info = madin_synonyms[field_path_normalized]
+            else:
+                info = madin_synonyms[field_name]
+
+            metpo_curie = get_entity_curie(info['entity'])
+            label = info.get('label', '')
+            entity_type_raw = info.get('entity_type', 'unknown')
+            entity_type = ENTITY_TYPE_MAP.get(entity_type_raw, entity_type_raw)
+
+            covered_entries.append({
+                'field': field_path,
+                'metpo_id': metpo_curie,
+                'label': label,
+                'entity_type': entity_type,
+                'unique_values': value_count
+            })
+        else:
+            missing_entries.append({
+                'field': field_path,
+                'unique_values': value_count
+            })
+
+    # Sort missing entries by value count (descending) to highlight high-value missing fields
+    missing_entries.sort(key=lambda x: x['unique_values'], reverse=True)
+
+    total = len(madin_fields)
+    covered_count = len(covered_entries)
+    missing_count = len(missing_entries)
+    coverage_pct = 100 * covered_count / total if total > 0 else 0
+
+    if output_format == "yaml":
+        result = {
+            'field_name_reconciliation': {
+                'summary': {
+                    'total_fields': total,
+                    'covered': covered_count,
+                    'missing': missing_count,
+                    'coverage_percentage': round(coverage_pct, 1)
+                },
+                'covered_fields': covered_entries,
+                'missing_fields': missing_entries,
+                'high_value_missing_fields': [
+                    entry for entry in missing_entries if entry['unique_values'] >= 5
+                ]
+            }
+        }
+        print(yaml.dump(result, default_flow_style=False, sort_keys=False, allow_unicode=True))
+    else:
+        print(f"\n{'='*80}")
+        print(f"Checking ALL Madin field names against METPO synonyms")
+        print(f"{'='*80}\n")
+        print(f"Total Madin fields: {total}\n")
+        print(f"COVERED ({covered_count}/{total} = {coverage_pct:.1f}%):")
+        print("-" * 80)
+        for entry in covered_entries:
+            if entry['label']:
+                print(f"  ✓ '{entry['field']}' → METPO:{entry['metpo_id']} ({entry['label']}) [{entry['unique_values']} unique values]")
+            else:
+                print(f"  ✓ '{entry['field']}' → METPO:{entry['metpo_id']} [{entry['unique_values']} unique values]")
+
+        if missing_entries:
+            print(f"\nMISSING ({missing_count}/{total} = {100*missing_count/total:.1f}%):")
+            print("-" * 80)
+            for entry in missing_entries:
+                print(f"  ✗ '{entry['field']}' [{entry['unique_values']} unique values]")
+
+            high_value_missing = [e for e in missing_entries if e['unique_values'] >= 5]
+            if high_value_missing:
+                print(f"\nHIGH-VALUE MISSING FIELDS ({len(high_value_missing)} fields with ≥5 unique values):")
+                print("-" * 80)
+                for entry in high_value_missing:
+                    print(f"  ⚠ '{entry['field']}' [{entry['unique_values']} unique values]")
+
+        print(f"\n{'='*80}\n")
+
+
+def reconcile_coverage(field_path: str, tsv_path: str, output_format: str = "text") -> None:
+    """
+    Reconcile Madin field values against METPO synonyms.
+
+    :param field_path: MongoDB field path to check
+    :param tsv_path: Path to synonym-sources.tsv report
+    :param output_format: Output format ('text' or 'yaml')
+    """
+    madin_value_map = get_madin_field_values(field_path)
+    madin_synonyms = load_madin_synonyms(tsv_path)
+
+    covered_entries = []
+    missing_entries = []
+
+    for normalized_value in sorted(madin_value_map.keys()):
+        original_value = madin_value_map[normalized_value]
+        was_normalized = (normalized_value != original_value)
+
+        if normalized_value in madin_synonyms:
+            info = madin_synonyms[normalized_value]
+            metpo_curie = get_entity_curie(info['entity'])
+            label = info.get('label', '')
+            entity_type_raw = info.get('entity_type', 'unknown')
+            entity_type = ENTITY_TYPE_MAP.get(entity_type_raw, entity_type_raw)
+
+            covered_entries.append({
+                'value': normalized_value,
+                'original_value': original_value if was_normalized else None,
+                'metpo_id': metpo_curie,
+                'label': label,
+                'entity_type': entity_type
+            })
+        else:
+            missing_entries.append({
+                'value': normalized_value,
+                'original_value': original_value if was_normalized else None
+            })
+
+    total = len(madin_value_map)
+    covered_count = len(covered_entries)
+    missing_count = len(missing_entries)
+    coverage_pct = 100 * covered_count / total if total > 0 else 0
+
+    if output_format == "yaml":
+        result = {
+            'field_value_reconciliation': {
+                'field': field_path,
+                'summary': {
+                    'total_values': total,
+                    'covered': covered_count,
+                    'missing': missing_count,
+                    'coverage_percentage': round(coverage_pct, 1)
+                },
+                'covered_values': covered_entries,
+                'missing_values': missing_entries
+            }
+        }
+        print(yaml.dump(result, default_flow_style=False, sort_keys=False, allow_unicode=True))
+    else:
+        print(f"\n{'='*80}")
+        print(f"Reconciling Madin field: {field_path}")
+        print(f"{'='*80}\n")
+        print(f"MongoDB values found: {total} (excluding 'NA')")
+        print(f"Madin synonyms in METPO: {len(madin_synonyms)}\n")
+        print(f"COVERED ({covered_count}/{total} = {coverage_pct:.1f}%):")
+        print("-" * 80)
+        for entry in covered_entries:
+            normalization_note = f" [NORMALIZED from '{entry['original_value']}']" if entry['original_value'] else ""
+            if entry['label']:
+                print(f"  ✓ '{entry['value']}' → METPO:{entry['metpo_id']} ({entry['label']}){normalization_note}")
+            else:
+                print(f"  ✓ '{entry['value']}' → METPO:{entry['metpo_id']}{normalization_note}")
+
+        if missing_entries:
+            print(f"\nMISSING ({missing_count}/{total} = {100*missing_count/total:.1f}%):")
+            print("-" * 80)
+            for entry in missing_entries:
+                normalization_note = f" [NORMALIZED from '{entry['original_value']}']" if entry['original_value'] else ""
+                print(f"  ✗ '{entry['value']}'{normalization_note}")
+
+        print(f"\n{'='*80}\n")
+
+
+def verify_madin_synonyms(tsv_path: str, output_format: str = "text") -> None:
+    """
+    Verify that all METPO synonyms attributed to Madin actually exist in the Madin MongoDB.
+
+    This checks the reverse direction: do the synonyms claimed in METPO actually appear
+    in the source data?
+
+    :param tsv_path: Path to synonym-sources.tsv report
+    :param output_format: Output format ('text' or 'yaml')
+    """
+    value_to_fields = get_all_madin_values_with_fields()
+    madin_synonyms = load_madin_synonyms(tsv_path)
+
+    verified_entries = []
+    unverified_entries = []
+
+    for syn_value, info in madin_synonyms.items():
+        metpo_curie = get_entity_curie(info['entity'])
+        entity_type_raw = info.get('entity_type', 'unknown')
+        entity_type = ENTITY_TYPE_MAP.get(entity_type_raw, entity_type_raw)
+        label = info.get('label', '')
+
+        if syn_value in value_to_fields:
+            fields = value_to_fields[syn_value]
+            verified_entries.append({
+                'synonym': syn_value,
+                'metpo_id': metpo_curie,
+                'entity_type': entity_type,
+                'label': label,
+                'found_in_fields': fields,
+                'field_count': len(fields)
+            })
+        else:
+            unverified_entries.append({
+                'synonym': syn_value,
+                'metpo_id': metpo_curie,
+                'entity_type': entity_type,
+                'label': label
+            })
+
+    total_madin_values = len(value_to_fields)
+    total_synonyms = len(madin_synonyms)
+    verified_count = len(verified_entries)
+    unverified_count = len(unverified_entries)
+    verification_pct = 100 * verified_count / total_synonyms if total_synonyms > 0 else 0
+
+    if output_format == "yaml":
+        result = {
+            'synonym_verification': {
+                'summary': {
+                    'total_madin_values': total_madin_values,
+                    'total_metpo_madin_synonyms': total_synonyms,
+                    'verified': verified_count,
+                    'unverified': unverified_count,
+                    'verification_percentage': round(verification_pct, 1)
+                },
+                'verified_synonyms': verified_entries,
+                'unverified_synonyms': unverified_entries,
+                'false_synonym_claims': unverified_entries  # Highlight false claims
+            }
+        }
+        print(yaml.dump(result, default_flow_style=False, sort_keys=False, allow_unicode=True))
+    else:
+        print(f"\n{'='*80}")
+        print(f"Verifying METPO Madin synonyms against actual Madin data")
+        print(f"{'='*80}\n")
+        print("Loading all Madin values from MongoDB...")
+        print(f"Total unique Madin values found: {total_madin_values}\n")
+        print("Loading METPO synonyms attributed to Madin...")
+        print(f"Total METPO synonyms attributed to Madin: {total_synonyms}\n")
+        print(f"VERIFIED ({verified_count}/{total_synonyms} = {verification_pct:.1f}%):")
+        print("-" * 80)
+        for entry in sorted(verified_entries, key=lambda x: x['synonym']):
+            fields_str = ', '.join(entry['found_in_fields']) if entry['field_count'] <= 3 else f"{', '.join(entry['found_in_fields'][:3])}, ..."
+            if entry['label']:
+                print(f"  ✓ '{entry['synonym']}' (METPO:{entry['metpo_id']} [{entry['entity_type']}] - {entry['label']}) in {entry['field_count']} field(s): [{fields_str}]")
+            else:
+                print(f"  ✓ '{entry['synonym']}' (METPO:{entry['metpo_id']} [{entry['entity_type']}]) in {entry['field_count']} field(s): [{fields_str}]")
+
+        if unverified_entries:
+            print(f"\nUNVERIFIED ({unverified_count}/{total_synonyms} = {100*unverified_count/total_synonyms:.1f}%):")
+            print("-" * 80)
+            print("These synonyms are attributed to Madin in METPO but NOT found in Madin field VALUES:")
+            print("⚠ FALSE SYNONYM CLAIMS - METPO incorrectly attributes these to Madin source")
+            print()
+            for entry in sorted(unverified_entries, key=lambda x: x['synonym']):
+                if entry['label']:
+                    print(f"  ✗ '{entry['synonym']}' (METPO:{entry['metpo_id']} [{entry['entity_type']}] - {entry['label']})")
+                else:
+                    print(f"  ✗ '{entry['synonym']}' (METPO:{entry['metpo_id']} [{entry['entity_type']}])")
+
+        print(f"\n{'='*80}\n")
+
+
+@click.command()
+@click.option(
+    '--mode',
+    type=click.Choice(['values', 'field_names', 'verify_synonyms'], case_sensitive=False),
+    default='values',
+    help="Reconciliation mode: 'values' checks field values, 'field_names' checks ALL field names, 'verify_synonyms' verifies METPO synonyms exist in Madin data"
+)
+@click.option(
+    '--field',
+    type=str,
+    help="MongoDB field path to reconcile (e.g., 'gram_stain', 'metabolism'). Required for 'values' mode."
+)
+@click.option(
+    '--tsv',
+    type=click.Path(exists=True),
+    default='reports/synonym-sources.tsv',
+    help="Path to synonym-sources.tsv report"
+)
+@click.option(
+    '--format',
+    'output_format',
+    type=click.Choice(['text', 'yaml'], case_sensitive=False),
+    default='text',
+    help="Output format: 'text' for console output, 'yaml' for structured YAML"
+)
+def main(mode, field, tsv, output_format):
+    """Reconcile Madin MongoDB field values against METPO synonyms."""
+    try:
+        if mode == "field_names":
+            reconcile_all_field_names(tsv, output_format)
+        elif mode == "verify_synonyms":
+            verify_madin_synonyms(tsv, output_format)
+        else:  # values mode
+            if not field:
+                raise click.UsageError("--field is required for 'values' mode")
+            reconcile_coverage(field, tsv, output_format)
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparql/synonym-sources.sparql
+++ b/src/sparql/synonym-sources.sparql
@@ -1,0 +1,68 @@
+PREFIX owl:   <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX IAO:   <http://purl.obolibrary.org/obo/IAO_>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX schema: <https://schema.org/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX dc:    <http://purl.org/dc/elements/1.1/>
+PREFIX prov:  <http://www.w3.org/ns/prov#>
+
+SELECT DISTINCT ?entity ?entityType ?synonymPred ?synValue (LANG(?synValue) AS ?lang)
+                ?synType ?xref ?src ?prov
+WHERE {
+  VALUES ?synonymPred {
+    rdfs:label
+    oboInOwl:hasExactSynonym
+    oboInOwl:hasRelatedSynonym
+    oboInOwl:hasNarrowSynonym
+    oboInOwl:hasBroadSynonym
+    IAO:0000118               # IAO alternative term/label
+    skos:prefLabel
+    skos:altLabel
+    skos:hiddenLabel
+    schema:alternateName
+    dcterms:alternative
+  }
+
+  {
+    ?entity a owl:Class ;
+            ?synonymPred ?synValue .
+    BIND("class" AS ?entityType)
+  }
+  UNION
+  {
+    ?entity a owl:ObjectProperty ;
+            ?synonymPred ?synValue .
+    BIND("property" AS ?entityType)
+  }
+  UNION
+  {
+    ?entity a owl:DatatypeProperty ;
+            ?synonymPred ?synValue .
+    BIND("property" AS ?entityType)
+  }
+  UNION
+  {
+    ?entity a owl:AnnotationProperty ;
+            ?synonymPred ?synValue .
+    BIND("property" AS ?entityType)
+  }
+
+  # Axiom annotations that qualify/attribute the synonym
+  OPTIONAL {
+    ?axiom a owl:Axiom ;
+           owl:annotatedSource ?entity ;
+           owl:annotatedProperty ?synonymPred ;
+           owl:annotatedTarget ?synValue .
+
+    OPTIONAL { ?axiom oboInOwl:hasSynonymType ?synType }   # e.g., abbreviation
+    OPTIONAL { ?axiom oboInOwl:hasDbXref ?xref }           # synonym provenance/citation
+    OPTIONAL { ?axiom oboInOwl:source ?src }               # occasional
+    OPTIONAL { ?axiom dcterms:source ?src }                # occasional
+    OPTIONAL { ?axiom dc:source ?src }                     # occasional
+    OPTIONAL { ?axiom prov:wasDerivedFrom ?prov }          # occasional
+    OPTIONAL { ?axiom IAO:0000119 ?src }                   # rare for synonyms; common for definitions
+  }
+}
+ORDER BY ?entityType ?synonymPred ?entity ?synValue

--- a/src/templates/metpo-properties.tsv
+++ b/src/templates/metpo-properties.tsv
@@ -1,5 +1,5 @@
  ID	label	TYPE	non-materialized comment	DOMAIN	RANGE	parent property	biolink equivalent	description	synonym property and value TUPLES	synonym source
- ID	LABEL	TYPE		DOMAIN	RANGE	SP %	AI skos:closeMatch	A IAO:0000115	AP	>AI IAO:0000119
+ ID	LABEL	TYPE		DOMAIN	RANGE	SP %	AI skos:closeMatch	A IAO:0000115	AP SPLIT=|	>AI IAO:0000119
 IAO:0000115	definition	owl:AnnotationProperty								
 IAO:0000119	definition source	owl:AnnotationProperty								
 METPO:1000059	phenotype	owl:Class	stub for using label in domain and range							
@@ -10,16 +10,12 @@ METPO:1000630	biological process	owl:Class	stub for using label in domain and ra
 METPO:1001000	observation	owl:Class	stub for using label in domain and range							
 METPO:1001001	optimum temperature observation	owl:Class	stub for using label in domain and range							
 METPO:1001002	growth temperature observation	owl:Class	stub for using label in domain and range							
-METPO:1001005	culture temperature observation	owl:Class	stub for using label in domain and range							
 METPO:1001003	temperature range observation	owl:Class	stub for using label in domain and range							
 METPO:1001004	temperature delta observation	owl:Class	stub for using label in domain and range							
-METPO:1001005	culture temperature observation	owl:Class	stub for using label in domain and range							
-METPO:1001006	culture NaCl observation	owl:Class	stub for using label in domain and range							
 METPO:1001007	growth NaCl observation	owl:Class	stub for using label in domain and range							
 METPO:1001008	NaCl delta observation	owl:Class	stub for using label in domain and range							
 METPO:1001009	NaCl range observation	owl:Class	stub for using label in domain and range							
 METPO:1001010	optimum NaCl observation	owl:Class	stub for using label in domain and range							
-METPO:1001011	culture pH observation	owl:Class	stub for using label in domain and range							
 METPO:1001012	growth pH observation	owl:Class	stub for using label in domain and range							
 METPO:1001013	optimum pH observation	owl:Class	stub for using label in domain and range							
 METPO:1001014	pH delta observation	owl:Class	stub for using label in domain and range							
@@ -80,7 +76,6 @@ METPO:2000053	has optimum temperature observation	owl:ObjectProperty		microbe	op
 METPO:2000054	has growth temperature observation	owl:ObjectProperty		microbe	growth temperature observation	has temperature observation		Relates a microbe to a growth temperature observation.		
 METPO:2000055	has range temperature observation	owl:ObjectProperty		microbe	temperature range observation	has temperature observation		Relates a microbe to a growth temperature range observation.		
 METPO:2000056	has temperature delta observation	owl:ObjectProperty		microbe	temperature delta observation	has temperature observation		Relates a microbe to a temperature tolerance breadth (delta) observation.		
-METPO:2000057	has culture temperature observation	owl:ObjectProperty		microbe	culture temperature observation	has temperature observation		Relates a microbe to a culture temperature observation (e.g., from BacDive).		
 METPO:2000058	has spot value	owl:DataProperty		observation	xsd:decimal	observation data property		A reported temperature value (°C) for this observation.		
 METPO:2000059	has minimum value	owl:DataProperty		observation	xsd:decimal	observation data property		The minimum temperature (°C) associated with this observation.		
 METPO:2000060	has maximum value	owl:DataProperty		observation	xsd:decimal	observation data property		The maximum temperature (°C) associated with this observation.		
@@ -89,55 +84,54 @@ METPO:2000062	is negative data	owl:DataProperty		observation	xsd:boolean	observa
 METPO:2000063	observation data property	owl:DataProperty								
 METPO:2000101	has quality	owl:ObjectProperty		microbe	quality					
 METPO:2000102	has phenotype	owl:ObjectProperty		microbe	phenotype	has quality	https://biolink.github.io/biolink-model/has_phenotype			
-METPO:2000103	capable of	owl:ObjectProperty		microbe	biological process		https://biolink.github.io/biolink-model/capable_of			
-METPO:2000200	disproportionates	owl:ObjectProperty	lost anabolizes synonym	microbe	chemical entity	organism interacts with chemical			oboInOwl:hasRelatedSynonym 'dismutates'	
-METPO:2000201	lyses	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000202	synthesizes	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical			oboInOwl:hasRelatedSynonym 'produces'	
-METPO:2000203	fixes	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000204	catabolizes	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000205	mineralizes	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000206	conjugates	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000207	transports	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
+METPO:2000103	capable of	owl:ObjectProperty		microbe	biological process		https://biolink.github.io/biolink-model/capable_of
+METPO:2000104	has observation	owl:ObjectProperty		microbe	observation
+METPO:2000200	disproportionates	owl:ObjectProperty	lost anabolizes synonym			organism interacts with chemical			oboInOwl:hasRelatedSynonym 'dismutates'
+METPO:2000201	lyses	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000202	synthesizes	owl:ObjectProperty				organism interacts with chemical			oboInOwl:hasRelatedSynonym 'produces'|oboInOwl:hasRelatedSynonym 'anabolizes'	
+METPO:2000203	fixes	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000204	catabolizes	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000205	mineralizes	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000206	conjugates	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000207	transports	owl:ObjectProperty				organism interacts with chemical				
 METPO:2000208	imports	owl:ObjectProperty		microbe	chemical entity	transports				
 METPO:2000209	exports	owl:ObjectProperty		microbe	chemical entity	transports				
-METPO:2000210	accumulates	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
+METPO:2000210	accumulates	owl:ObjectProperty				organism interacts with chemical				
 METPO:2000211	sequesters	owl:ObjectProperty		microbe	chemical entity	accumulates				
 METPO:2000212	compartmentalizes	owl:ObjectProperty		microbe	chemical entity	accumulates				
-METPO:2000213	binds	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000214	chelates	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000215	precipitates	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000216	solubilizes	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000217	volatilizes	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000218	crystallizes	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000219	adsorbs	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000220	does not disproportionate	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000221	does not lyse	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000222	does not produce	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000223	does not fix	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000224	does not catabolize	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000225	does not mineralize	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000226	does not conjugate	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000227	does not transport	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
+METPO:2000213	binds	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000214	chelates	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000215	precipitates	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000216	solubilizes	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000217	volatilizes	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000218	crystallizes	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000219	adsorbs	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000220	does not disproportionate	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000221	does not lyse	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000222	does not produce	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000223	does not fix	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000224	does not catabolize	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000225	does not mineralize	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000226	does not conjugate	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000227	does not transport	owl:ObjectProperty				organism interacts with chemical				
 METPO:2000228	does not import	owl:ObjectProperty		microbe	chemical entity	does not transport				
 METPO:2000229	does not export	owl:ObjectProperty		microbe	chemical entity	does not transport				
-METPO:2000230	does not accumulate	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
+METPO:2000230	does not accumulate	owl:ObjectProperty				organism interacts with chemical				
 METPO:2000231	does not sequester	owl:ObjectProperty		microbe	chemical entity	does not accumulate				
 METPO:2000232	does not compartmentalize	owl:ObjectProperty		microbe	chemical entity	does not accumulate				
-METPO:2000233	does not bind	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000234	does not chelate	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000235	does not precipitate	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000236	does not solubilize	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000237	does not volatilize	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000238	does not crystallize	owl:ObjectProperty		microbe	chemical entity	organism interacts with chemical				
-METPO:2000239	has pH observation	owl:ObjectProperty		microbe	observation	organism interacts with chemical		Relates a microbe to a pH observation.		
-METPO:2000501	has optimum pH observation	owl:ObjectProperty		microbe	optimum pH observation	has pH observation		Relates a microbe to an optimum pH observation.		
-METPO:2000502	has growth pH observation	owl:ObjectProperty		microbe	growth pH observation	has pH observation		Relates a microbe to a growth pH observation.		
-METPO:2000503	has range pH observation	owl:ObjectProperty		microbe	pH range observation	has pH observation		Relates a microbe to a growth pH range observation.		
-METPO:2000504	has pH delta observation	owl:ObjectProperty		microbe	pH delta observation	has pH observation		Relates a microbe to a pH tolerance breadth (delta) observation.		
-METPO:2000505	has culture pH observation	owl:ObjectProperty		microbe	culture pH observation	has pH observation		Relates a microbe to a culture pH observation (e.g., from BacDive).		
-METPO:2000506	has NaCl observation	owl:ObjectProperty		microbe	observation	has NaCl observation		Relates a microbe to a NaCl observation.		
-METPO:2000507	has optimum NaCl observation	owl:ObjectProperty		microbe	optimum NaCl observation	has NaCl observation		Relates a microbe to an optimum NaCl observation.		
-METPO:2000508	has growth NaCl observation	owl:ObjectProperty		microbe	growth NaCl observation	has NaCl observation		Relates a microbe to a growth NaCl observation.		
-METPO:2000509	has range NaCl observation	owl:ObjectProperty		microbe	NaCl range observation	has NaCl observation		Relates a microbe to a growth NaCl range observation.		
-METPO:2000510	has NaCl delta observation	owl:ObjectProperty		microbe	NaCl delta observation	has NaCl observation		Relates a microbe to a NaCl tolerance breadth (delta) observation.		
-METPO:2000511	has culture NaCl observation	owl:ObjectProperty		microbe	culture NaCl observation	has NaCl observation		Relates a microbe to a culture NaCl observation (e.g., from BacDive).		
+METPO:2000233	does not bind	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000234	does not chelate	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000235	does not precipitate	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000236	does not solubilize	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000237	does not volatilize	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000238	does not crystallize	owl:ObjectProperty				organism interacts with chemical				
+METPO:2000239	has pH observation	owl:ObjectProperty		microbe	observation	METPO:2000104		Relates a microbe to a pH observation.
+METPO:2000501	has optimum pH observation	owl:ObjectProperty		microbe	optimum pH observation	METPO:2000239		Relates a microbe to an optimum pH observation.
+METPO:2000502	has growth pH observation	owl:ObjectProperty		microbe	growth pH observation	METPO:2000239		Relates a microbe to a growth pH observation.
+METPO:2000503	has range pH observation	owl:ObjectProperty		microbe	pH range observation	METPO:2000239		Relates a microbe to a growth pH range observation.
+METPO:2000504	has pH delta observation	owl:ObjectProperty		microbe	pH delta observation	METPO:2000239		Relates a microbe to a pH tolerance breadth (delta) observation.
+METPO:2000506	has NaCl observation	owl:ObjectProperty		microbe	observation	METPO:2000104		Relates a microbe to a NaCl observation.
+METPO:2000507	has optimum NaCl observation	owl:ObjectProperty		microbe	optimum NaCl observation	METPO:2000506		Relates a microbe to an optimum NaCl observation.
+METPO:2000508	has growth NaCl observation	owl:ObjectProperty		microbe	growth NaCl observation	METPO:2000506		Relates a microbe to a growth NaCl observation.
+METPO:2000509	has range NaCl observation	owl:ObjectProperty		microbe	NaCl range observation	METPO:2000506		Relates a microbe to a growth NaCl range observation.
+METPO:2000510	has NaCl delta observation	owl:ObjectProperty		microbe	NaCl delta observation	METPO:2000506		Relates a microbe to a NaCl tolerance breadth (delta) observation.

--- a/src/templates/metpo_sheet.tsv
+++ b/src/templates/metpo_sheet.tsv
@@ -195,13 +195,10 @@ METPO:1001001	optimum temperature observation	owl:Class	observation	An observati
 METPO:1001002	growth temperature observation	owl:Class	observation	An observation specializing temperature observation for general growth temperature data.											
 METPO:1001003	temperature range observation	owl:Class	observation	An observation specializing temperature observation for growth temperature range data.											
 METPO:1001004	temperature delta observation	owl:Class	observation	An observation specializing temperature observation for tolerance breadth (delta) data.											
-METPO:1001005	culture temperature observation	owl:Class	observation	An observation specializing temperature observation for culture temperature data (e.g., reported culture conditions).											
-METPO:1001006	culture NaCl observation	owl:Class	observation												
 METPO:1001007	growth NaCl observation	owl:Class	observation												
 METPO:1001008	NaCl delta observation	owl:Class	observation												
 METPO:1001009	NaCl range observation	owl:Class	observation												
 METPO:1001010	optimum NaCl observation	owl:Class	observation												
-METPO:1001011	culture pH observation	owl:Class	observation												
 METPO:1001012	growth pH observation	owl:Class	observation												
 METPO:1001013	optimum pH observation	owl:Class	observation												
 METPO:1001014	pH delta observation	owl:Class	observation												

--- a/uv.lock
+++ b/uv.lock
@@ -1858,6 +1858,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "pymongo" },
     { name = "pyyaml" },
 ]
 
@@ -1880,6 +1881,7 @@ requires-dist = [
     { name = "ontogpt", marker = "extra == 'dev'", specifier = "==1.0.16" },
     { name = "openai", marker = "extra == 'dev'", specifier = ">=1.95,<1.100" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.3.1" },
+    { name = "pymongo", specifier = ">=4.15.2" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rdflib", marker = "extra == 'dev'", specifier = ">=7.1.4" },
     { name = "semsql", marker = "extra == 'dev'", specifier = ">=0.4.0" },
@@ -2869,6 +2871,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/61/e001a4b679a171f84783deb8e215a91c9f614cb498807e24e4f73ea4e5ed/PyJSG-0.11.10.tar.gz", hash = "sha256:4bd6e3ff2833fa2b395bbe803a2d72a5f0bab5b7285bccd0da1a1bc0aee88bfa", size = 130742 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/ee/370c3b1908327dac967841ff723db391a02f3637c95c6898160e5ffe1060/PyJSG-0.11.10-py3-none-any.whl", hash = "sha256:10af60ff42219be7e85bf7f11c19b648715b0b29eb2ddbd269e87069a7c3f26d", size = 80763 },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/cf/587d7b0737c93ff1b2d777227e25777d8811bc694ca52046c1ae13f68070/pymongo-4.15.2.tar.gz", hash = "sha256:45103766c3f1bf1f5fc2da43a48dbe03a343389a334eb1d02ef39024957cdc91", size = 2470598 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/76/bc85dfe94df5d18fe700fe940237b8e99293a962f70ae81defd3b9e3725d/pymongo-4.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:69515e1042a2fb4fadf6384918be34703aa2c792b9a8d3d406ad43e07cb095a2", size = 865405 },
+    { url = "https://files.pythonhosted.org/packages/fd/4e/45450af2eb5d8d19d53b6c8c6cc9325f5dcf9bb3da446472416686dd52e9/pymongo-4.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:587202db4a64d5c091bc39695095af461a6a08b2a52ddd881a6e5cb34244d672", size = 865699 },
+    { url = "https://files.pythonhosted.org/packages/ad/7a/de35dabd764933195b8c9288d733af462735cf8d90f66c1a689cb15570e9/pymongo-4.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:05b9eab3bc049f8fd150869375eff3a85ceab606531b6226b60f054daf7d1368", size = 1426367 },
+    { url = "https://files.pythonhosted.org/packages/ba/ec/dc22e2f3c60a2680ff69399bbf9c30f9ea938933dd856a33b6c6b285a7e1/pymongo-4.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f736f1a6d85f3b1c182018ae0e6c387bb342935e3b97637c258b9b46e0509af2", size = 1453585 },
+    { url = "https://files.pythonhosted.org/packages/26/d4/e34e56005e761c8c101f4b9e7b0e58842e631ea2bfa245e15d17e50ba2e5/pymongo-4.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:22ad78ac0222b8c5f5a28cdf6300cf19481fff193110506768c9915c8cd3396b", size = 1511454 },
+    { url = "https://files.pythonhosted.org/packages/84/b6/9fbba5670464a4e3969dc66c60ab24b5083292888b22d3b0b09c2746e609/pymongo-4.15.2-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:75f6f8363a57ba8a6bb1076114dc9aa29336f525c8b621cc1e4cfccae4ff546a", size = 1497423 },
+    { url = "https://files.pythonhosted.org/packages/a8/cd/0da070d21201bb633327172932e5346b86349aea8d7d05b4a195087f9c81/pymongo-4.15.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:597dce90bc607b3180735a6692abcf75c111d7f6169b2b1cca1db85086ee980c", size = 1448959 },
+    { url = "https://files.pythonhosted.org/packages/d7/37/c7d4f6191b28f8e00e7c0ad81ef5be80b073b3adbbaeb470168359763cc0/pymongo-4.15.2-cp311-cp311-win32.whl", hash = "sha256:a15ad3f11556a30e5dd86344567e85eb46550b09e0ea8d3297476788f0c76d77", size = 844325 },
+    { url = "https://files.pythonhosted.org/packages/2d/13/b5b8fce3e38980ae63b9f01be11a258544d54e7d1946330098c2faa255a4/pymongo-4.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:cedfd1be19c8f7b41a1f5fbaea299303087b5d40605e956ffbcfe2adc76de0ec", size = 858944 },
+    { url = "https://files.pythonhosted.org/packages/0b/97/7802ad208936929d4a784483a150c73d75f86c18af94c755882ce2115ab8/pymongo-4.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:a98f67df7aae325c0476aa453877475f9a1160f84b7e6e24e4804498ef99178e", size = 848296 },
+    { url = "https://files.pythonhosted.org/packages/e7/8f/61c7abf92da7ab2d65a355754ab38c90587c2d49a8f5418d1b62efda2b1f/pymongo-4.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d54b8139979e6e2ee6fec91b189e948ee2d83f125957793cf191c5e33be567e7", size = 920263 },
+    { url = "https://files.pythonhosted.org/packages/1c/8f/72061803dd878dfb53e3c5f049f757dd955a9f05ac706e6ab6cf92b96443/pymongo-4.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1db14e952ceb574cb8acacf063040e2a6e9570bd50671fa903fb47adb7cf49cc", size = 919960 },
+    { url = "https://files.pythonhosted.org/packages/6a/85/06837bca59751e1ff477f68df747b840e0880cf609aa0c9b3515c78b05e5/pymongo-4.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a33e118e14bd350bef6127a000c8d08e6bade8b9045bcd70d09a665434035705", size = 1685317 },
+    { url = "https://files.pythonhosted.org/packages/8a/ec/cb853f70e20537d52c0abbd303ed06c2609d883fdb38550f2a974d4e938a/pymongo-4.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fad596a092ab9cd821c98d75b48dd6a9c3fc52df8b1453d2f10d8219676269a", size = 1721445 },
+    { url = "https://files.pythonhosted.org/packages/74/fa/c9ba34caf0f2ed6a3e19fa480407c1d6fc499c36a10bb78434cfbf724f1a/pymongo-4.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2daa9434828a5e5638b9d78f0031c9e19b5bc84ce9f5e69cf6083f58aa3e3901", size = 1795356 },
+    { url = "https://files.pythonhosted.org/packages/96/2f/6f9eba4c864718ee77ce263d8d0533f5b10d890856c689e72dbbee4f102f/pymongo-4.15.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a244e27c034707f48f979fdcebe0df47ea000fd52ee1b2b2d2d2cb5b7b0e24dd", size = 1780463 },
+    { url = "https://files.pythonhosted.org/packages/49/9e/603cfbc874471bbf9cb5741cc9eaecf6a1dce98302094042b08008f94c50/pymongo-4.15.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de0c88d7229a96a5bfe2827170578bcd871ee16843c47e5cb3290edf1aaf62ca", size = 1713706 },
+    { url = "https://files.pythonhosted.org/packages/8e/b0/1872a972e0b11131a199fa270f5ccfa772de6da8fee7230395e30380b6ed/pymongo-4.15.2-cp312-cp312-win32.whl", hash = "sha256:dece75a28450fa813040b13f7fbe80a614d02e04f7ff84255a2600c440bf227a", size = 891169 },
+    { url = "https://files.pythonhosted.org/packages/85/9a/46e1ac4cb226efba9571206552eff6ceb91ea430f102df8e47b66c0f4e81/pymongo-4.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:9fa833908d94b5869e6c9a53b778dc8235caca6fcda03aac8410b8f067cd8a6f", size = 910613 },
+    { url = "https://files.pythonhosted.org/packages/29/14/9040761be52fe1fa63494024ab54e5257dc5791b5305464be12e4b301341/pymongo-4.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:3ab5ba56b868c56a38cfeb3202ee78dcdd4152bc364d24b71aaf1ee3994c7f96", size = 896236 },
+    { url = "https://files.pythonhosted.org/packages/21/cb/d3db977a546349637bea3abf442924ca2f6ebdf4863fa40fe95e90337ca5/pymongo-4.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bf646006bfce5e153cc838adaee319ff8a3d625978d491208cc290e89f9c2a21", size = 974494 },
+    { url = "https://files.pythonhosted.org/packages/26/d9/b13fda53e8c4552dc90fe22ca196e5089a3c6c9c65072d09ec25812691e6/pymongo-4.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b5fe426128a03393d2e7f10169e1f10cf6a6355f40876f52b51a03721c12e6e5", size = 974197 },
+    { url = "https://files.pythonhosted.org/packages/1e/2e/534b52a064c1e417b9514008e056d6a70b7b1124ed14f4a7069d83bdadb1/pymongo-4.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eb1423432631994d965e92ee63e448627d57793fd780c56c49570f12d4be1ff4", size = 1944230 },
+    { url = "https://files.pythonhosted.org/packages/6c/b3/e56b7c19d2510438d667be3735dfd83ee1b2597edd572b29891662562053/pymongo-4.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a994b40542ba44748af9e382fd54e69428f40c1728ae06bc649c87a1135d1cfb", size = 1989108 },
+    { url = "https://files.pythonhosted.org/packages/11/1d/a6bbcae660bcd03f65610e320ef1d151875c6eef3e272d8ceb115e66e8b7/pymongo-4.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:18bc73e47d21cabfde719d0cc5aa6b556856993397c9433d934089c86732e3d3", size = 2079206 },
+    { url = "https://files.pythonhosted.org/packages/37/71/ff04c18ea7a54bb2f3b84563ad4169599ebeff57a87017c176f570a24134/pymongo-4.15.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2968cf01e2257f2f5193aba259116c1e9e56f739a16eceef36e85a55edc91604", size = 2063351 },
+    { url = "https://files.pythonhosted.org/packages/bb/ad/97cd74eb4a230829aefb3aec17cdad563d130cf41891a37791c0f0e30ccb/pymongo-4.15.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3fafe5ef96943ab9b837f89b6abe779951102bee44d21c743259d43cfc1d9f6e", size = 1978665 },
+    { url = "https://files.pythonhosted.org/packages/cf/a8/3569abe29d2cdf355d51c1868bc5e1619a4b3f93b1e44a093958dd319fef/pymongo-4.15.2-cp313-cp313-win32.whl", hash = "sha256:a42ad84dfab44218f264e2d68b79e0e684c03c66fe8180a7961d6eb670eec4a3", size = 937993 },
+    { url = "https://files.pythonhosted.org/packages/46/72/6227a40c9872592118937b561e932886c38e220156a9747f2025b9e479ac/pymongo-4.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:5fa558bc6320e1183965db06e069973c9642b971a37729a8ae23c37f1c13ce21", size = 962225 },
+    { url = "https://files.pythonhosted.org/packages/2f/cd/396a1a03cc3c99e327aea23ab3e0dde5e069f4d9279dc26c80604b2783c7/pymongo-4.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:38785ba507a019edb742e333c6bf2fa3644043f1ce79ef4d20a4f7bb2180ee74", size = 944144 },
+    { url = "https://files.pythonhosted.org/packages/e5/b8/9f58b93d4b5be4f65dd2744ee0a28aa40df79eaeee01bb0e49e5ecc95ad0/pymongo-4.15.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3dc0ec9d78d4f28a24bd965e06c0a77459086522005aa199a8e4fc652ed1ce8e", size = 1028826 },
+    { url = "https://files.pythonhosted.org/packages/04/59/098321efdbdf2cceeced41404f4debc77283bc5318052cb033395d868e70/pymongo-4.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f9d3bbb4741a6ab81dbcd73b0754725f304b118c4c738449639fd060ee8b5da9", size = 1028486 },
+    { url = "https://files.pythonhosted.org/packages/c1/30/51d5269b70c86a981799ddbc5318ef73d954f262944520a24a821a19e0dc/pymongo-4.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:21b1d1d33bdbc87c1a082b747aa9ab40a30638c4e58e799d8fe9f5cb15feb38f", size = 2203353 },
+    { url = "https://files.pythonhosted.org/packages/41/6e/3f0e258789aebe8b472d22e47c5f0ac8231a3e78042b1682208afcbf935a/pymongo-4.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddf9face1dadf4cce4578dda29547ca2af6df09d44e7dd1bd6fe185f7c18dfc9", size = 2256978 },
+    { url = "https://files.pythonhosted.org/packages/b1/d9/4f1ce4c98be23ec9da3845236c25343dc7d54df43249298e329428a446d7/pymongo-4.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a4a0d3cf68f9bf84a7ee737ba0b29265cfeeaf586a856c6d7773491c545e5230", size = 2362327 },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/1eb05f84a89c776d591c30d82d361b37afe8d5191223b6b2130e789a534c/pymongo-4.15.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7089a1f2d5883f5137f1c2766691db904741985bb7e7a400ed50c3b370507b17", size = 2343088 },
+    { url = "https://files.pythonhosted.org/packages/9a/64/90ed1f6c965c1cc5fb127995f3af3c5f25aedc12e5cbb7dba8ac9434de33/pymongo-4.15.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05e96219d1acca15643042478103241771e46a3f5331bae3e19d2ea2756968b1", size = 2243085 },
+    { url = "https://files.pythonhosted.org/packages/84/a4/830b6b389c12d34b03ad9f45d0016626c90de05196ddb2f9bf05acaf20d1/pymongo-4.15.2-cp314-cp314-win32.whl", hash = "sha256:780447f9112f0e57d821ced8d593657b45616f3821becb0740e6c0fc38b0e91e", size = 992749 },
+    { url = "https://files.pythonhosted.org/packages/6f/36/9c283623d4c224d33f9e364bbdc0f0745ac5d22ff73b4a41b8724e7dd464/pymongo-4.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:d9410537204bb9e83f1c5e43f6e5df2c0d3fe092dbd8d30bd883736818a6d786", size = 1020795 },
+    { url = "https://files.pythonhosted.org/packages/3f/b2/208e58188cc84217dfefebdcfc3955f55c019df0ccb917f08497ab6fb1d8/pymongo-4.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:29645a9a8166f20b3fc6aa05095af6caf8ee9af9a4cf23cd857576084e29cc9c", size = 1000362 },
+    { url = "https://files.pythonhosted.org/packages/91/79/e55708e705ac9f25489894f70740c8c60afb050a30bbe7009861bc9919b7/pymongo-4.15.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:76c1c013bc577c7fb2c9a69d52ee335672eac1bdbfb9c37a432bb155bc69ffdc", size = 1085288 },
+    { url = "https://files.pythonhosted.org/packages/d0/8b/d7da6fb14f69c0fa510651889ed6870e9c5e287ad028c97e26d4bd2cf226/pymongo-4.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466840413fbd23605e9f95b702374b061525e85ea7f47dca6a88981455490ec", size = 1085297 },
+    { url = "https://files.pythonhosted.org/packages/2d/be/5c112313539d26166e914d719346172086a2df750ae9a2423107397804b6/pymongo-4.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f03716cfd4c86e3a8537ab8e1169cec26d532cc70fcd02e30027820ac587d28b", size = 2520808 },
+    { url = "https://files.pythonhosted.org/packages/ff/04/d00a2cbf3a96da878d4d3eb459fd87bbf8b49b40c2f46b6acdb38afee81d/pymongo-4.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5bfbde2ccc88b96d56cdc6bd104b856d9b039aa209b491311f8012e611d9f58", size = 2593741 },
+    { url = "https://files.pythonhosted.org/packages/d9/f6/467a9f0fd5d7b838c58ab01b4dd1ebad3933d4323a659b19ebe4a1b435a5/pymongo-4.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0ad7ec297e8999b0f984c998e2c1c605f11e9b8c7682256bbbc53c24a195f76e", size = 2713498 },
+    { url = "https://files.pythonhosted.org/packages/39/0e/b306750b01cf87b50b6ffd28734056d93e0b973f66092d681c079739fcea/pymongo-4.15.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:338b29d89f92c665a1038d53c7cc68869e2a04e171dd4fb2d416d7ad263dc50a", size = 2693584 },
+    { url = "https://files.pythonhosted.org/packages/04/bb/6fa3620dcf3ce11ed9bff111db8007d153f916c4df4272fdf4330a5094db/pymongo-4.15.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50325282876a263ece78371319e78518dd034e434c11e3ab12402547292b8fd5", size = 2571570 },
+    { url = "https://files.pythonhosted.org/packages/ec/d1/e7272f9e7b03c696661f15ba43b7475f2020edfac68cbed3eace8aa0f39a/pymongo-4.15.2-cp314-cp314t-win32.whl", hash = "sha256:c95a8d0ca11d16e325749fbd9f7d9aeb9a90241245e419007a941f446ff94dd6", size = 1043733 },
+    { url = "https://files.pythonhosted.org/packages/f4/53/e2406011e61826e4ea0e8da9da414b7f94bc7102368cf61e03c4de6dcd90/pymongo-4.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:1f2af4b98fc6d54489d187c0faa12bfbf0ef6c56c3e735eeb837ac8ff235b490", size = 1077981 },
+    { url = "https://files.pythonhosted.org/packages/19/99/f8fc04ae46fbf721b2935c59f3542810e72f50a4cb5b8aa092b6246a643f/pymongo-4.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:2c816a9e9d4aaaa0e4e9fb2534b72957666d262f3ce874a0408f8b925cfd4d99", size = 1050833 },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit implements a complete reconciliation pipeline to assess coverage of Madin bacteria/archaea traits data in the METPO ontology.

Key features:
- SPARQL query to extract all METPO synonyms with their source attributions
- Python script with multiple reconciliation modes (field names, field values, synonym verification, integrated report)
- Special handling for comma-separated pathways field
- YAML structured output for comprehensive analysis
- Makefile targets for automated report generation

The integrated report shows:
- Which Madin field names map to METPO classes/properties
- Value coverage percentage for each mapped field
- Individual pathway analysis (not just compound strings)
- High-value unmapped fields (2-20 unique values - good ontology candidates)
- Verification that METPO synonym attributions exist in source data

Current coverage: 8/35 field names mapped, 7/8 with 100% value coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)