### PR TITLE
feat(ontology): Add pigment classes and fix reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,13 +172,14 @@ create-bactotraits-files:
 SPREADSHEET_ID = 1_Lr-9_5QHi8QLvRyTZFSciUhzGKD4DbUObyTpJ16_RU
 BASE_URL = https://docs.google.com/spreadsheets/d/$(SPREADSHEET_ID)/export
 
-# All sheet gids discovered via Google Apps Script (9 total sheets)
+# All sheet gids discovered via Google Apps Script (10 total sheets)
 GID_MINIMAL_CLASSES = 355012485
 GID_PROPERTIES = 2094089867
 GID_BACTOTRAITS = 1192666692
 GID_MORE_SYNONYMS = 907926993
-GID_MORE_CLASSES = 1427185859
-GID_METABOLIC_AND_RESPIRATORY = 499077032
+GID_MORE_CLASSES___INCONSISTENT = 1427185859
+GID_METABOLIC_AND_RESPIRATORY_ROBOT = 2135183176
+GID_METABOLIC_AND_RESPIRATORY_LLM = 499077032
 GID_TROPHIC_MAPPING_BACDIVE__TBDELETED = 44169923
 GID_ATTIC_CLASSES = 1347388120
 GID_ATTIC_PROPERTIES = 565614186
@@ -186,8 +187,8 @@ GID_ATTIC_PROPERTIES = 565614186
 .PHONY: download-all-sheets clean-sheets
 
 # Download all discovered sheets to downloads/sheets/
-download-all-sheets: downloads/sheets/minimal_classes.tsv downloads/sheets/properties.tsv downloads/sheets/bactotraits.tsv downloads/sheets/more_synonyms.tsv downloads/sheets/more_classes.tsv downloads/sheets/metabolic_and_respiratory.tsv downloads/sheets/trophic_mapping_bacdive__tbdeleted.tsv downloads/sheets/attic_classes.tsv downloads/sheets/attic_properties.tsv
-	@echo "All 9 sheets downloaded to downloads/sheets/"
+download-all-sheets: downloads/sheets/minimal_classes.tsv downloads/sheets/properties.tsv downloads/sheets/bactotraits.tsv downloads/sheets/more_synonyms.tsv downloads/sheets/more_classes___inconsistent.tsv downloads/sheets/metabolic_and_respiratory_robot.tsv downloads/sheets/metabolic_and_respiratory_llm.tsv downloads/sheets/trophic_mapping_bacdive__tbdeleted.tsv downloads/sheets/attic_classes.tsv downloads/sheets/attic_properties.tsv
+	@echo "All 10 sheets downloaded to downloads/sheets/"
 
 # Individual sheet download targets
 downloads/sheets/minimal_classes.tsv: | downloads/sheets
@@ -202,11 +203,14 @@ downloads/sheets/bactotraits.tsv: | downloads/sheets
 downloads/sheets/more_synonyms.tsv: | downloads/sheets
 	curl -L -s '$(BASE_URL)?exportFormat=tsv&gid=$(GID_MORE_SYNONYMS)' > $@
 
-downloads/sheets/more_classes.tsv: | downloads/sheets
-	curl -L -s '$(BASE_URL)?exportFormat=tsv&gid=$(GID_MORE_CLASSES)' > $@
+downloads/sheets/more_classes___inconsistent.tsv: | downloads/sheets
+	curl -L -s '$(BASE_URL)?exportFormat=tsv&gid=$(GID_MORE_CLASSES___INCONSISTENT)' > $@
 
-downloads/sheets/metabolic_and_respiratory.tsv: | downloads/sheets
-	curl -L -s '$(BASE_URL)?exportFormat=tsv&gid=$(GID_METABOLIC_AND_RESPIRATORY)' > $@
+downloads/sheets/metabolic_and_respiratory_robot.tsv: | downloads/sheets
+	curl -L -s '$(BASE_URL)?exportFormat=tsv&gid=$(GID_METABOLIC_AND_RESPIRATORY_ROBOT)' > $@
+
+downloads/sheets/metabolic_and_respiratory_llm.tsv: | downloads/sheets
+	curl -L -s '$(BASE_URL)?exportFormat=tsv&gid=$(GID_METABOLIC_AND_RESPIRATORY_LLM)' > $@
 
 downloads/sheets/trophic_mapping_bacdive__tbdeleted.tsv: | downloads/sheets
 	curl -L -s '$(BASE_URL)?exportFormat=tsv&gid=$(GID_TROPHIC_MAPPING_BACDIVE__TBDELETED)' > $@

--- a/docs/ISSUE_python_quality_checks.md
+++ b/docs/ISSUE_python_quality_checks.md
@@ -1,0 +1,15 @@
+# CI: Implement Python code quality checks (ruff, mypy, pytest)
+
+### The Issue
+
+The repository currently has CI configured for ontology quality checks in `.github/workflows/qc.yml`, but there are no automated standards for the Python code itself.
+
+### Proposal
+
+To improve code quality, maintainability, and catch errors early, we should implement the following standard tools into the CI pipeline:
+
+- **`ruff`**: For fast linting and code formatting.
+- **`mypy`**: For static type checking.
+- **`pytest`**: For running a test suite.
+
+This would likely involve adding a new job to the `qc.yml` workflow that runs on pushes and pull requests, ensuring all Python code adheres to a consistent standard.

--- a/reports/bactotraits-metpo-reconciliation.yaml
+++ b/reports/bactotraits-metpo-reconciliation.yaml
@@ -2,13 +2,12 @@ field_name_reconciliation:
   summary:
     total_fields: 105
     total_trait_fields: 94
-    covered: 59
-    missing: 46
-    missing_traits: 36
-    coverage_percentage: 56.2
-    traits_coverage_percentage: 62.8
+    covered: 85
+    missing_traits: 9
+    traits_coverage_percentage: 90.4
   covered_fields:
   - field: 10_to_14
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000464
     label: pH range high
@@ -31,7 +30,8 @@ field_name_reconciliation:
     - value: '0.5'
       count: 20
   - field: GC_42_65_57_0
-    matched_as: GC_42.65.57.0
+    original_kgmicrobe_name: ' GC_42.65_57.0'
+    matched_as: null
     metpo_id: METPO:1000429
     label: GC low
     entity_type: owl:Class
@@ -45,7 +45,8 @@ field_name_reconciliation:
     - value: '1'
       count: 2620
   - field: GC_57_0_66_3
-    matched_as: GC_57.0_66.3
+    original_kgmicrobe_name: GC_57.0_66.3
+    matched_as: null
     metpo_id: METPO:1000431
     label: GC mid2
     entity_type: owl:Class
@@ -58,7 +59,38 @@ field_name_reconciliation:
       count: 7954
     - value: '1'
       count: 2320
+  - field: GC_gt_66_3
+    original_kgmicrobe_name: GC_>66.3
+    matched_as: GC_>66_3
+    metpo_id: METPO:1000430
+    label: GC mid1
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 9181
+    - value: '0'
+      count: 7831
+    - value: '1'
+      count: 2443
+  - field: GC_lte_42_65
+    original_kgmicrobe_name: GC_<=42.65
+    matched_as: null
+    metpo_id: METPO:1000432
+    label: GC high
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 9181
+    - value: '0'
+      count: 7383
+    - value: '1'
+      count: 2891
   - field: G_negative
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000699
     label: gram negative
@@ -75,6 +107,7 @@ field_name_reconciliation:
     - value: '0.5'
       count: 84
   - field: G_positive
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000698
     label: gram positive
@@ -91,6 +124,7 @@ field_name_reconciliation:
     - value: '0.5'
       count: 84
   - field: NaO_1_to_3
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000466
     label: NaCl optimum mid1
@@ -105,6 +139,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1213
   - field: NaO_3_to_8
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000467
     label: NaCl optimum mid2
@@ -118,7 +153,38 @@ field_name_reconciliation:
       count: 2345
     - value: '1'
       count: 673
+  - field: NaO_gt_8
+    original_kgmicrobe_name: NaO_>8
+    matched_as: null
+    metpo_id: METPO:1000468
+    label: NaCl optimum high
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 16437
+    - value: '0'
+      count: 2852
+    - value: '1'
+      count: 166
+  - field: NaO_lte_1
+    original_kgmicrobe_name: NaO_<=1
+    matched_as: null
+    metpo_id: METPO:1000465
+    label: NaCl optimum low
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 16437
+    - value: '0'
+      count: 2065
+    - value: '1'
+      count: 953
   - field: NaR_1_to_3
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000470
     label: NaCl range mid1
@@ -141,6 +207,7 @@ field_name_reconciliation:
     - value: '1'
       count: 11
   - field: NaR_3_to_8
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000471
     label: NaCl range mid2
@@ -160,7 +227,54 @@ field_name_reconciliation:
       count: 202
     - value: '0.5'
       count: 189
+  - field: NaR_gt_8
+    original_kgmicrobe_name: NaR_>8
+    matched_as: null
+    metpo_id: METPO:1000472
+    label: NaCl range high
+    entity_type: owl:Class
+    unique_values: 5
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 15021
+    - value: '0'
+      count: 3373
+    - value: '0.25'
+      count: 666
+    - value: '0.4'
+      count: 202
+    - value: '0.5'
+      count: 117
+    - value: '0.333333333333333'
+      count: 75
+    - value: '1'
+      count: 1
+  - field: NaR_lte_1
+    original_kgmicrobe_name: NaR_<=1
+    matched_as: null
+    metpo_id: METPO:1000469
+    label: NaCl range low
+    entity_type: owl:Class
+    unique_values: 5
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 15021
+    - value: '0.333333333333333'
+      count: 1584
+    - value: '0.5'
+      count: 1048
+    - value: '0.25'
+      count: 666
+    - value: '1'
+      count: 541
+    - value: '0'
+      count: 393
+    - value: '0.2'
+      count: 202
   - field: Nad_1_3
+    original_kgmicrobe_name: null
     matched_as: Nad_1.3
     metpo_id: METPO:1000480
     label: NaCl delta mid1
@@ -175,6 +289,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1173
   - field: Nad_3_8
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000481
     label: NaCl delta mid2
@@ -188,7 +303,38 @@ field_name_reconciliation:
       count: 2773
     - value: '1'
       count: 1658
+  - field: Nad_gt_8
+    original_kgmicrobe_name: Nad_>8
+    matched_as: null
+    metpo_id: METPO:1000482
+    label: NaCl delta high
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 15024
+    - value: '0'
+      count: 3421
+    - value: '1'
+      count: 1010
+  - field: Nad_lte_1
+    original_kgmicrobe_name: Nad_<=1
+    matched_as: null
+    metpo_id: METPO:1000479
+    label: NaCl delta low
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 15024
+    - value: '0'
+      count: 3841
+    - value: '1'
+      count: 590
   - field: Ox_aerobic
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000602
     label: aerobic
@@ -203,6 +349,7 @@ field_name_reconciliation:
     - value: ''
       count: 4157
   - field: Ox_anaerobic
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000603
     label: anaerobic
@@ -217,6 +364,7 @@ field_name_reconciliation:
     - value: '1'
       count: 3525
   - field: Ox_facultative_aerobe_anaerobe
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000612
     label: facultative oxygen preference
@@ -231,6 +379,7 @@ field_name_reconciliation:
     - value: '1'
       count: 600
   - field: Ox_microerophile
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000604
     label: microaerophilic
@@ -244,7 +393,186 @@ field_name_reconciliation:
       count: 4157
     - value: '1'
       count: 3586
+  - field: Pigment_black
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003022
+    label: black pigmented
+    entity_type: owl:Class
+    unique_values: 3
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 93
+    - value: '0.5'
+      count: 4
+    - value: '1'
+      count: 2
+    - value: '0.333'
+      count: 2
+  - field: Pigment_brown
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003023
+    label: brown pigmented
+    entity_type: owl:Class
+    unique_values: 2
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 82
+    - value: '0.5'
+      count: 10
+    - value: '1'
+      count: 9
+  - field: Pigment_carotenoid
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003031
+    label: carotenoid pigmentation
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 97
+    - value: '1'
+      count: 4
+  - field: Pigment_cream
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003024
+    label: cream pigmented
+    entity_type: owl:Class
+    unique_values: 2
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 90
+    - value: '1'
+      count: 6
+    - value: '0.5'
+      count: 5
+  - field: Pigment_green
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003025
+    label: green pigmented
+    entity_type: owl:Class
+    unique_values: 3
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 98
+    - value: '1'
+      count: 1
+    - value: '0.334'
+      count: 1
+    - value: '0.5'
+      count: 1
+  - field: Pigment_orange
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003026
+    label: orange pigmented
+    entity_type: owl:Class
+    unique_values: 2
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 83
+    - value: '1'
+      count: 10
+    - value: '0.5'
+      count: 8
+  - field: Pigment_pink
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003027
+    label: pink pigmented
+    entity_type: owl:Class
+    unique_values: 3
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 88
+    - value: '0.5'
+      count: 7
+    - value: '1'
+      count: 5
+    - value: '0.333'
+      count: 1
+  - field: Pigment_red
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003028
+    label: red pigmented
+    entity_type: owl:Class
+    unique_values: 2
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 91
+    - value: '0.5'
+      count: 6
+    - value: '1'
+      count: 4
+  - field: Pigment_white
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003029
+    label: white pigmented
+    entity_type: owl:Class
+    unique_values: 3
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 89
+    - value: '0.5'
+      count: 9
+    - value: '1'
+      count: 2
+    - value: '0.334'
+      count: 1
+  - field: Pigment_yellow
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1003030
+    label: yellow pigmented
+    entity_type: owl:Class
+    unique_values: 3
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 19354
+    - value: '0'
+      count: 62
+    - value: '1'
+      count: 24
+    - value: '0.5'
+      count: 14
+    - value: '0.333'
+      count: 1
   - field: S_curved_spiral
+    original_kgmicrobe_name: ' S_curved_spiral'
     matched_as: null
     metpo_id: METPO:1000670
     label: curved shaped
@@ -259,6 +587,7 @@ field_name_reconciliation:
     - value: '1'
       count: 92
   - field: S_filament
+    original_kgmicrobe_name: ' S_filament'
     matched_as: null
     metpo_id: METPO:1000674
     label: filament shaped
@@ -273,6 +602,7 @@ field_name_reconciliation:
     - value: '1'
       count: 30
   - field: S_ovoid
+    original_kgmicrobe_name: ' S_ovoid'
     matched_as: null
     metpo_id: METPO:1000677
     label: ovoid shaped
@@ -287,6 +617,7 @@ field_name_reconciliation:
     - value: '1'
       count: 253
   - field: S_rod
+    original_kgmicrobe_name: ' S_rod'
     matched_as: null
     metpo_id: METPO:1000681
     label: rod shaped
@@ -301,6 +632,7 @@ field_name_reconciliation:
     - value: '0'
       count: 896
   - field: S_sphere
+    original_kgmicrobe_name: ' S_sphere'
     matched_as: null
     metpo_id: METPO:1000683
     label: sphere shaped
@@ -315,6 +647,7 @@ field_name_reconciliation:
     - value: '1'
       count: 495
   - field: S_star_dumbbell_pleomorphic
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000672
     label: dumbbell shaped
@@ -329,6 +662,7 @@ field_name_reconciliation:
     - value: '1'
       count: 26
   - field: TO_10_to_22
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000442
     label: temperature optimum low
@@ -343,6 +677,7 @@ field_name_reconciliation:
     - value: '1'
       count: 302
   - field: TO_22_to_27
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000443
     label: temperature optimum mid1
@@ -357,6 +692,7 @@ field_name_reconciliation:
     - value: '1'
       count: 745
   - field: TO_27_to_30
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000444
     label: temperature optimum mid2
@@ -371,6 +707,7 @@ field_name_reconciliation:
     - value: '0'
       count: 2889
   - field: TO_30_to_34
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000445
     label: temperature optimum mid3
@@ -385,6 +722,7 @@ field_name_reconciliation:
     - value: '1'
       count: 584
   - field: TO_34_to_40
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000446
     label: temperature optimum mid4
@@ -398,7 +736,38 @@ field_name_reconciliation:
       count: 4932
     - value: '1'
       count: 890
+  - field: TO_gt_40
+    original_kgmicrobe_name: TO_>40
+    matched_as: null
+    metpo_id: METPO:1000447
+    label: temperature optimum high
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 13633
+    - value: '0'
+      count: 5485
+    - value: '1'
+      count: 337
+  - field: TO_lte_10
+    original_kgmicrobe_name: TO_<=10
+    matched_as: null
+    metpo_id: METPO:1000441
+    label: temperature optimum very low
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 13633
+    - value: '0'
+      count: 5791
+    - value: '1'
+      count: 31
   - field: TR_10_to_22
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000449
     label: temperature range low
@@ -425,6 +794,7 @@ field_name_reconciliation:
     - value: '1'
       count: 17
   - field: TR_22_to_27
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000450
     label: temperature range mid1
@@ -451,6 +821,7 @@ field_name_reconciliation:
     - value: '1'
       count: 6
   - field: TR_27_to_30
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000451
     label: temperature range mid2
@@ -477,6 +848,7 @@ field_name_reconciliation:
     - value: '1'
       count: 28
   - field: TR_30_to_34
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000452
     label: temperature range mid3
@@ -501,6 +873,7 @@ field_name_reconciliation:
     - value: '0.5'
       count: 31
   - field: TR_34_to_40
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000453
     label: temperature range mid4
@@ -526,7 +899,62 @@ field_name_reconciliation:
       count: 172
     - value: '1'
       count: 28
+  - field: TR_gt_40
+    original_kgmicrobe_name: TR_>40
+    matched_as: null
+    metpo_id: METPO:1000454
+    label: temperature range high
+    entity_type: owl:Class
+    unique_values: 7
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 13555
+    - value: '0'
+      count: 4201
+    - value: '0.1666667'
+      count: 565
+    - value: '0.1428571'
+      count: 508
+    - value: '0.2'
+      count: 174
+    - value: '0.25'
+      count: 158
+    - value: '0.5'
+      count: 149
+    - value: '1'
+      count: 136
+    - value: '0.3333333'
+      count: 9
+  - field: TR_lte_10
+    original_kgmicrobe_name: TR_<=10
+    matched_as: null
+    metpo_id: METPO:1000448
+    label: temperature range very low
+    entity_type: owl:Class
+    unique_values: 7
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 13555
+    - value: '0'
+      count: 3692
+    - value: '0.1666667'
+      count: 1114
+    - value: '0.1428571'
+      count: 508
+    - value: '0.25'
+      count: 303
+    - value: '0.2'
+      count: 157
+    - value: '0.3333333'
+      count: 83
+    - value: '0.5'
+      count: 40
+    - value: '1'
+      count: 3
   - field: TT_autotroph
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000632
     label: autotrophic
@@ -547,6 +975,7 @@ field_name_reconciliation:
     - value: '0.5'
       count: 2
   - field: TT_chemotroph
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000641
     label: chemotrophic
@@ -569,6 +998,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1
   - field: TT_heterotroph
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000644
     label: heterotrophic
@@ -591,6 +1021,7 @@ field_name_reconciliation:
     - value: '0.2'
       count: 2
   - field: TT_lithotroph
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000649
     label: lithotrophic
@@ -613,6 +1044,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1
   - field: TT_methylotroph
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000651
     label: methylotrophic
@@ -627,6 +1059,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1
   - field: TT_oligotroph
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000654
     label: oligotrophic
@@ -641,6 +1074,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1
   - field: TT_organotroph
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000655
     label: organotrophic
@@ -663,6 +1097,7 @@ field_name_reconciliation:
     - value: '0.2'
       count: 1
   - field: TT_phototroph
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000660
     label: phototrophic
@@ -685,7 +1120,8 @@ field_name_reconciliation:
     - value: '0.5'
       count: 1
   - field: Td_10_20
-    matched_as: Td_10.20
+    original_kgmicrobe_name: null
+    matched_as: null
     metpo_id: METPO:1000485
     label: temperature delta mid1
     entity_type: owl:Class
@@ -699,6 +1135,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1280
   - field: Td_1_5
+    original_kgmicrobe_name: null
     matched_as: Td_1.5
     metpo_id: METPO:1000483
     label: temperature delta very low
@@ -713,7 +1150,8 @@ field_name_reconciliation:
     - value: '1'
       count: 387
   - field: Td_20_30
-    matched_as: Td_20.30
+    original_kgmicrobe_name: null
+    matched_as: null
     metpo_id: METPO:1000486
     label: temperature delta mid2
     entity_type: owl:Class
@@ -727,6 +1165,7 @@ field_name_reconciliation:
     - value: '1'
       count: 2152
   - field: Td_5_10
+    original_kgmicrobe_name: null
     matched_as: Td_5.10
     metpo_id: METPO:1000484
     label: temperature delta low
@@ -740,7 +1179,23 @@ field_name_reconciliation:
       count: 5009
     - value: '1'
       count: 891
+  - field: Td_gt_30
+    original_kgmicrobe_name: Td_>30
+    matched_as: null
+    metpo_id: METPO:1000487
+    label: temperature delta high
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 13555
+    - value: '0'
+      count: 4710
+    - value: '1'
+      count: 1190
   - field: motile
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000702
     label: motile
@@ -754,10 +1209,26 @@ field_name_reconciliation:
       count: 2820
     - value: '1'
       count: 579
+  - field: no_spore
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1000872
+    label: non-spore forming
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 15425
+    - value: '1'
+      count: 2700
+    - value: '0'
+      count: 1330
   - field: non_motile
-    matched_as: motile
-    metpo_id: METPO:1000702
-    label: motile
+    original_kgmicrobe_name: non-motile
+    matched_as: null
+    metpo_id: METPO:1000703
+    label: non motile
     entity_type: owl:Class
     unique_values: 1
     matched_from_source: null
@@ -769,6 +1240,7 @@ field_name_reconciliation:
     - value: '0'
       count: 2339
   - field: pHO_0_to_6
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000455
     label: pH optimum low
@@ -783,6 +1255,7 @@ field_name_reconciliation:
     - value: '1'
       count: 294
   - field: pHO_6_to_7
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000456
     label: pH optimum mid1
@@ -797,6 +1270,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1928
   - field: pHO_7_to_8
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000457
     label: pH optimum mid2
@@ -811,6 +1285,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1706
   - field: pHO_8_to_14
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000458
     label: pH optimum high
@@ -825,6 +1300,7 @@ field_name_reconciliation:
     - value: '1'
       count: 367
   - field: pHR_0_to_4
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000459
     label: pH range very low
@@ -849,6 +1325,7 @@ field_name_reconciliation:
     - value: '1'
       count: 3
   - field: pHR_4_to_6
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000460
     label: pH range low
@@ -873,6 +1350,7 @@ field_name_reconciliation:
     - value: '1'
       count: 15
   - field: pHR_6_to_7
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000461
     label: pH range mid1
@@ -897,6 +1375,7 @@ field_name_reconciliation:
     - value: '1'
       count: 8
   - field: pHR_7_to_8
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000462
     label: pH range mid2
@@ -921,6 +1400,7 @@ field_name_reconciliation:
     - value: '1'
       count: 8
   - field: pHR_8_to_10
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000463
     label: pH range mid3
@@ -945,7 +1425,8 @@ field_name_reconciliation:
     - value: '1'
       count: 3
   - field: pHd_1_2
-    matched_as: null
+    original_kgmicrobe_name: null
+    matched_as: pHd_1.2
     metpo_id: METPO:1000474
     label: pH delta low
     entity_type: owl:Class
@@ -959,7 +1440,8 @@ field_name_reconciliation:
     - value: '1'
       count: 781
   - field: pHd_2_3
-    matched_as: pHd_2.3
+    original_kgmicrobe_name: null
+    matched_as: null
     metpo_id: METPO:1000475
     label: pH delta mid1
     entity_type: owl:Class
@@ -973,6 +1455,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1196
   - field: pHd_3_4
+    original_kgmicrobe_name: null
     matched_as: null
     metpo_id: METPO:1000476
     label: pH delta mid2
@@ -987,6 +1470,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1113
   - field: pHd_4_5
+    original_kgmicrobe_name: null
     matched_as: pHd_4.5
     metpo_id: METPO:1000477
     label: pH delta mid3
@@ -1001,7 +1485,8 @@ field_name_reconciliation:
     - value: '1'
       count: 619
   - field: pHd_5_9
-    matched_as: pHd_5.9
+    original_kgmicrobe_name: null
+    matched_as: null
     metpo_id: METPO:1000478
     label: pH delta high
     entity_type: owl:Class
@@ -1014,213 +1499,39 @@ field_name_reconciliation:
       count: 3933
     - value: '1'
       count: 326
+  - field: pHd_lte_1
+    original_kgmicrobe_name: pHd_<=1
+    matched_as: null
+    metpo_id: METPO:1000473
+    label: pH delta very low
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 15196
+    - value: '0'
+      count: 4035
+    - value: '1'
+      count: 224
+  - field: spore
+    original_kgmicrobe_name: null
+    matched_as: null
+    metpo_id: METPO:1000871
+    label: spore forming
+    entity_type: owl:Class
+    unique_values: 1
+    matched_from_source: null
+    value_distribution:
+    - value: ''
+      count: 15425
+    - value: '0'
+      count: 2700
+    - value: '1'
+      count: 1330
   missing_trait_fields:
-  - field: culture_collection_codes
-    unique_values: 19439
-  - field: TR_gt_40
-    unique_values: 7
-    value_distribution:
-    - value: ''
-      count: 13555
-    - value: '0'
-      count: 4201
-    - value: '0.1666667'
-      count: 565
-    - value: '0.1428571'
-      count: 508
-    - value: '0.2'
-      count: 174
-    - value: '0.25'
-      count: 158
-    - value: '0.5'
-      count: 149
-    - value: '1'
-      count: 136
-    - value: '0.3333333'
-      count: 9
-  - field: TR_lte_10
-    unique_values: 7
-    value_distribution:
-    - value: ''
-      count: 13555
-    - value: '0'
-      count: 3692
-    - value: '0.1666667'
-      count: 1114
-    - value: '0.1428571'
-      count: 508
-    - value: '0.25'
-      count: 303
-    - value: '0.2'
-      count: 157
-    - value: '0.3333333'
-      count: 83
-    - value: '0.5'
-      count: 40
-    - value: '1'
-      count: 3
-  - field: NaR_gt_8
-    unique_values: 5
-    value_distribution:
-    - value: ''
-      count: 15021
-    - value: '0'
-      count: 3373
-    - value: '0.25'
-      count: 666
-    - value: '0.4'
-      count: 202
-    - value: '0.5'
-      count: 117
-    - value: '0.333333333333333'
-      count: 75
-    - value: '1'
-      count: 1
-  - field: NaR_lte_1
-    unique_values: 5
-    value_distribution:
-    - value: ''
-      count: 15021
-    - value: '0.333333333333333'
-      count: 1584
-    - value: '0.5'
-      count: 1048
-    - value: '0.25'
-      count: 666
-    - value: '1'
-      count: 541
-    - value: '0'
-      count: 393
-    - value: '0.2'
-      count: 202
-  - field: Pigment_black
-    unique_values: 3
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 93
-    - value: '0.5'
-      count: 4
-    - value: '0.333'
-      count: 2
-    - value: '1'
-      count: 2
-  - field: Pigment_green
-    unique_values: 3
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 98
-    - value: '1'
-      count: 1
-    - value: '0.334'
-      count: 1
-    - value: '0.5'
-      count: 1
-  - field: Pigment_pink
-    unique_values: 3
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 88
-    - value: '0.5'
-      count: 7
-    - value: '1'
-      count: 5
-    - value: '0.333'
-      count: 1
-  - field: Pigment_white
-    unique_values: 3
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 89
-    - value: '0.5'
-      count: 9
-    - value: '1'
-      count: 2
-    - value: '0.334'
-      count: 1
-  - field: Pigment_yellow
-    unique_values: 3
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 62
-    - value: '1'
-      count: 24
-    - value: '0.5'
-      count: 14
-    - value: '0.333'
-      count: 1
-  - field: Pigment_brown
-    unique_values: 2
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 82
-    - value: '0.5'
-      count: 10
-    - value: '1'
-      count: 9
-  - field: Pigment_cream
-    unique_values: 2
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 90
-    - value: '1'
-      count: 6
-    - value: '0.5'
-      count: 5
-  - field: Pigment_orange
-    unique_values: 2
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 83
-    - value: '1'
-      count: 10
-    - value: '0.5'
-      count: 8
-  - field: Pigment_red
-    unique_values: 2
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 91
-    - value: '0.5'
-      count: 6
-    - value: '1'
-      count: 4
-  - field: GC_gt_66_3
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 9181
-    - value: '0'
-      count: 7831
-    - value: '1'
-      count: 2443
-  - field: GC_lte_42_65
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 9181
-    - value: '0'
-      count: 7383
-    - value: '1'
-      count: 2891
   - field: L_1_3_2
+    original_kgmicrobe_name: ' L_1.3_2'
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1230,6 +1541,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1317
   - field: L_2_3
+    original_kgmicrobe_name: null
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1239,6 +1551,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1017
   - field: L_gt_3
+    original_kgmicrobe_name: L_>3
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1248,6 +1561,7 @@ field_name_reconciliation:
     - value: '1'
       count: 989
   - field: L_lte_1_3
+    original_kgmicrobe_name: L_<=1.3
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1256,70 +1570,8 @@ field_name_reconciliation:
       count: 3323
     - value: '1'
       count: 1140
-  - field: NaO_gt_8
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 16437
-    - value: '0'
-      count: 2852
-    - value: '1'
-      count: 166
-  - field: NaO_lte_1
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 16437
-    - value: '0'
-      count: 2065
-    - value: '1'
-      count: 953
-  - field: Nad_gt_8
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 15024
-    - value: '0'
-      count: 3421
-    - value: '1'
-      count: 1010
-  - field: Nad_lte_1
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 15024
-    - value: '0'
-      count: 3841
-    - value: '1'
-      count: 590
-  - field: Pigment_carotenoid
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 19354
-    - value: '0'
-      count: 97
-    - value: '1'
-      count: 4
-  - field: TO_gt_40
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 13633
-    - value: '0'
-      count: 5485
-    - value: '1'
-      count: 337
-  - field: TO_lte_10
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 13633
-    - value: '0'
-      count: 5791
-    - value: '1'
-      count: 31
   - field: TT_copiotroph_diazotroph
+    original_kgmicrobe_name: null
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1328,16 +1580,8 @@ field_name_reconciliation:
       count: 337
     - value: '1'
       count: 2
-  - field: Td_gt_30
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 13555
-    - value: '0'
-      count: 4710
-    - value: '1'
-      count: 1190
   - field: W_0_5_0_65
+    original_kgmicrobe_name: ' W_0.5_0.65'
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1347,6 +1591,7 @@ field_name_reconciliation:
     - value: '1'
       count: 870
   - field: W_0_65_0_9
+    original_kgmicrobe_name: W_0.65_0.9
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1356,6 +1601,7 @@ field_name_reconciliation:
     - value: '1'
       count: 1132
   - field: W_gt_0_9
+    original_kgmicrobe_name: W_>0.9
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1365,6 +1611,7 @@ field_name_reconciliation:
     - value: '1'
       count: 826
   - field: W_lte_0_5
+    original_kgmicrobe_name: W_<=0.5
     unique_values: 1
     value_distribution:
     - value: ''
@@ -1373,81 +1620,42 @@ field_name_reconciliation:
       count: 2828
     - value: '1'
       count: 1633
-  - field: no_spore
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 15425
-    - value: '1'
-      count: 2700
-    - value: '0'
-      count: 1330
-  - field: pHd_lte_1
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 15196
-    - value: '0'
-      count: 4035
-    - value: '1'
-      count: 224
-  - field: spore
-    unique_values: 1
-    value_distribution:
-    - value: ''
-      count: 15425
-    - value: '0'
-      count: 2700
-    - value: '1'
-      count: 1330
-  missing_taxonomic_id_fields:
-  - field: Bacdive_ID
-    unique_values: 19455
+  missing_identifier_fields:
   - field: Full_name
+    original_kgmicrobe_name: null
     unique_values: 11355
   - field: ncbitaxon_id
+    original_kgmicrobe_name: null
     unique_values: 9933
+  permanently_excluded_fields:
+  - field: Bacdive_ID
+    original_kgmicrobe_name: null
+    unique_values: 19455
+  - field: culture_collection_codes
+    original_kgmicrobe_name: culture collection codes
+    unique_values: 19439
   - field: Species
+    original_kgmicrobe_name: null
     unique_values: 6525
   - field: Genus
+    original_kgmicrobe_name: null
     unique_values: 2394
   - field: Family
+    original_kgmicrobe_name: null
     unique_values: 708
   - field: Order
+    original_kgmicrobe_name: null
     unique_values: 471
   - field: Class
+    original_kgmicrobe_name: null
     unique_values: 363
   - field: Phylum
+    original_kgmicrobe_name: null
     unique_values: 323
   - field: Kingdom
+    original_kgmicrobe_name: null
     unique_values: 1
     value_distribution:
     - value: Bacteria
       count: 19455
-  high_value_missing_fields:
-  - field: TR_gt_40
-    unique_values: 7
-  - field: TR_lte_10
-    unique_values: 7
-  - field: NaR_gt_8
-    unique_values: 5
-  - field: NaR_lte_1
-    unique_values: 5
-  - field: Pigment_black
-    unique_values: 3
-  - field: Pigment_green
-    unique_values: 3
-  - field: Pigment_pink
-    unique_values: 3
-  - field: Pigment_white
-    unique_values: 3
-  - field: Pigment_yellow
-    unique_values: 3
-  - field: Pigment_brown
-    unique_values: 2
-  - field: Pigment_cream
-    unique_values: 2
-  - field: Pigment_orange
-    unique_values: 2
-  - field: Pigment_red
-    unique_values: 2
+  high_value_missing_fields: []

--- a/reports/bactotraits-metpo-set-diff.yaml
+++ b/reports/bactotraits-metpo-set-diff.yaml
@@ -1,10 +1,10 @@
 summary:
   kg_microbe_total_fields: 105
-  metpo_bactotraits_synonyms: 73
-  exact_matches: 73
-  bactotraits_not_in_metpo: 32
+  metpo_bactotraits_synonyms: 85
+  exact_matches: 85
+  bactotraits_not_in_metpo: 20
   bactotraits_with_close_matches: 0
-  bactotraits_truly_missing: 32
+  bactotraits_truly_missing: 20
   metpo_not_in_bactotraits: 0
   metpo_with_close_matches: 0
   metpo_truly_orphaned: 0
@@ -30,16 +30,6 @@ bactotraits_fields_not_in_metpo:
   - L_>3
   - Order
   - Phylum
-  - Pigment_black
-  - Pigment_brown
-  - Pigment_carotenoid
-  - Pigment_cream
-  - Pigment_green
-  - Pigment_orange
-  - Pigment_pink
-  - Pigment_red
-  - Pigment_white
-  - Pigment_yellow
   - Species
   - TT_copiotroph_diazotroph
   - W_0.65_0.9
@@ -47,8 +37,6 @@ bactotraits_fields_not_in_metpo:
   - W_>0.9
   - culture collection codes
   - ncbitaxon_id
-  - no_spore
-  - spore
 metpo_synonyms_not_in_bactotraits:
   close_matches_by_issue:
     case_differences: []
@@ -87,6 +75,16 @@ exact_matches:
 - Ox_anaerobic
 - Ox_facultative_aerobe_anaerobe
 - Ox_microerophile
+- Pigment_black
+- Pigment_brown
+- Pigment_carotenoid
+- Pigment_cream
+- Pigment_green
+- Pigment_orange
+- Pigment_pink
+- Pigment_red
+- Pigment_white
+- Pigment_yellow
 - S_star_dumbbell_pleomorphic
 - TO_10_to_22
 - TO_22_to_27
@@ -116,6 +114,7 @@ exact_matches:
 - Td_5_10
 - Td_>30
 - motile
+- no_spore
 - non-motile
 - pHO_0_to_6
 - pHO_6_to_7
@@ -132,3 +131,4 @@ exact_matches:
 - pHd_4_5
 - pHd_5_9
 - pHd_<=1
+- spore

--- a/reports/synonym-sources.tsv
+++ b/reports/synonym-sources.tsv
@@ -334,11 +334,23 @@
 <https://w3id.org/metpo/1000870>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"General.keywords"	""			<https://bacdive.dsmz.de/>	
 <https://w3id.org/metpo/1000870>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Physiology and metabolism.spore formation.spore formation"	""			<https://bacdive.dsmz.de/>	
 <https://w3id.org/metpo/1000870>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"sporulation"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000871>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"spore"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
 <https://w3id.org/metpo/1000871>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"yes"	""			<https://bacdive.dsmz.de/>	
 <https://w3id.org/metpo/1000871>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"yes"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
 <https://w3id.org/metpo/1000872>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"no"	""			<https://bacdive.dsmz.de/>	
 <https://w3id.org/metpo/1000872>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"no"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1000872>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"no_spore"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
 <https://w3id.org/metpo/1002005>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"fermentation"	""			<https://github.com/jmadin/bacteria_archaea_traits>	
+<https://w3id.org/metpo/1003022>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_black"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003023>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_brown"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003024>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_cream"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003025>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_green"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003026>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_orange"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003027>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_pink"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003028>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_red"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003029>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_white"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003030>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_yellow"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
+<https://w3id.org/metpo/1003031>	"class"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"Pigment_carotenoid"	""			<https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>	
 <https://w3id.org/metpo/1000059>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"phenotype"	""				
 <https://w3id.org/metpo/1000060>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"metabolism"	""				
 <https://w3id.org/metpo/1000127>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"GC content"	""				
@@ -568,6 +580,17 @@
 <https://w3id.org/metpo/1003007>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"facultatively acidophilic"	""				
 <https://w3id.org/metpo/1003008>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"acidotolerant"	""				
 <https://w3id.org/metpo/1003009>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"alkalotolerant"	""				
+<https://w3id.org/metpo/1003021>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pigmentation"	""				
+<https://w3id.org/metpo/1003022>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"black pigmented"	""				
+<https://w3id.org/metpo/1003023>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"brown pigmented"	""				
+<https://w3id.org/metpo/1003024>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"cream pigmented"	""				
+<https://w3id.org/metpo/1003025>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"green pigmented"	""				
+<https://w3id.org/metpo/1003026>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"orange pigmented"	""				
+<https://w3id.org/metpo/1003027>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"pink pigmented"	""				
+<https://w3id.org/metpo/1003028>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"red pigmented"	""				
+<https://w3id.org/metpo/1003029>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"white pigmented"	""				
+<https://w3id.org/metpo/1003030>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"yellow pigmented"	""				
+<https://w3id.org/metpo/1003031>	"class"	<http://www.w3.org/2000/01/rdf-schema#label>	"carotenoid pigmentation"	""				
 <https://w3id.org/metpo/2000002>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"assimilation"	""			<https://bacdive.dsmz.de/>	
 <https://w3id.org/metpo/2000003>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"builds acid from"	""			<https://bacdive.dsmz.de/>	
 <https://w3id.org/metpo/2000004>	"property"	<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>	"builds base from"	""			<https://bacdive.dsmz.de/>	

--- a/src/ontology/components/metpo-properties.owl
+++ b/src/ontology/components/metpo-properties.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<https://w3id.org/metpo/metpo/components/metpo-properties.owl>
-<https://w3id.org/metpo/metpo/releases/2025-10-14/components/metpo-properties.owl>
-Annotation(owl:versionInfo "2025-10-14")
+<https://w3id.org/metpo/metpo/releases/2025-10-15/components/metpo-properties.owl>
+Annotation(owl:versionInfo "2025-10-15")
 
 Declaration(Class(<https://w3id.org/metpo/1000059>))
 Declaration(Class(<https://w3id.org/metpo/1000188>))

--- a/src/ontology/components/metpo-synonyms.owl
+++ b/src/ontology/components/metpo-synonyms.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<https://w3id.org/metpo/metpo/components/metpo-synonyms.owl>
-<https://w3id.org/metpo/metpo/releases/2025-10-14/components/metpo-synonyms.owl>
-Annotation(owl:versionInfo "2025-10-14")
+<https://w3id.org/metpo/metpo/releases/2025-10-15/components/metpo-synonyms.owl>
+Annotation(owl:versionInfo "2025-10-15")
 
 
 

--- a/src/ontology/components/metpo_sheet.owl
+++ b/src/ontology/components/metpo_sheet.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<https://w3id.org/metpo/metpo/components/metpo_sheet.owl>
-<https://w3id.org/metpo/metpo/releases/2025-10-14/components/metpo_sheet.owl>
-Annotation(owl:versionInfo "2025-10-14")
+<https://w3id.org/metpo/metpo/releases/2025-10-15/components/metpo_sheet.owl>
+Annotation(owl:versionInfo "2025-10-15")
 
 Declaration(Class(<https://w3id.org/metpo/1000059>))
 Declaration(Class(<https://w3id.org/metpo/1000060>))
@@ -239,6 +239,17 @@ Declaration(Class(<https://w3id.org/metpo/1003006>))
 Declaration(Class(<https://w3id.org/metpo/1003007>))
 Declaration(Class(<https://w3id.org/metpo/1003008>))
 Declaration(Class(<https://w3id.org/metpo/1003009>))
+Declaration(Class(<https://w3id.org/metpo/1003021>))
+Declaration(Class(<https://w3id.org/metpo/1003022>))
+Declaration(Class(<https://w3id.org/metpo/1003023>))
+Declaration(Class(<https://w3id.org/metpo/1003024>))
+Declaration(Class(<https://w3id.org/metpo/1003025>))
+Declaration(Class(<https://w3id.org/metpo/1003026>))
+Declaration(Class(<https://w3id.org/metpo/1003027>))
+Declaration(Class(<https://w3id.org/metpo/1003028>))
+Declaration(Class(<https://w3id.org/metpo/1003029>))
+Declaration(Class(<https://w3id.org/metpo/1003030>))
+Declaration(Class(<https://w3id.org/metpo/1003031>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000115>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000119>))
 Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>))
@@ -1601,6 +1612,7 @@ SubClassOf(<https://w3id.org/metpo/1000870> <https://w3id.org/metpo/1000059>)
 
 # Class: <https://w3id.org/metpo/1000871> (spore forming)
 
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1000871> "spore")
 AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://bacdive.dsmz.de/>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1000871> "yes")
 AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://github.com/jmadin/bacteria_archaea_traits>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1000871> "yes")
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000871> "spore forming")
@@ -1610,6 +1622,7 @@ SubClassOf(<https://w3id.org/metpo/1000871> <https://w3id.org/metpo/1000870>)
 
 AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://bacdive.dsmz.de/>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1000872> "no")
 AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://github.com/jmadin/bacteria_archaea_traits>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1000872> "no")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1000872> "no_spore")
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000872> "non-spore forming")
 SubClassOf(<https://w3id.org/metpo/1000872> <https://w3id.org/metpo/1000870>)
 
@@ -1833,6 +1846,82 @@ SubClassOf(<https://w3id.org/metpo/1003008> <https://w3id.org/metpo/1003000>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <https://w3id.org/metpo/1003009> "alkalitolerant")
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003009> "alkalotolerant")
 SubClassOf(<https://w3id.org/metpo/1003009> <https://w3id.org/metpo/1003000>)
+
+# Class: <https://w3id.org/metpo/1003021> (pigmentation)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003021> "A phenotype characterized by the color of pigments produced by a microorganism.")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003021> "pigmentation")
+SubClassOf(<https://w3id.org/metpo/1003021> <https://w3id.org/metpo/1000059>)
+
+# Class: <https://w3id.org/metpo/1003022> (black pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003022> "A phenotype characterized by the production of black-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003022> "Pigment_black")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003022> "black pigmented")
+SubClassOf(<https://w3id.org/metpo/1003022> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003023> (brown pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003023> "A phenotype characterized by the production of brown-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003023> "Pigment_brown")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003023> "brown pigmented")
+SubClassOf(<https://w3id.org/metpo/1003023> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003024> (cream pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003024> "A phenotype characterized by the production of cream-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003024> "Pigment_cream")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003024> "cream pigmented")
+SubClassOf(<https://w3id.org/metpo/1003024> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003025> (green pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003025> "A phenotype characterized by the production of green-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003025> "Pigment_green")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003025> "green pigmented")
+SubClassOf(<https://w3id.org/metpo/1003025> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003026> (orange pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003026> "A phenotype characterized by the production of orange-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003026> "Pigment_orange")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003026> "orange pigmented")
+SubClassOf(<https://w3id.org/metpo/1003026> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003027> (pink pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003027> "A phenotype characterized by the production of pink-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003027> "Pigment_pink")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003027> "pink pigmented")
+SubClassOf(<https://w3id.org/metpo/1003027> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003028> (red pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003028> "A phenotype characterized by the production of red-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003028> "Pigment_red")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003028> "red pigmented")
+SubClassOf(<https://w3id.org/metpo/1003028> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003029> (white pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003029> "A phenotype characterized by the production of white-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003029> "Pigment_white")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003029> "white pigmented")
+SubClassOf(<https://w3id.org/metpo/1003029> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003030> (yellow pigmented)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003030> "A phenotype characterized by the production of yellow-colored pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003030> "Pigment_yellow")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003030> "yellow pigmented")
+SubClassOf(<https://w3id.org/metpo/1003030> <https://w3id.org/metpo/1003021>)
+
+# Class: <https://w3id.org/metpo/1003031> (carotenoid pigmentation)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://w3id.org/metpo/1003031> "A phenotype characterized by the production of carotenoid pigments.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> <https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv>) <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <https://w3id.org/metpo/1003031> "Pigment_carotenoid")
+AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1003031> "carotenoid pigmentation")
+SubClassOf(<https://w3id.org/metpo/1003031> <https://w3id.org/metpo/1003021>)
 
 
 )

--- a/src/templates/metpo_sheet.tsv
+++ b/src/templates/metpo_sheet.tsv
@@ -109,7 +109,7 @@ METPO:1000623	moderately halophilic	owl:Class	halophily preference							moderat
 METPO:1000666	cell shape	owl:Class	phenotype							cell_shape	https://github.com/jmadin/bacteria_archaea_traits	Morphology.cell morphology.cell shape|General.keywords	https://bacdive.dsmz.de/		
 METPO:1000697	gram stain	owl:Class	phenotype							gram_stain	https://github.com/jmadin/bacteria_archaea_traits	Morphology.cell morphology.gram stain|General.keywords	https://bacdive.dsmz.de/		
 METPO:1000701	motility	owl:Class	phenotype							motility	https://github.com/jmadin/bacteria_archaea_traits	Morphology.cell morphology.motility|General.keywords	https://bacdive.dsmz.de/		
-METPO:1000872	non-spore forming	owl:Class	sporulation							no	https://github.com/jmadin/bacteria_archaea_traits	no	https://bacdive.dsmz.de/		
+METPO:1000872	non-spore forming	owl:Class	sporulation							no	https://github.com/jmadin/bacteria_archaea_traits	no	https://bacdive.dsmz.de/	no_spore	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
 METPO:1000624	non halophilic	owl:Class	halophily preference							non-halophilic	https://github.com/jmadin/bacteria_archaea_traits	non-halophilic	https://bacdive.dsmz.de/		
 METPO:1000606	obligately aerobic	owl:Class	oxygen preference	A microbial oxygen preference phenotype that requires molecular oxygen (O₂) for growth.						obligate aerobic	https://github.com/jmadin/bacteria_archaea_traits	obligate aerobe	https://bacdive.dsmz.de/		
 METPO:1000607	obligately anaerobic	owl:Class	oxygen preference	A microbial oxygen preference phenotype in which molecular oxygen (O₂) inhibits or prevents growth.						obligate anaerobic	https://github.com/jmadin/bacteria_archaea_traits	obligate anaerobe	https://bacdive.dsmz.de/		
@@ -132,7 +132,7 @@ METPO:1000682	spore shaped	owl:Class	cell shape									spore-shaped	https://bac
 METPO:1000616	thermophilic	owl:Class	temperature preference	A temperature preference phenotype in which growth is favored at elevated temperatures, typically ≥45 °C.						thermophilic	https://github.com/jmadin/bacteria_archaea_traits	thermophilic	https://bacdive.dsmz.de/		
 METPO:1000700	gram variable	owl:Class	gram stain								https://github.com/jmadin/bacteria_archaea_traits	variable	https://bacdive.dsmz.de/		
 METPO:1000686	vibrio shaped	owl:Class	cell shape							vibrio	https://github.com/jmadin/bacteria_archaea_traits	vibrio-shaped	https://bacdive.dsmz.de/		
-METPO:1000871	spore forming	owl:Class	sporulation							yes	https://github.com/jmadin/bacteria_archaea_traits	yes	https://bacdive.dsmz.de/		
+METPO:1000871	spore forming	owl:Class	sporulation							yes	https://github.com/jmadin/bacteria_archaea_traits	yes	https://bacdive.dsmz.de/	spore	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
 METPO:1000845	Acetogenesis	owl:Class	metabolism						Acetate fermentation	acetogenesis	https://github.com/jmadin/bacteria_archaea_traits				
 METPO:1000705	axially filamented	owl:Class	motile							axial filament	https://github.com/jmadin/bacteria_archaea_traits				
 METPO:1000667	bacillus shaped	owl:Class	cell shape							bacillus	https://github.com/jmadin/bacteria_archaea_traits				
@@ -229,3 +229,14 @@ METPO:1000329	temperature optimum (metabolic activity)	owl:Class	biological proc
 METPO:1000306	temperature range (growth tolerance)	owl:Class	phenotype	The span of temperatures within which an organism can grow											
 METPO:1000330	temperature range (metabolic viability)	owl:Class	biological process	The span of temperatures within which a microorganism can maintain metabolic functions and population viability.											
 METPO:1001003	temperature range observation	owl:Class	observation	An observation specializing temperature observation for growth temperature range data.											
+METPO:1003021	pigmentation	owl:Class	phenotype	A phenotype characterized by the color of pigments produced by a microorganism.											
+METPO:1003022	black pigmented	owl:Class	pigmentation	A phenotype characterized by the production of black-colored pigments.										Pigment_black	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003023	brown pigmented	owl:Class	pigmentation	A phenotype characterized by the production of brown-colored pigments.										Pigment_brown	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003024	cream pigmented	owl:Class	pigmentation	A phenotype characterized by the production of cream-colored pigments.										Pigment_cream	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003025	green pigmented	owl:Class	pigmentation	A phenotype characterized by the production of green-colored pigments.										Pigment_green	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003026	orange pigmented	owl:Class	pigmentation	A phenotype characterized by the production of orange-colored pigments.										Pigment_orange	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003027	pink pigmented	owl:Class	pigmentation	A phenotype characterized by the production of pink-colored pigments.										Pigment_pink	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003028	red pigmented	owl:Class	pigmentation	A phenotype characterized by the production of red-colored pigments.										Pigment_red	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003029	white pigmented	owl:Class	pigmentation	A phenotype characterized by the production of white-colored pigments.										Pigment_white	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003030	yellow pigmented	owl:Class	pigmentation	A phenotype characterized by the production of yellow-colored pigments.										Pigment_yellow	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+METPO:1003031	carotenoid pigmentation	owl:Class	pigmentation	A phenotype characterized by the production of carotenoid pigments.										Pigment_carotenoid	https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv


### PR DESCRIPTION
- Adds 11 new classes for pigment and carotenoid phenotypes to address gaps identified in BactoTraits data.
- Fixes a bug in the reconciliation script to correctly categorize permanently excluded fields.
- Regenerates reports, increasing BactoTraits coverage to 90.4%.
- Includes new issue draft for Python CI.