### PR TITLE
Remove misleading .gitignore entries for tracked directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,12 +64,8 @@ literature_mining/random-*-pmids.txt
 literature_mining/logs/*.log
 literature_mining/outputs/**/*.log
 
-# Literature mining corpus and workspace
-literature_mining/abstracts/
-literature_mining/corpus/
+# Literature mining workspace (untracked working files)
 literature_mining/workspace/
-literature_mining/CMM-AI/
-literature_mining/PFAS-AI/
 
 # Large reference files
 assets/chebi.lex


### PR DESCRIPTION
## Summary

Removes confusing `.gitignore` entries for directories that are already tracked in git.

| Directory | Tracked Files | Action |
|-----------|---------------|--------|
| `literature_mining/abstracts/` | 205 | Removed from .gitignore |
| `literature_mining/corpus/` | 75 | Removed from .gitignore |
| `literature_mining/CMM-AI/` | 73 | Removed from .gitignore |
| `literature_mining/PFAS-AI/` | 28 | Removed from .gitignore |
| `literature_mining/workspace/` | 0 | Kept (legitimate) |

## Why

`.gitignore` doesn't affect already-tracked files, so these entries were:
1. Misleading - suggests directories should be ignored but they're tracked
2. Confusing for contributors - unclear what's in git vs not

Related to #279 (action item: "Files that should be tracked but are ignored")

## Test plan

- [x] Verify tracked files unchanged: `git ls-files literature_mining/`
- [x] Verify workspace still ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)