### PR TITLE
Add MetaTraits mapping spec and ID allocation reference (#345)

### DIFF
--- a/docs/metatraits_to_metpo_mapping_specification.md
+++ b/docs/metatraits_to_metpo_mapping_specification.md
@@ -134,6 +134,7 @@ NCBITaxon:1299 -> METPO:2000303 (does not show activity of) -> GO:0004096
 
 EC numbers map to GO MF terms via the maintained ec2go mapping file at
 https://current.geneontology.org/ontology/external2go/ec2go
+
 EC is a flat classification; GO molecular function terms are in a DAG.
 Use GO terms as KGX objects; record EC as an xref/annotation if needed.
 
@@ -312,10 +313,10 @@ Domain: microbe. Range: xsd:decimal.
 | METPO:2000714 | has estimated gene count value | genes | estimated gene count |
 | METPO:2000715 | has GC percentage value | % | GC percentage |
 | METPO:2000716 | has coding density value | % | coding density |
-| METPO:2000721 | has cell length value | um | cell length |
-| METPO:2000722 | has cell width value | um | cell width |
+| METPO:2000721 | has cell length value | µm | cell length |
+| METPO:2000722 | has cell width value | µm | cell width |
 
-### 5.3 New Phenotype Classes (~18 classes)
+### 5.3 New Phenotype Classes (17 classes)
 
 | Proposed ID | Label | Parent | MetaTraits trait | External mapping |
 |-------------|-------|--------|------------------|-----------------|

--- a/docs/metpo_id_allocation_reference.md
+++ b/docs/metpo_id_allocation_reference.md
@@ -64,7 +64,7 @@ In practice: **1xxxxxx = classes**, **2xxxxxx = properties**.
 | 1001101-1001106 | 6 IDs | Biosafety levels 1-5 + parent | 6 |
 | 1002003-1002006 | 4 IDs | Cable bacteria metabolism, fermentation, syntrophy | 4 |
 | 1003000-1003031 | ~20 IDs | pH preference (10) + pigmentation (12) | ~22 |
-| 1004000-1004005 | ~5 IDs | Pathogenicity (4) + growth medium (1) | 5 |
+| 1004000-1004005 | 5 IDs | Pathogenicity (4) + growth medium (1) | 5 |
 
 ### Gaps in Class IDs
 
@@ -124,7 +124,7 @@ In practice: **1xxxxxx = classes**, **2xxxxxx = properties**.
 
 | Proposed Range | Purpose | Count needed |
 |----------------|---------|-------------|
-| METPO:1005001-1005010 | Nitrogen cycle process classes | ~1 (nitrification) |
+| METPO:1005001-1005010 | Nitrogen cycle process classes (nitrification + reserved for future N-cycle terms) | ~10 |
 | METPO:1005011-1005020 | Biochemical test phenotypes (indole/MR/VP +/-) | ~6 |
 | METPO:1005021-1005030 | Missing phenotypes (capnophilic, hemolytic) | ~3 |
 | METPO:1005031-1005050 | Flagellum arrangement types | ~7 |


### PR DESCRIPTION
## Summary

- Add `docs/metatraits_to_metpo_mapping_specification.md` — comprehensive specification for expressing MetaTraits assertions as KGX edges using METPO + Biolink predicates, covering all 5 data access methods, trait format taxonomy, mapping rules, new terms needed, and implementation checklist
- Add `docs/metpo_id_allocation_reference.md` — definitive record of all 1,228 METPO IDs ever allocated across current templates and 9 historical BioPortal submissions, with block-by-block topical groupings, gap analysis, and safe ranges for new term allocation

Closes #345

## Test plan

- [ ] Verify docs render correctly on GitHub
- [ ] Confirm ID ranges in allocation reference match actual template/historical data

🤖 Generated with [Claude Code](https://claude.com/claude-code)