### PR TITLE
Make ChromaDB storage paths configurable via METPO_CHROMADB_ROOT

### DIFF
--- a/data/chromadb/README.md
+++ b/data/chromadb/README.md
@@ -1,8 +1,19 @@
 # ChromaDB Setup for query_chromadb.ipynb
 
+## Configuration
+
+Set `METPO_CHROMADB_ROOT` to point to your local ChromaDB directory:
+
+```bash
+export METPO_CHROMADB_ROOT=/path/to/your/chromadb/metpo
+```
+
+If unset, defaults to `data/chromadb` (project-relative). All CLI scripts
+accept `--chroma-path` overrides.
+
 ## Database: chroma_ols20_nonols4
 
-**Location**: `data/chromadb/chroma_ols20_nonols4/`
+**Location**: `$METPO_CHROMADB_ROOT/chroma_ols20_nonols4/`
 **Collection**: `combined_embeddings`
 **Size**: 3.4GB (gitignored)
 **Embeddings**: 452,942 embeddings from 24 curated ontologies

--- a/metpo/cli_common.py
+++ b/metpo/cli_common.py
@@ -15,6 +15,9 @@ Example:
         pass
 """
 
+import os
+from pathlib import Path
+
 import click
 
 # =============================================================================
@@ -106,16 +109,23 @@ def output_dir_option(required=False, default=None, help_text="Output directory 
 # =============================================================================
 
 
-def chroma_path_option(default="./chroma_db", help_text="ChromaDB storage directory path"):
+CHROMADB_ROOT = Path(os.environ.get("METPO_CHROMADB_ROOT", "data/chromadb"))
+
+
+def chroma_path_option(collection="chroma_db", help_text="ChromaDB storage directory path"):
     """Standard ChromaDB storage path option.
 
+    Resolves the default from METPO_CHROMADB_ROOT env var (fallback: data/chromadb)
+    joined with the collection name.
+
     Args:
-        default: Default ChromaDB path (default: './chroma_db')
+        collection: Collection subdirectory name under CHROMADB_ROOT
         help_text: Custom help text
 
     Returns:
         Click option decorator for --chroma-path
     """
+    default = str(CHROMADB_ROOT / collection)
     return click.option(
         "--chroma-path", type=click.Path(path_type=str), default=default, help=help_text
     )

--- a/metpo/database/audit_chromadb.py
+++ b/metpo/database/audit_chromadb.py
@@ -6,6 +6,8 @@ import chromadb
 import click
 from chromadb.config import Settings
 
+from metpo.cli_common import CHROMADB_ROOT
+
 
 def audit_collection(chroma_path: str, collection_name: str):
     """Audit a ChromaDB collection."""
@@ -99,9 +101,9 @@ def main():
     """Audit all ChromaDB collections."""
 
     collections = [
-        ("./chroma_ols_27", "ols_embeddings"),
-        ("../embeddings_chroma", "non_ols_embeddings"),
-        ("./chroma_combined", "combined_embeddings"),
+        (str(CHROMADB_ROOT / "chroma_ols_27"), "ols_embeddings"),
+        (str(CHROMADB_ROOT / "embeddings_chroma"), "non_ols_embeddings"),
+        (str(CHROMADB_ROOT / "chroma_combined"), "combined_embeddings"),
     ]
 
     results = {}
@@ -115,9 +117,9 @@ def main():
     print("CROSS-DATABASE COMPARISON")
     print(f"{'=' * 80}")
 
-    ols_result = results.get("./chroma_ols_27/ols_embeddings")
-    non_ols_result = results.get("../embeddings_chroma/non_ols_embeddings")
-    combined_result = results.get("./chroma_combined/combined_embeddings")
+    ols_result = results.get(f"{CHROMADB_ROOT / 'chroma_ols_27'}/ols_embeddings")
+    non_ols_result = results.get(f"{CHROMADB_ROOT / 'embeddings_chroma'}/non_ols_embeddings")
+    combined_result = results.get(f"{CHROMADB_ROOT / 'chroma_combined'}/combined_embeddings")
 
     if ols_result and non_ols_result and combined_result:
         print("\nTotal Counts:")

--- a/metpo/database/combine_chromadb.py
+++ b/metpo/database/combine_chromadb.py
@@ -1,30 +1,32 @@
 """Combine OLS and non-OLS ChromaDB databases into a single unified database."""
 
-import os
+from pathlib import Path
 
 import chromadb
 import click
 from chromadb.config import Settings
 from tqdm import tqdm
 
+from metpo.cli_common import CHROMADB_ROOT
+
 
 @click.command()
 @click.option(
     "--ols-path",
     type=click.Path(exists=True),
-    default="notebooks/chroma_ols_27",
+    default=str(CHROMADB_ROOT / "chroma_ols_27"),
     help="Path to OLS ChromaDB",
 )
 @click.option(
     "--non-ols-path",
     type=click.Path(exists=True),
-    default="embeddings_chroma",
+    default=str(CHROMADB_ROOT / "embeddings_chroma"),
     help="Path to non-OLS ChromaDB",
 )
 @click.option(
     "--output-path",
     type=click.Path(),
-    default="notebooks/chroma_combined",
+    default=str(CHROMADB_ROOT / "chroma_combined"),
     help="Path for combined ChromaDB output",
 )
 @click.option(
@@ -46,7 +48,7 @@ def main(ols_path, non_ols_path, output_path, output_collection, batch_size):
     print("=" * 80)
 
     # Check if output already exists
-    if os.path.exists(output_path):
+    if Path(output_path).exists():
         click.confirm(
             f"\nWarning: Output path '{output_path}' already exists. Overwrite?", abort=True
         )

--- a/metpo/database/filter_ols_chromadb.py
+++ b/metpo/database/filter_ols_chromadb.py
@@ -8,14 +8,24 @@ import chromadb
 import click
 from chromadb.config import Settings
 
+from metpo.cli_common import CHROMADB_ROOT
+
 # OLS ontologies to REMOVE (7 total)
 OLS_TO_REMOVE = {"chebi", "foodon", "cl", "fypo", "ecto", "aro", "ddpheno"}
 
 
 @click.command()
-@click.option("--input-path", default="./chroma_ols_27", help="Path to input ChromaDB")
+@click.option(
+    "--input-path",
+    default=str(CHROMADB_ROOT / "chroma_ols_27"),
+    help="Path to input ChromaDB",
+)
 @click.option("--input-collection", default="ols_embeddings", help="Input collection name")
-@click.option("--output-path", default="./chroma_ols_20", help="Path to output ChromaDB")
+@click.option(
+    "--output-path",
+    default=str(CHROMADB_ROOT / "chroma_ols_20"),
+    help="Path to output ChromaDB",
+)
 @click.option("--output-collection", default="ols_embeddings", help="Output collection name")
 @click.option("--batch-size", default=10000, help="Batch size for processing")
 def main(input_path, input_collection, output_path, output_collection, batch_size):

--- a/metpo/database/migrate_to_chromadb_resilient.py
+++ b/metpo/database/migrate_to_chromadb_resilient.py
@@ -17,6 +17,8 @@ import click
 from chromadb.config import Settings
 from tqdm import tqdm
 
+from metpo.cli_common import CHROMADB_ROOT
+
 
 def extract_embedding_vector(embedding_json: str) -> list[float]:
     """Extract embedding vector from JSON, handling dict or list formats."""
@@ -235,7 +237,7 @@ def migrate_embeddings_resilient(
 @click.option(
     "--chroma-path",
     type=click.Path(path_type=str),
-    default="./chroma_db",
+    default=str(CHROMADB_ROOT / "chroma_db"),
     help="Path to ChromaDB storage directory",
 )
 @click.option("--batch-size", type=int, default=1000, help="Batch size for migration")

--- a/metpo/pipeline/chromadb_semantic_mapper.py
+++ b/metpo/pipeline/chromadb_semantic_mapper.py
@@ -366,13 +366,13 @@ def query_chromadb_for_term(
 @click.option(
     "--chroma-path",
     type=click.Path(path_type=str),
-    default=str(CHROMADB_ROOT / "embeddings_chroma"),
+    default=str(CHROMADB_ROOT / "chroma_ols20_nonols4"),
     help="Path to ChromaDB storage directory",
 )
 @click.option(
     "--collection-name",
     type=str,
-    default="ols_embeddings",
+    default="combined_embeddings",
     help="Name of the ChromaDB collection to query",
 )
 @click.option(

--- a/metpo/pipeline/chromadb_semantic_mapper.py
+++ b/metpo/pipeline/chromadb_semantic_mapper.py
@@ -42,6 +42,7 @@ from chromadb.config import Settings
 from dotenv import load_dotenv
 from tqdm import tqdm
 
+from metpo.cli_common import CHROMADB_ROOT
 from metpo.utils.sssom_utils import normalize_object_id
 
 CORE_CURIE_MAP = {
@@ -365,7 +366,7 @@ def query_chromadb_for_term(
 @click.option(
     "--chroma-path",
     type=click.Path(path_type=str),
-    default="./embeddings_chroma",
+    default=str(CHROMADB_ROOT / "embeddings_chroma"),
     help="Path to ChromaDB storage directory",
 )
 @click.option(

--- a/metpo/pipeline/embed_ontology_to_chromadb.py
+++ b/metpo/pipeline/embed_ontology_to_chromadb.py
@@ -20,6 +20,8 @@ from chromadb.config import Settings
 from dotenv import load_dotenv
 from tqdm import tqdm
 
+from metpo.cli_common import CHROMADB_ROOT
+
 
 def parse_robot_output(tsv_path: str, ontology_id: str) -> list[dict]:
     """
@@ -209,7 +211,7 @@ def insert_into_chromadb(
 @click.option(
     "--chroma-path",
     type=click.Path(),
-    default="./embeddings_chroma",
+    default=str(CHROMADB_ROOT / "embeddings_chroma"),
     help="Path to ChromaDB storage directory",
 )
 @click.option(

--- a/metpo/presentations/analyze_primary_sources.py
+++ b/metpo/presentations/analyze_primary_sources.py
@@ -8,22 +8,23 @@ Primary sources:
 """
 
 import csv
+import os
 import sqlite3
 from collections import Counter
 from pathlib import Path
 
 from metpo.utils.sssom_utils import extract_prefix, parse_sssom_curie_map
 
+_CHROMADB_ROOT = Path(os.environ.get("METPO_CHROMADB_ROOT", "data/chromadb"))
+
 # PRIMARY SOURCE 1: ChromaDB databases
-CHROMA_COMBINED = Path("/home/mark/gitrepos/metpo/notebooks/chroma_combined/chroma.sqlite3")
-CHROMA_OLS_20 = Path("/home/mark/gitrepos/metpo/notebooks/chroma_ols_20/chroma.sqlite3")
-CHROMA_NONOLS_4 = Path("/home/mark/gitrepos/metpo/notebooks/chroma_nonols_4/chroma.sqlite3")
+CHROMA_COMBINED = _CHROMADB_ROOT / "chroma_combined" / "chroma.sqlite3"
+CHROMA_OLS_20 = _CHROMADB_ROOT / "chroma_ols_20" / "chroma.sqlite3"
+CHROMA_NONOLS_4 = _CHROMADB_ROOT / "chroma_nonols_4" / "chroma.sqlite3"
 
 # PRIMARY SOURCE 2: SSSOM mappings
-SSSOM_RELAXED = Path(
-    "/home/mark/gitrepos/metpo/data/mappings/metpo_mappings_combined_relaxed.sssom.tsv"
-)
-SSSOM_OPTIMIZED = Path("/home/mark/gitrepos/metpo/data/mappings/metpo_mappings_optimized.sssom.tsv")
+SSSOM_RELAXED = Path("data/mappings/metpo_mappings_combined_relaxed.sssom.tsv")
+SSSOM_OPTIMIZED = Path("data/mappings/metpo_mappings_optimized.sssom.tsv")
 
 
 def query_chromadb(db_path, description):

--- a/metpo/scripts/find_best_definitions.py
+++ b/metpo/scripts/find_best_definitions.py
@@ -21,6 +21,8 @@ import chromadb
 import click
 from chromadb.config import Settings
 
+from metpo.cli_common import CHROMADB_ROOT
+
 
 def is_real_definition(label: str, definition: str, min_length: int = 30) -> bool:
     """
@@ -159,7 +161,7 @@ def get_definition_from_chromadb(term_iri: str, collection, ontology_id: str) ->
     "--chromadb-path",
     "-c",
     type=click.Path(exists=True, path_type=Path),
-    default="data/chromadb/chroma_ols20_nonols4",
+    default=str(CHROMADB_ROOT / "chroma_ols20_nonols4"),
     help="Path to ChromaDB directory",
 )
 @click.option(

--- a/metpo/scripts/iterative_definition_improvement.py
+++ b/metpo/scripts/iterative_definition_improvement.py
@@ -22,6 +22,8 @@ import click
 from openai import OpenAI
 from tqdm import tqdm
 
+from metpo.cli_common import CHROMADB_ROOT
+
 
 def load_ready_improvements(ready_path: str) -> dict[str, dict]:
     """Load undergraduate curator improvements."""
@@ -255,7 +257,7 @@ def choose_best_definition(
 @click.option(
     "--chroma-path",
     type=click.Path(exists=True),
-    default="data/chromadb/chroma_ols20_nonols4",
+    default=str(CHROMADB_ROOT / "chroma_ols20_nonols4"),
     help="ChromaDB directory",
 )
 @click.option("--collection-name", default="combined_embeddings", help="ChromaDB collection name")


### PR DESCRIPTION
## Summary

All ChromaDB CLI defaults now resolve via `METPO_CHROMADB_ROOT` env var (fallback: `data/chromadb`). Centralized `CHROMADB_ROOT` in `cli_common.py`; removed all hardcoded personal paths from ChromaDB-related code.

### Usage
```bash
export METPO_CHROMADB_ROOT=/path/to/your/chromadb/metpo
```

If unset, defaults to `data/chromadb` (project-relative). All CLI scripts still accept `--chroma-path` overrides.

### Expected filesystem hierarchy under METPO_CHROMADB_ROOT

Scripts expect ChromaDB persistent directories (each containing `chroma.sqlite3` + UUID subdirectory) at these paths:

| Path | Collection name | Used by | Required? |
|---|---|---|---|
| `chroma_ols20_nonols4/` | `combined_embeddings` | `chromadb-semantic-mapper`, `find-best-definitions`, `iterative-definition-improvement` | **Yes** — primary mapping database (24 ontologies, 452K embeddings) |
| `chroma_ols_27/` | `ols_embeddings` | `audit-chromadb`, `combine-chromadb`, `filter-ols-chromadb` (input) | Build dependency only |
| `chroma_ols_20/` | `ols_embeddings` | `filter-ols-chromadb` (output) | Build intermediate |
| `embeddings_chroma/` | `non_ols_embeddings` | `embed-ontology-to-chromadb` (output), `audit-chromadb` | Build intermediate |
| `chroma_combined/` | `combined_embeddings` | `combine-chromadb` (output), `audit-chromadb` | Build intermediate |
| `chroma_db/` | varies | `migrate-to-chromadb-resilient` (output) | Migration target |

**Only `chroma_ols20_nonols4/` is needed for day-to-day mapping work.** The others are intermediates from the build pipeline.

### How to obtain the databases

There is no automated build pipeline. The databases were built manually via:
1. 300GB OLS SQLite embedding file (pre-embedded by EBI) → `filter-ols-chromadb` → `chroma_ols_20`
2. BioPortal OWL files → ROBOT term extraction → `embed-ontology-to-chromadb` (requires OpenAI API key, ~$50) → `embeddings_chroma`
3. `combine-chromadb` merges OLS + non-OLS → `chroma_ols20_nonols4`

Or: copy from another machine via rsync:
```bash
rsync -avz --progress ubuntu:~/path/to/chromadb/metpo/chroma_ols20_nonols4/ $METPO_CHROMADB_ROOT/chroma_ols20_nonols4/
```

## Status: Draft — pending architectural decision

This PR addresses path hygiene but a broader rethink is underway in **#364**: evaluating OLS4's embeddings API + linkml-store as replacements for the DIY ChromaDB pipeline. The path configurability here is still useful if we keep any local ChromaDB, but the scope of what's stored locally may shrink dramatically.

### Also fixed
- Pre-existing bug: `chromadb-semantic-mapper` defaulted to `embeddings_chroma` / `ols_embeddings` (mismatched path and collection name). Fixed to `chroma_ols20_nonols4` / `combined_embeddings`.

## Related
- #364 — Evaluate OLS4 embeddings API + linkml-store to replace DIY ChromaDB pipeline
- #313 — Sync ChromaDB with repository ontology changes
- #350 — Add automated tests

## Test plan
- [x] `ruff check` and `ruff format` pass
- [x] CI passes (all 4 checks)
- [x] Copilot review comments addressed
- [ ] Makefile targets updated to use `METPO_CHROMADB_ROOT`
- [ ] Resolve #364 architectural direction before taking out of draft