### PR TITLE
fix: address all 5 CodeQL scanning alerts

### DIFF
--- a/docs/metpo/scripts/definition_work/fetch_source_metadata.py
+++ b/docs/metpo/scripts/definition_work/fetch_source_metadata.py
@@ -273,7 +273,7 @@ def main():
     print()
 
     if BIOPORTAL_API_KEY:
-        print(f"✓ BioPortal API key found ({BIOPORTAL_API_KEY[:10]}...)")
+        print("✓ BioPortal API key found")
     else:
         print("⚠ No BioPortal API key - only OLS will be used")
         print("  Set with: export BIOPORTAL_API_KEY='your-key-here'")

--- a/metpo/literature_mining/analysis/analyze_metpo_efficiency.py
+++ b/metpo/literature_mining/analysis/analyze_metpo_efficiency.py
@@ -55,7 +55,14 @@ def analyze_file(yaml_file):
                         other_ontology_formats["RHEA"].add("CURIE")
                     elif entity_id.startswith("AUTO:"):
                         other_ontology_formats["AUTO"].add("CURIE-like")
-                    elif entity_id.startswith(("https://w3id.org/", "http://purl.obolibrary.org/")):
+                    elif entity_id.startswith(
+                        (
+                            "https://w3id.org/",
+                            "http://w3id.org/",
+                            "https://purl.obolibrary.org/",
+                            "http://purl.obolibrary.org/",
+                        )
+                    ):
                         # Check if any other ontology uses URI format
                         if "metpo" not in entity_id:
                             prefix = entity_id.split("/")[-2] if "/" in entity_id else "unknown"

--- a/metpo/literature_mining/analysis/analyze_metpo_efficiency.py
+++ b/metpo/literature_mining/analysis/analyze_metpo_efficiency.py
@@ -55,7 +55,7 @@ def analyze_file(yaml_file):
                         other_ontology_formats["RHEA"].add("CURIE")
                     elif entity_id.startswith("AUTO:"):
                         other_ontology_formats["AUTO"].add("CURIE-like")
-                    elif "w3id.org" in entity_id or "purl.obolibrary.org" in entity_id:
+                    elif entity_id.startswith(("https://w3id.org/", "http://purl.obolibrary.org/")):
                         # Check if any other ontology uses URI format
                         if "metpo" not in entity_id:
                             prefix = entity_id.split("/")[-2] if "/" in entity_id else "unknown"

--- a/metpo/utils/sssom_utils.py
+++ b/metpo/utils/sssom_utils.py
@@ -137,7 +137,14 @@ def extract_prefix(identifier: str, curie_map: dict[str, str] | None = None) -> 
             detected = text.split("/obo/")[1].split("_")[0]
         elif lowered.startswith(("https://doi.org/", "http://doi.org/")):
             detected = "doi"
-        elif lowered.startswith(("https://biolink", "http://biolink")):
+        elif lowered.startswith(
+            (
+                "https://w3id.org/biolink/vocab/",
+                "http://w3id.org/biolink/vocab/",
+                "https://w3id.org/biolink/",
+                "http://w3id.org/biolink/",
+            )
+        ):
             detected = "biolink"
         elif lowered.startswith(("https://purl.dsmz.de/", "http://purl.dsmz.de/")):
             detected = "d3o"

--- a/metpo/utils/sssom_utils.py
+++ b/metpo/utils/sssom_utils.py
@@ -135,13 +135,13 @@ def extract_prefix(identifier: str, curie_map: dict[str, str] | None = None) -> 
     if detected is None:
         if "/obo/" in text and "_" in text:
             detected = text.split("/obo/")[1].split("_")[0]
-        elif "doi.org" in lowered:
+        elif lowered.startswith(("https://doi.org/", "http://doi.org/")):
             detected = "doi"
-        elif "biolink" in lowered:
+        elif lowered.startswith(("https://biolink", "http://biolink")):
             detected = "biolink"
-        elif "purl.dsmz.de" in lowered:
+        elif lowered.startswith(("https://purl.dsmz.de/", "http://purl.dsmz.de/")):
             detected = "d3o"
-        elif "mdatahub.org" in lowered:
+        elif lowered.startswith(("https://mdatahub.org/", "http://mdatahub.org/")):
             detected = "meo"
         elif "semanticweb.org/bipon/" in lowered:
             detected = "bipon"


### PR DESCRIPTION
## Summary

Fixes all 5 alerts from the initial CodeQL scan.

| Alert | Severity | File | Fix |
|---|---|---|---|
| #1 | error | `fetch_source_metadata.py:276` | Remove partial API key (`[:10]`) from print — was leaking key prefix to stdout |
| #2-3 | warning | `analyze_metpo_efficiency.py:58` | Replace `"w3id.org" in entity_id` with `startswith(("https://w3id.org/", ...))` |
| #4-5 | warning | `sssom_utils.py:138,144` | Replace `"doi.org" in lowered` etc. with `startswith()` for all IRI-based prefix detection |

The URL substring checks were IRI classification logic, not sanitization — but `startswith` is more correct regardless (prevents false matches on query params or path segments).

## Test plan

- [x] 17/17 tests pass
- [ ] CodeQL re-scan clears all 5 alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)