### PR TITLE
Consolidate Dependabot workflow action bumps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
         language: ['python']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -57,7 +57,7 @@ jobs:
     needs: quality-checks
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Run ontology QC checks
         env:

--- a/.github/workflows/uv-upgrade.yml
+++ b/.github/workflows/uv-upgrade.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/uv-upgrade.yml
+++ b/.github/workflows/uv-upgrade.yml
@@ -21,7 +21,7 @@ jobs:
         run: uv lock --upgrade
 
       - name: Open PR if lockfile changed
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: uv lock --upgrade"
           branch: chore/uv-upgrade

--- a/.github/workflows/uv-upgrade.yml
+++ b/.github/workflows/uv-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Upgrade all dependencies
         run: uv lock --upgrade


### PR DESCRIPTION
This folds the currently open Dependabot workflow-action updates into one PR.

Included changes:
- bump `github/codeql-action` from v3 to v4
- bump `actions/checkout` from v3/v4 to v6 where used
- bump `actions/setup-python` from v5 to v6
- bump `peter-evans/create-pull-request` from v7 to v8
- bump `astral-sh/setup-uv` from v5 to v7

Explicitly excluded per request:
- #363

Supersedes: #403, #404, #405, #406, #407.