### PR TITLE
Resolve sheet URLs without uv inside the ODK container

### DIFF
--- a/docs/google_sheets_template_sync.md
+++ b/docs/google_sheets_template_sync.md
@@ -97,7 +97,34 @@ curl -sL 'https://docs.google.com/spreadsheets/d/1_Lr-9_5QHi8QLvRyTZFSciUhzGKD4D
 
 Google Sheets also maintains version history (File → Version history) which can restore any prior state.
 
+## Build-time URL resolution (host vs ODK container)
+
+The Makefile rules that download templates from the Google Sheet need to resolve the export URL at parse time. Resolution has to work in two environments:
+
+| Environment | python3 | pyyaml | uv | metpo package importable |
+|---|---|---|---|---|
+| ODK container (`sh run.sh make ...`) | yes | yes | **no** | no |
+| Host with active uv venv | yes (venv) | yes | yes | yes (editable install) |
+| Host plain (`python3` from Homebrew or system) | yes | usually **no** | maybe | no |
+
+`src/ontology/metpo.Makefile` uses a two-tier fallback:
+
+1. **Hardcoded defaults** (`SPREADSHEET_ID`, `SRC_URL_MAIN`, `SRC_URL_PROPERTIES` at the top of the file) — always work regardless of environment.
+2. **Override from sheets.yaml** — runs `python3 ../../metpo/sheets_config.py classes` (and `properties`). If python3 + pyyaml are present, this prints the URL derived from `sheets.yaml`, and Make overrides the hardcoded default. If anything fails (`ModuleNotFoundError`, missing file, etc.), stderr is swallowed and the hardcoded default stands.
+
+`metpo/sheets_config.py` is **both** an importable module (used by Python scripts in the repo) **and** a runnable script (used by Makefiles). The `if __name__ == "__main__":` block at the bottom calls `export_url(sys.argv[1])`.
+
+### Why two tiers instead of one
+
+Earlier, the Makefile invoked `uv run python -c "from metpo.sheets_config import export_url; ..."`. That worked on host but failed silently inside the ODK container with `/bin/sh: 1: uv: not found`, returning an empty URL and producing a zero-byte `metpo_sheet.tsv`. The two-tier setup keeps the central-source-of-truth benefit of `sheets.yaml` (issue [#372](https://github.com/berkeleybop/metpo/issues/372)) while making the build robust to environments that lack `uv` or `pyyaml`.
+
+### When sheet GIDs change
+
+Update both `sheets.yaml` AND the hardcoded `SRC_URL_MAIN` / `SRC_URL_PROPERTIES` defaults in `src/ontology/metpo.Makefile`. The yaml-derived value is preferred when available, but the hardcoded fallback should not drift far from reality.
+
 ## Related issues
 
 - [#366](https://github.com/berkeleybop/metpo/issues/366) — Template lifecycle: diff, sync, and push workflow
 - [#365](https://github.com/berkeleybop/metpo/issues/365) — Properties template needs per-source synonym columns
+- [#372](https://github.com/berkeleybop/metpo/issues/372) — Centralize Google Sheets GIDs in single config file (introduced `sheets.yaml`)
+- [#433](https://github.com/berkeleybop/metpo/issues/433) — Umbrella: SoT switch + agentic-maintenance guardrails

--- a/docs/google_sheets_template_sync.md
+++ b/docs/google_sheets_template_sync.md
@@ -99,7 +99,7 @@ Google Sheets also maintains version history (File → Version history) which ca
 
 ## Build-time URL resolution (host vs ODK container)
 
-The Makefile rules that download templates from the Google Sheet need to resolve the export URL at parse time. Resolution has to work in two environments:
+The Makefile rules that download templates from the Google Sheet need to resolve the export URL at parse time. Resolution has to work across three distinct setups (one container target plus two host variants):
 
 | Environment | python3 | pyyaml | uv | metpo package importable |
 |---|---|---|---|---|

--- a/docs/google_sheets_template_sync.md
+++ b/docs/google_sheets_template_sync.md
@@ -122,6 +122,20 @@ Earlier, the Makefile invoked `uv run python -c "from metpo.sheets_config import
 
 Update both `sheets.yaml` AND the hardcoded `SRC_URL_MAIN` / `SRC_URL_PROPERTIES` defaults in `src/ontology/metpo.Makefile`. The yaml-derived value is preferred when available, but the hardcoded fallback should not drift far from reality.
 
+## Other build environment quirks
+
+### `useradd` warning on macOS hosts
+
+When running `sh run.sh make <anything>` on a macOS host, the ODK container's entrypoint prints:
+
+```
+useradd warning: odkuser's uid 502 outside of the UID_MIN 1000 and UID_MAX 60000 range.
+```
+
+**Benign, ignore.** The entrypoint creates a Linux user inside the container that matches your macOS UID (501/502 for the first non-system user on macOS) so files the container writes to the mounted repo come out owned by you on the host. Linux convention reserves UIDs below 1000 for system accounts; `useradd` accepts the out-of-range UID and continues, just complaining. Same warning shows up with any Docker image that UID-matches a macOS host (OAK, GO build containers, etc.).
+
+If you want to silence it long-term, the fix is upstream in [`INCATools/ontology-development-kit`](https://github.com/INCATools/ontology-development-kit) (have the entrypoint pre-check the macOS-typical UID range and skip the warning, or pass `-K UID_MIN=0` to `useradd`). Low-priority and mostly cosmetic.
+
 ## Related issues
 
 - [#366](https://github.com/berkeleybop/metpo/issues/366) — Template lifecycle: diff, sync, and push workflow

--- a/metpo/sheets_config.py
+++ b/metpo/sheets_config.py
@@ -55,4 +55,13 @@ if __name__ == "__main__":
     # Lets the ODK Makefile resolve sheet URLs using only python3 + pyyaml
     # (both present in the ODK container), without needing `uv run`.
     import sys
-    print(export_url(sys.argv[1]))
+
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <sheet_name>", file=sys.stderr)
+        sys.exit(2)
+    sheet = sys.argv[1]
+    if sheet not in SHEET_GIDS:
+        valid = ", ".join(sorted(SHEET_GIDS))
+        print(f"unknown sheet '{sheet}'; valid: {valid}", file=sys.stderr)
+        sys.exit(1)
+    print(export_url(sheet))

--- a/metpo/sheets_config.py
+++ b/metpo/sheets_config.py
@@ -46,3 +46,13 @@ def all_export_urls() -> dict[str, str]:
                 f"/export?exportFormat=tsv&gid={gid}"
             )
     return urls
+
+
+if __name__ == "__main__":
+    # Callable directly as a script without installing the metpo package:
+    #   python3 metpo/sheets_config.py classes
+    #   python3 metpo/sheets_config.py properties
+    # Lets the ODK Makefile resolve sheet URLs using only python3 + pyyaml
+    # (both present in the ODK container), without needing `uv run`.
+    import sys
+    print(export_url(sys.argv[1]))

--- a/src/ontology/metpo.Makefile
+++ b/src/ontology/metpo.Makefile
@@ -9,12 +9,14 @@
 # Two-tier resolution so the build works on both host and inside the ODK
 # container (which does not ship `uv`):
 #
-#   1. Hardcoded defaults below ALWAYS work: container has no python deps,
-#      host with no pyyaml, etc.
-#   2. If python3 + pyyaml are available (true in the ODK container, and on
-#      hosts with `pip install pyyaml` or an active uv venv), we override
-#      the defaults by reading sheets.yaml via metpo/sheets_config.py
-#      invoked as a script (no package install required).
+#   1. Hardcoded defaults below always work, even if python3 or pyyaml are
+#      unavailable, since they require nothing beyond Make itself.
+#   2. If python3 + pyyaml ARE available (true in the ODK container, on
+#      hosts with `pip install pyyaml`, and inside an active uv venv), we
+#      override the defaults by reading sheets.yaml via
+#      metpo/sheets_config.py invoked as a script (no package install
+#      required). The shell command's stderr is swallowed so a missing
+#      python3 or pyyaml falls through silently to the hardcoded defaults.
 #
 # If the sheet's GIDs ever change, update both the hardcoded defaults here
 # AND sheets.yaml. See docs/google_sheets_template_sync.md.

--- a/src/ontology/metpo.Makefile
+++ b/src/ontology/metpo.Makefile
@@ -55,13 +55,13 @@ diff-drafts: ../templates/metpo_sheet.tsv ../templates/metpo-properties.tsv
 	@diff $(DRAFTS_DIR)/metpo-properties.tsv ../templates/metpo-properties.tsv || true
 
 ../templates/metpo_sheet.tsv:
-	curl -L -s $(SRC_URL_MAIN) > $@
+	curl -L -s "$(SRC_URL_MAIN)" > $@
 
 #../templates/metpo-synonyms.tsv:
-#	curl -L -s $(SRC_URL_SYNONYMS) > $@
+#	curl -L -s "$(SRC_URL_SYNONYMS)" > $@
 
 ../templates/metpo-properties.tsv:
-	curl -L -s $(SRC_URL_PROPERTIES) > $@
+	curl -L -s "$(SRC_URL_PROPERTIES)" > $@
 
 squeaky-clean: clean clean-templates
 

--- a/src/ontology/metpo.Makefile
+++ b/src/ontology/metpo.Makefile
@@ -3,10 +3,34 @@
 ## If you need to customize your Makefile, make
 ## changes here rather than in the main Makefile
 
-# Sheet GIDs are centralized in sheets.yaml at repo root.
+# Sheet GIDs and spreadsheet ID are centralized in sheets.yaml at repo root.
 # See https://github.com/berkeleybop/metpo/issues/372
-SRC_URL_MAIN := $(shell cd ../.. && uv run python -c "from metpo.sheets_config import export_url; print(export_url('classes'))")
-SRC_URL_PROPERTIES := $(shell cd ../.. && uv run python -c "from metpo.sheets_config import export_url; print(export_url('properties'))")
+#
+# Two-tier resolution so the build works on both host and inside the ODK
+# container (which does not ship `uv`):
+#
+#   1. Hardcoded defaults below ALWAYS work: container has no python deps,
+#      host with no pyyaml, etc.
+#   2. If python3 + pyyaml are available (true in the ODK container, and on
+#      hosts with `pip install pyyaml` or an active uv venv), we override
+#      the defaults by reading sheets.yaml via metpo/sheets_config.py
+#      invoked as a script (no package install required).
+#
+# If the sheet's GIDs ever change, update both the hardcoded defaults here
+# AND sheets.yaml. See docs/google_sheets_template_sync.md.
+SPREADSHEET_ID := 1_Lr-9_5QHi8QLvRyTZFSciUhzGKD4DbUObyTpJ16_RU
+SRC_URL_MAIN := https://docs.google.com/spreadsheets/d/$(SPREADSHEET_ID)/export?exportFormat=tsv&gid=1569766102
+SRC_URL_PROPERTIES := https://docs.google.com/spreadsheets/d/$(SPREADSHEET_ID)/export?exportFormat=tsv&gid=681401984
+
+SRC_URL_MAIN_FROM_YAML := $(shell python3 ../../metpo/sheets_config.py classes 2>/dev/null)
+ifneq ($(SRC_URL_MAIN_FROM_YAML),)
+SRC_URL_MAIN := $(SRC_URL_MAIN_FROM_YAML)
+endif
+
+SRC_URL_PROPERTIES_FROM_YAML := $(shell python3 ../../metpo/sheets_config.py properties 2>/dev/null)
+ifneq ($(SRC_URL_PROPERTIES_FROM_YAML),)
+SRC_URL_PROPERTIES := $(SRC_URL_PROPERTIES_FROM_YAML)
+endif
 
 DRAFTS_DIR = ../templates/drafts
 


### PR DESCRIPTION
## Summary

- Two-tier sheet URL resolution in `src/ontology/metpo.Makefile`: hardcoded defaults that always work + optional override from `sheets.yaml` via `python3` when pyyaml is available
- `metpo/sheets_config.py` becomes both importable and script-runnable (`if __name__ == "__main__":` block)
- `docs/google_sheets_template_sync.md` documents the host vs ODK container environment matrix and the fallback design

Removes the `/bin/sh: 1: uv: not found` warnings and the zero-byte-TSV failure mode after `squeaky-clean`. Preserves the `sheets.yaml` single-source-of-truth intent from #372.

Fixes #438.
Related: #372, #433.

## Test plan

- [x] `python3 metpo/sheets_config.py classes` works inside ODK container (verified, returns expected URL)
- [x] `python3 metpo/sheets_config.py classes` fails gracefully on host without pyyaml (verified, stderr swallowed by 2>/dev/null, Makefile falls back to hardcoded)
- [x] `uv run python metpo/sheets_config.py classes` works on host with venv (verified)
- [x] `sh run.sh make squeaky-clean` no longer prints `uv: not found` (verified by Mark)
- [ ] `sh run.sh make all` end-to-end build (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)