### PR TITLE
Enrich ontology header metadata; document synonym column conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,41 @@ sh run.sh make prepare_release
 5. **Follow naming patterns** - Consistent with existing terms in the ontology
 6. **Place imports appropriately** - Keep imported terms in imports directory
 
+### Synonym Column Conventions (source-bound vs ontology-native)
+
+The classes-tab template has two kinds of synonym columns; they have different editing rules.
+
+**Source-bound columns** (always paired with a source URL column):
+
+| Column | Source column | Holds |
+|---|---|---|
+| `madin synonym or field` | `Madin synonym source` | Verbatim field name or value from Madin et al. |
+| `bacdive keyword synonym` | `Bacdive synonym source` | Verbatim keyword from BacDive |
+| `bactotraits related synonym` | `Bactotraits synonym source` | Verbatim column name from the BactoTraits CSV |
+| `metatraits synonym` | `MetaTraits synonym source` | Verbatim term from MetaTraits |
+
+**Rule:** values in source-bound columns are verbatim from the named source. Do **not** normalize them, even when the source contains:
+
+- typos (BactoTraits `Ox_microerophile` for microaerophile)
+- inconsistent prefixes (BactoTraits header has `pHR_8_to_10` then `10_to_14` for the next bin, no `pHR_` prefix)
+- non-English forms
+- unusual capitalization or punctuation
+
+The implicit contract is that downstream consumers (e.g. `kg-microbe`'s BactoTraits transformer) match on the exact source string. Normalizing breaks matching.
+
+**Ontology-native columns:**
+
+| Column | Holds |
+|---|---|
+| `confirmed exact synonym` | Clean US English synonyms curated for METPO itself (`oboInOwl:hasExactSynonym`) |
+| `literature mining related synonyms` | OntoGPT-derived candidates (`oboInOwl:hasRelatedSynonym`) |
+| `biolink close match` | `skos:closeMatch` to a Biolink class |
+| `biolink broad match` | `skos:broadMatch` to a Biolink class (when METPO term is more specific) |
+
+**Rule:** ontology-native columns use normal, consistent US English orthography. Foreign-language forms, source typos, and one-off transcriptions belong in source-bound columns or in `literature mining related synonyms`, not here.
+
+When a source value happens to coincide with the desired ontology-native synonym, write it in *both* columns; do not rely on the source-bound column carrying English semantics.
+
 ---
 
 ## Project Organization

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,9 +221,17 @@ The implicit contract is that downstream consumers (e.g. `kg-microbe`'s BactoTra
 | `biolink close match` | `skos:closeMatch` to a Biolink class |
 | `biolink broad match` *(added to sheet 2026-05-18; appears in `src/templates/metpo_sheet.tsv` after any build that re-fetches; not in the committed snapshot at this PR's HEAD)* | `skos:broadMatch` to a Biolink class (when METPO term is more specific) |
 
-**Important nuance about the committed TSV vs the Google Sheet:** the Google Sheet is the source of truth for ontology content. `src/templates/metpo_sheet.tsv` in the repo is a build cache: `make squeaky-clean && make all` deletes the local copy and re-curls it from the sheet, so every build runs against current sheet data. The committed TSV is a snapshot from the last time someone ran the build and `git add`ed the result; it can lag behind the sheet without affecting builds. Contributors who browse the repo via GitHub may see a stale snapshot of column structure, but the build always sees what is in the sheet right now.
+**Important nuance about the committed TSV vs the Google Sheet (today's flow):** the Google Sheet is the conceptual source of truth for ontology content. `src/templates/metpo_sheet.tsv` in the repo is a build cache. The Makefile rule `../templates/metpo_sheet.tsv:` has *no* prerequisites, so Make re-fetches from the sheet **only when the local file is missing**. Three concrete cases:
 
-The cache rule is unconditional (`../templates/metpo_sheet.tsv:` has no prerequisites), so direct local edits to the TSV survive subsequent `make all` invocations until the next `squeaky-clean`. Don't rely on this for durable changes; commit them via the sheet.
+| Invocation | TSV state | Uses sheet? |
+|---|---|---|
+| `make all` after `make squeaky-clean` (or otherwise missing TSV) | absent → re-fetched via curl | yes (live sheet) |
+| `make all` on a fresh clone / CI run | present (committed snapshot) | no — uses committed TSV as-is |
+| `make all` after local edits to the TSV | present (locally edited) | no — local edits survive until next `squeaky-clean` |
+
+CI runs `make test IMP=false PAT=false MIR=false` from `.github/workflows/qc.yml` (no `squeaky-clean`), so CI tests against the **committed** TSV and the **committed** `components/metpo_sheet.owl`, not the live sheet. To get sheet edits into CI, someone has to run `squeaky-clean && make all`, then commit the regenerated `src/templates/*.tsv` and `src/ontology/components/*.owl`. Until then the committed snapshot is what gets tested.
+
+This is mostly fine because the cadence of sheet edits is "edit then run a verifying build then commit," not "edit and forget." But it does mean contributors browsing the repo via GitHub see whatever was last committed, and that's also what CI is checking.
 
 **Rule:** ontology-native columns use normal, consistent US English orthography. Foreign-language forms, source typos, and one-off transcriptions belong in source-bound columns or in `literature mining related synonyms`, not here.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,9 @@ The implicit contract is that downstream consumers (e.g. `kg-microbe`'s BactoTra
 | `confirmed exact synonym` | Clean US English synonyms curated for METPO itself (`oboInOwl:hasExactSynonym`) |
 | `literature mining related synonyms` | OntoGPT-derived candidates (`oboInOwl:hasRelatedSynonym`) |
 | `biolink close match` | `skos:closeMatch` to a Biolink class |
-| `biolink broad match` | `skos:broadMatch` to a Biolink class (when METPO term is more specific) |
+| `biolink broad match` *(added 2026-05-18; not yet in committed `src/templates/metpo_sheet.tsv` until the next Sheet → TSV sync per #366)* | `skos:broadMatch` to a Biolink class (when METPO term is more specific) |
+
+The `biolink broad match` column exists today only in the Google Sheet (`classes` tab, column X with ROBOT directive `AI skos:broadMatch`). It will appear in the repo TSVs the next time `make squeaky-clean && make all` re-downloads from the sheet. Until then, contributors editing the local TSV file directly will not see it.
 
 **Rule:** ontology-native columns use normal, consistent US English orthography. Foreign-language forms, source typos, and one-off transcriptions belong in source-bound columns or in `literature mining related synonyms`, not here.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,9 +219,11 @@ The implicit contract is that downstream consumers (e.g. `kg-microbe`'s BactoTra
 | `confirmed exact synonym` | Clean US English synonyms curated for METPO itself (`oboInOwl:hasExactSynonym`) |
 | `literature mining related synonyms` | OntoGPT-derived candidates (`oboInOwl:hasRelatedSynonym`) |
 | `biolink close match` | `skos:closeMatch` to a Biolink class |
-| `biolink broad match` *(added 2026-05-18; not yet in committed `src/templates/metpo_sheet.tsv` until the next Sheet → TSV sync per #366)* | `skos:broadMatch` to a Biolink class (when METPO term is more specific) |
+| `biolink broad match` *(added to sheet 2026-05-18; appears in `src/templates/metpo_sheet.tsv` after any build that re-fetches; not in the committed snapshot at this PR's HEAD)* | `skos:broadMatch` to a Biolink class (when METPO term is more specific) |
 
-The `biolink broad match` column exists today only in the Google Sheet (`classes` tab, column X with ROBOT directive `AI skos:broadMatch`). It will appear in the repo TSVs the next time `make squeaky-clean && make all` re-downloads from the sheet. Until then, contributors editing the local TSV file directly will not see it.
+**Important nuance about the committed TSV vs the Google Sheet:** the Google Sheet is the source of truth for ontology content. `src/templates/metpo_sheet.tsv` in the repo is a build cache: `make squeaky-clean && make all` deletes the local copy and re-curls it from the sheet, so every build runs against current sheet data. The committed TSV is a snapshot from the last time someone ran the build and `git add`ed the result; it can lag behind the sheet without affecting builds. Contributors who browse the repo via GitHub may see a stale snapshot of column structure, but the build always sees what is in the sheet right now.
+
+The cache rule is unconditional (`../templates/metpo_sheet.tsv:` has no prerequisites), so direct local edits to the TSV survive subsequent `make all` invocations until the next `squeaky-clean`. Don't rely on this for durable changes; commit them via the sheet.
 
 **Rule:** ontology-native columns use normal, consistent US English orthography. Foreign-language forms, source typos, and one-off transcriptions belong in source-bound columns or in `literature mining related synonyms`, not here.
 

--- a/src/ontology/metpo-edit.owl
+++ b/src/ontology/metpo-edit.owl
@@ -10,14 +10,19 @@ Prefix(IAO:=<http://purl.obolibrary.org/obo/IAO_>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/metpo.owl>
+Annotation(dcterms:title "METPO: Microbial Ecophysiological Trait and Phenotype Ontology")
+Annotation(dcterms:description "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible.")
 Annotation(dcterms:creator "METPO Development Team")
-Annotation(dcterms:description "Microbial ecophysiological trait and phenotype ontology")
-Annotation(dcterms:issued "2024-01-01")
+Annotation(dcterms:contributor <https://orcid.org/0000-0001-9076-6066>)
 Annotation(dcterms:license <https://creativecommons.org/licenses/by/4.0/>)
-Annotation(dcterms:modified "2025-09-29")
-Annotation(dcterms:title "METPO")
+Annotation(dcterms:issued "2024-01-01")
+Annotation(dcterms:modified "2026-05-18")
+Annotation(rdfs:seeAlso <https://github.com/berkeleybop/metpo>)
+Annotation(rdfs:seeAlso <https://bioregistry.io/registry/metpo>)
+Annotation(rdfs:seeAlso <https://bioportal.bioontology.org/ontologies/METPO>)
 
 
+Declaration(AnnotationProperty(dcterms:contributor))
 Declaration(AnnotationProperty(dcterms:creator))
 Declaration(AnnotationProperty(dcterms:description))
 Declaration(AnnotationProperty(dcterms:issued))


### PR DESCRIPTION
## Summary

- `src/ontology/metpo-edit.owl`: upgrade ontology-header `dcterms` annotations (substantive description, multi-line title, contributor ORCID, `rdfs:seeAlso` to GitHub repo / bioregistry / BioPortal); refresh `dcterms:modified`
- `CLAUDE.md`: add 'Synonym Column Conventions (source-bound vs ontology-native)' subsection codifying that source-bound columns (madin/bacdive/bactotraits/metatraits) hold verbatim source values including upstream typos, and ontology-native columns use clean US English. Mentions the new `biolink broad match` column to be reflected in `src/templates/` after the next Google Sheet → TSV sync

Closes #80.
Closes #82.
Related: #433.

## Test plan

- [ ] ODK build picks up the header annotations after `sh run.sh make all` (verify with `grep "rdfs:seeAlso" metpo.owl` and `grep "0000-0001-9076-6066" metpo.owl`)
- [ ] No new validation errors from `make test` (header annotations are inert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)