### PR TITLE
release 2026-05-19

### DIFF
--- a/metpo-base.json
+++ b/metpo-base.json
@@ -6,11 +6,14 @@
         "pred" : "http://purl.org/dc/elements/1.1/type",
         "val" : "http://purl.obolibrary.org/obo/IAO_8000001"
       }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0001-9076-6066"
+      }, {
         "pred" : "http://purl.org/dc/terms/creator",
         "val" : "METPO Development Team"
       }, {
         "pred" : "http://purl.org/dc/terms/description",
-        "val" : "Microbial ecophysiological trait and phenotype ontology"
+        "val" : "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible."
       }, {
         "pred" : "http://purl.org/dc/terms/issued",
         "val" : "2024-01-01"
@@ -19,18 +22,31 @@
         "val" : "https://creativecommons.org/licenses/by/4.0/"
       }, {
         "pred" : "http://purl.org/dc/terms/modified",
-        "val" : "2025-09-29"
+        "val" : "2026-05-18"
       }, {
         "pred" : "http://purl.org/dc/terms/title",
-        "val" : "METPO"
+        "val" : "METPO: Microbial Ecophysiological Trait and Phenotype Ontology"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://bioportal.bioontology.org/ontologies/METPO"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://bioregistry.io/registry/metpo"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://github.com/berkeleybop/metpo"
       }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-03-24"
+        "val" : "2026-05-19"
       } ],
-      "version" : "https://w3id.org/metpo/metpo/releases/2026-03-24/metpo-base.json"
+      "version" : "https://w3id.org/metpo/metpo/releases/2026-05-19/metpo-base.json"
     },
     "nodes" : [ {
       "id" : "http://purl.org/dc/elements/1.1/type",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.org/dc/terms/contributor",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {

--- a/metpo-base.obo
+++ b/metpo-base.obo
@@ -1,14 +1,18 @@
 format-version: 1.2
-data-version: https://w3id.org/metpo/metpo/releases/2026-03-24/metpo-base.owl
+data-version: https://w3id.org/metpo/metpo/releases/2026-05-19/metpo-base.owl
 idspace: dce http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
 ontology: https://w3id.org/metpo/metpo/metpo-base.owl
 property_value: dce:type IAO:8000001
+property_value: dcterms:contributor https://orcid.org/0000-0001-9076-6066
 property_value: dcterms:creator "METPO Development Team" xsd:string
-property_value: dcterms:description "Microbial ecophysiological trait and phenotype ontology" xsd:string
+property_value: dcterms:description "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible." xsd:string
 property_value: dcterms:issued "2024-01-01" xsd:string
 property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
-property_value: dcterms:modified "2025-09-29" xsd:string
-property_value: dcterms:title "METPO" xsd:string
-property_value: owl:versionInfo "2026-03-24" xsd:string
+property_value: dcterms:modified "2026-05-18" xsd:string
+property_value: dcterms:title "METPO: Microbial Ecophysiological Trait and Phenotype Ontology" xsd:string
+property_value: owl:versionInfo "2026-05-19" xsd:string
+property_value: seeAlso https://bioportal.bioontology.org/ontologies/METPO
+property_value: seeAlso https://bioregistry.io/registry/metpo
+property_value: seeAlso https://github.com/berkeleybop/metpo
 

--- a/metpo-base.owl
+++ b/metpo-base.owl
@@ -10,15 +10,19 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:dcterms="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="https://w3id.org/metpo/metpo/metpo-base.owl">
-        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-03-24/metpo-base.owl"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-05-19/metpo-base.owl"/>
         <dce:type rdf:resource="http://purl.obolibrary.org/obo/IAO_8000001"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0001-9076-6066"/>
         <dcterms:creator>METPO Development Team</dcterms:creator>
-        <dcterms:description>Microbial ecophysiological trait and phenotype ontology</dcterms:description>
+        <dcterms:description>METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible.</dcterms:description>
         <dcterms:issued>2024-01-01</dcterms:issued>
         <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-        <dcterms:modified>2025-09-29</dcterms:modified>
-        <dcterms:title>METPO</dcterms:title>
-        <owl:versionInfo>2026-03-24</owl:versionInfo>
+        <dcterms:modified>2026-05-18</dcterms:modified>
+        <dcterms:title>METPO: Microbial Ecophysiological Trait and Phenotype Ontology</dcterms:title>
+        <rdfs:seeAlso rdf:resource="https://bioportal.bioontology.org/ontologies/METPO"/>
+        <rdfs:seeAlso rdf:resource="https://bioregistry.io/registry/metpo"/>
+        <rdfs:seeAlso rdf:resource="https://github.com/berkeleybop/metpo"/>
+        <owl:versionInfo>2026-05-19</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -37,6 +41,12 @@
     <!-- http://purl.org/dc/elements/1.1/type -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/type"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/contributor -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
     
 
 

--- a/metpo-full.json
+++ b/metpo-full.json
@@ -3,11 +3,14 @@
     "id" : "https://w3id.org/metpo/metpo/metpo-full.json",
     "meta" : {
       "basicPropertyValues" : [ {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0001-9076-6066"
+      }, {
         "pred" : "http://purl.org/dc/terms/creator",
         "val" : "METPO Development Team"
       }, {
         "pred" : "http://purl.org/dc/terms/description",
-        "val" : "Microbial ecophysiological trait and phenotype ontology"
+        "val" : "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible."
       }, {
         "pred" : "http://purl.org/dc/terms/issued",
         "val" : "2024-01-01"
@@ -16,23 +19,8267 @@
         "val" : "https://creativecommons.org/licenses/by/4.0/"
       }, {
         "pred" : "http://purl.org/dc/terms/modified",
-        "val" : "2025-09-29"
+        "val" : "2026-05-18"
       }, {
         "pred" : "http://purl.org/dc/terms/title",
-        "val" : "METPO"
+        "val" : "METPO: Microbial Ecophysiological Trait and Phenotype Ontology"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://bioportal.bioontology.org/ontologies/METPO"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://bioregistry.io/registry/metpo"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://github.com/berkeleybop/metpo"
       }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-03-24"
+        "val" : "2026-05-19"
       } ],
-      "version" : "https://w3id.org/metpo/metpo/releases/2026-03-24/metpo-full.json"
+      "version" : "https://w3id.org/metpo/metpo/releases/2026-05-19/metpo-full.json"
     },
     "nodes" : [ {
+      "id" : "https://w3id.org/metpo/0000001",
+      "lbl" : "obsolete Temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000002",
+      "lbl" : "obsolete Salinity",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000003",
+      "lbl" : "obsolete pH",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000004",
+      "lbl" : "obsolete Oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000005",
+      "lbl" : "obsolete Trophic type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000006",
+      "lbl" : "obsolete Motility",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000007",
+      "lbl" : "obsolete Sporulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000008",
+      "lbl" : "obsolete Pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000009",
+      "lbl" : "obsolete GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000001",
+      "lbl" : "obsolete Temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000010",
+      "lbl" : "obsolete Cell Width",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000011",
+      "lbl" : "obsolete Cell Length",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000012",
+      "lbl" : "obsolete Temperature Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000013",
+      "lbl" : "obsolete Temperature Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000014",
+      "lbl" : "obsolete pH Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000015",
+      "lbl" : "obsolete pH Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000016",
+      "lbl" : "obsolete NaCl Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000017",
+      "lbl" : "obsolete NaCl Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000018",
+      "lbl" : "obsolete pH delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000019",
+      "lbl" : "obsolete NaCl delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000002",
+      "lbl" : "obsolete Salinity",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000020",
+      "lbl" : "obsolete Temperature Delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000021",
+      "lbl" : "obsolete METPO Morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000022",
+      "lbl" : "obsolete Psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000023",
+      "lbl" : "obsolete Psychrotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000024",
+      "lbl" : "obsolete Mesophilie",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000025",
+      "lbl" : "obsolete Thermotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000026",
+      "lbl" : "obsolete Thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000027",
+      "lbl" : "obsolete Extreme thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000028",
+      "lbl" : "obsolete Hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000029",
+      "lbl" : "obsolete Extreme hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000003",
+      "lbl" : "obsolete pH",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000030",
+      "lbl" : "obsolete Halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000031",
+      "lbl" : "obsolete Non-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000032",
+      "lbl" : "obsolete Slight halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000033",
+      "lbl" : "obsolete Moderate halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000034",
+      "lbl" : "obsolete Extreme halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000035",
+      "lbl" : "obsolete Halotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000036",
+      "lbl" : "obsolete Haloalkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000037",
+      "lbl" : "obsolete Extreme Acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000038",
+      "lbl" : "obsolete Acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000039",
+      "lbl" : "obsolete Neutrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000004",
+      "lbl" : "obsolete Oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000040",
+      "lbl" : "obsolete Alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000041",
+      "lbl" : "obsolete Acid Tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000042",
+      "lbl" : "obsolete Alkali Tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000043",
+      "lbl" : "obsolete Extreme Alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000044",
+      "lbl" : "obsolete Facultative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000045",
+      "lbl" : "obsolete Obligative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000046",
+      "lbl" : "obsolete Aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000047",
+      "lbl" : "obsolete Anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000048",
+      "lbl" : "obsolete Facultative anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000049",
+      "lbl" : "obsolete Facultative aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000005",
+      "lbl" : "obsolete Trophic type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000050",
+      "lbl" : "obsolete Microaerophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000051",
+      "lbl" : "obsolete Aerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000052",
+      "lbl" : "obsolete Microaerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000053",
+      "lbl" : "obsolete Aerotolerant anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000054",
+      "lbl" : "obsolete Obligate aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000055",
+      "lbl" : "obsolete Obligate anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000056",
+      "lbl" : "obsolete Oxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000057",
+      "lbl" : "obsolete Anoxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000058",
+      "lbl" : "obsolete Autotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000059",
+      "lbl" : "obsolete Photoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000006",
+      "lbl" : "obsolete Motility",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000060",
+      "lbl" : "obsolete Chemoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000061",
+      "lbl" : "obsolete Heterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000062",
+      "lbl" : "obsolete Photoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000063",
+      "lbl" : "obsolete Chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000064",
+      "lbl" : "obsolete Lithotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000065",
+      "lbl" : "obsolete Organotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000066",
+      "lbl" : "obsolete Phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000067",
+      "lbl" : "obsolete Chemotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000068",
+      "lbl" : "obsolete Oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000069",
+      "lbl" : "obsolete Copiotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000007",
+      "lbl" : "obsolete Sporulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000070",
+      "lbl" : "obsolete Lithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000071",
+      "lbl" : "obsolete Mixotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000072",
+      "lbl" : "obsolete Lithoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000073",
+      "lbl" : "obsolete Chemoorganoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000074",
+      "lbl" : "obsolete Chemolithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000075",
+      "lbl" : "obsolete Methylotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000076",
+      "lbl" : "obsolete Methanotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000077",
+      "lbl" : "obsolete Carboxydotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000078",
+      "lbl" : "obsolete Hydrogenotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000079",
+      "lbl" : "obsolete Hydrogen oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000008",
+      "lbl" : "obsolete Pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000080",
+      "lbl" : "obsolete Hydrogen producer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000081",
+      "lbl" : "obsolete Nitrogen fixer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000082",
+      "lbl" : "obsolete Methanogen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000083",
+      "lbl" : "obsolete Sulfate reducer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000084",
+      "lbl" : "obsolete Sulfur oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000085",
+      "lbl" : "obsolete Denitrifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000086",
+      "lbl" : "obsolete Capnophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000087",
+      "lbl" : "obsolete Motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000088",
+      "lbl" : "obsolete Non-motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000089",
+      "lbl" : "obsolete Flagellated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000009",
+      "lbl" : "obsolete GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000090",
+      "lbl" : "obsolete Peritrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000091",
+      "lbl" : "obsolete Lophotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000092",
+      "lbl" : "obsolete Monotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000093",
+      "lbl" : "obsolete Ciliated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000094",
+      "lbl" : "obsolete Gliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000095",
+      "lbl" : "obsolete Twitching",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000096",
+      "lbl" : "obsolete Sliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000097",
+      "lbl" : "obsolete Swarming",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000098",
+      "lbl" : "obsolete Endospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000099",
+      "lbl" : "obsolete Exospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000010",
+      "lbl" : "obsolete Cell Width",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000100",
+      "lbl" : "obsolete Myxospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000101",
+      "lbl" : "obsolete Arthrospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000102",
+      "lbl" : "obsolete Conidia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000103",
+      "lbl" : "obsolete Sporangiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000104",
+      "lbl" : "obsolete Zygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000105",
+      "lbl" : "obsolete Akinetes",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000106",
+      "lbl" : "obsolete Chlamydospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000107",
+      "lbl" : "obsolete Sporocysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000108",
+      "lbl" : "obsolete Hypnospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000109",
+      "lbl" : "obsolete Gemmae",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000011",
+      "lbl" : "obsolete Cell Length",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000110",
+      "lbl" : "obsolete Oospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000111",
+      "lbl" : "obsolete Azygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000112",
+      "lbl" : "obsolete Cysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000113",
+      "lbl" : "obsolete Ascospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000114",
+      "lbl" : "obsolete Basidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000115",
+      "lbl" : "obsolete Aleuriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000116",
+      "lbl" : "obsolete Stylospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000117",
+      "lbl" : "obsolete Sclerotia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000118",
+      "lbl" : "obsolete Zoospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000119",
+      "lbl" : "obsolete Teliospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000012",
+      "lbl" : "obsolete Temperature Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000120",
+      "lbl" : "obsolete Urediniospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000121",
+      "lbl" : "obsolete Pycnidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000122",
+      "lbl" : "obsolete Acriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000123",
+      "lbl" : "obsolete Aplanospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000124",
+      "lbl" : "obsolete Statismospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000125",
+      "lbl" : "obsolete Barotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000126",
+      "lbl" : "obsolete Piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000127",
+      "lbl" : "obsolete Piezotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000128",
+      "lbl" : "obsolete Piezosensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000129",
+      "lbl" : "obsolete Obligate barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000013",
+      "lbl" : "obsolete Temperature Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000130",
+      "lbl" : "obsolete Facultative barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000131",
+      "lbl" : "obsolete Hyperbarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000132",
+      "lbl" : "obsolete Hypobarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000133",
+      "lbl" : "obsolete Atmospheric pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000134",
+      "lbl" : "obsolete Moderate piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000135",
+      "lbl" : "obsolete Extreme piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000136",
+      "lbl" : "obsolete Stenopiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000137",
+      "lbl" : "obsolete Eurypiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000138",
+      "lbl" : "obsolete Pressure-sensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000139",
+      "lbl" : "obsolete Pressure-resistant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000014",
+      "lbl" : "obsolete pH Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000140",
+      "lbl" : "obsolete Pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000141",
+      "lbl" : "obsolete Piezo-acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000142",
+      "lbl" : "obsolete Piezo-alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000143",
+      "lbl" : "obsolete Piezo-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000144",
+      "lbl" : "obsolete Piezo-psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000145",
+      "lbl" : "obsolete Piezo-thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000146",
+      "lbl" : "obsolete Piezo-lithoautotrophe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000147",
+      "lbl" : "obsolete Piezo-chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000148",
+      "lbl" : "obsolete Piezo-oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000149",
+      "lbl" : "obsolete Piezo-endolithic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000015",
+      "lbl" : "obsolete pH Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000150",
+      "lbl" : "obsolete Piezo-tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000151",
+      "lbl" : "obsolete GC low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000152",
+      "lbl" : "obsolete GC mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000153",
+      "lbl" : "obsolete GC mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000154",
+      "lbl" : "obsolete GC high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000155",
+      "lbl" : "obsolete Cell width very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000156",
+      "lbl" : "obsolete Cell width low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000157",
+      "lbl" : "obsolete Cell width mid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000158",
+      "lbl" : "obsolete Cell width high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000159",
+      "lbl" : "obsolete Cell length very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000016",
+      "lbl" : "obsolete NaCl Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000160",
+      "lbl" : "obsolete Cell length low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000161",
+      "lbl" : "obsolete Cell length mid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000162",
+      "lbl" : "obsolete Cell length high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000163",
+      "lbl" : "obsolete Temperature Optimum very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000164",
+      "lbl" : "obsolete Temperature Optimum low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000165",
+      "lbl" : "obsolete Temperature Optimum mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000166",
+      "lbl" : "obsolete Temperature Optimum mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000167",
+      "lbl" : "obsolete Temperature Optimum mid3",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000168",
+      "lbl" : "obsolete Temperature Optimum mid4",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000169",
+      "lbl" : "obsolete Temperature Optimum high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000017",
+      "lbl" : "obsolete NaCl Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000170",
+      "lbl" : "obsolete Temperature Range very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000171",
+      "lbl" : "obsolete Temperature Range low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000172",
+      "lbl" : "obsolete Temperature Range mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000173",
+      "lbl" : "obsolete Temperature Range mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000174",
+      "lbl" : "obsolete Temperature Range mid3",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000175",
+      "lbl" : "obsolete Temperature Range mid4",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000176",
+      "lbl" : "obsolete Temperature Range high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000177",
+      "lbl" : "obsolete pH Optimum low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000178",
+      "lbl" : "obsolete pH Optimum mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000179",
+      "lbl" : "obsolete pH Optimum mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000018",
+      "lbl" : "obsolete pH delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000180",
+      "lbl" : "obsolete pH Optimum high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000181",
+      "lbl" : "obsolete pH Range very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000182",
+      "lbl" : "obsolete pH Range low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000183",
+      "lbl" : "obsolete pH Range mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000184",
+      "lbl" : "obsolete pH Range mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000185",
+      "lbl" : "obsolete pH Range mid3",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000186",
+      "lbl" : "obsolete pH Range high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000187",
+      "lbl" : "obsolete NaCl Optimum low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000188",
+      "lbl" : "obsolete NaCl Optimum mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000189",
+      "lbl" : "obsolete NaCl Optimum mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000019",
+      "lbl" : "obsolete NaCl delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000190",
+      "lbl" : "obsolete NaCl Optimum high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000191",
+      "lbl" : "obsolete NaCl Range low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000192",
+      "lbl" : "obsolete NaCl Range mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000193",
+      "lbl" : "obsolete NaCl Range mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000194",
+      "lbl" : "obsolete NaCl Range high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000195",
+      "lbl" : "obsolete pH Delta very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000196",
+      "lbl" : "obsolete pH Delta low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000197",
+      "lbl" : "obsolete pH Delta mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000198",
+      "lbl" : "obsolete pH Delta mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000199",
+      "lbl" : "obsolete pH Delta mid3",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000020",
+      "lbl" : "obsolete Temperature Delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000200",
+      "lbl" : "obsolete pH Delta high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000201",
+      "lbl" : "obsolete NaCl Delta low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000202",
+      "lbl" : "obsolete NaCl Delta mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000203",
+      "lbl" : "obsolete NaCl Delta mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000204",
+      "lbl" : "obsolete NaCl Delta high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000205",
+      "lbl" : "obsolete Temperature Delta very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000206",
+      "lbl" : "obsolete Temperature Delta low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000207",
+      "lbl" : "obsolete Temperature Delta mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000208",
+      "lbl" : "obsolete Temperature Delta mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000209",
+      "lbl" : "obsolete Temperature Delta high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000021",
+      "lbl" : "obsolete Morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000210",
+      "lbl" : "obsolete Bacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000211",
+      "lbl" : "obsolete Branced",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000212",
+      "lbl" : "obsolete Coccobacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000213",
+      "lbl" : "obsolete Coccus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000214",
+      "lbl" : "obsolete Crescent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000215",
+      "lbl" : "obsolete Curved",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000216",
+      "lbl" : "obsolete Curved Spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000217",
+      "lbl" : "obsolete Diplococcus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000218",
+      "lbl" : "obsolete Disc",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000219",
+      "lbl" : "obsolete Dumbbell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000022",
+      "lbl" : "obsolete Other",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000220",
+      "lbl" : "obsolete Ellipsoidal",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000221",
+      "lbl" : "obsolete Filament",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000222",
+      "lbl" : "obsolete Flask",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000223",
+      "lbl" : "obsolete Fusiform",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000224",
+      "lbl" : "obsolete Helical",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000225",
+      "lbl" : "obsolete Irregular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000226",
+      "lbl" : "obsolete Oval",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000227",
+      "lbl" : "obsolete Ovoid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000228",
+      "lbl" : "obsolete Pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000229",
+      "lbl" : "obsolete Ring",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000023",
+      "lbl" : "obsolete Psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000230",
+      "lbl" : "obsolete Rod",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000231",
+      "lbl" : "obsolete Sphere",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000232",
+      "lbl" : "obsolete Spindle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000233",
+      "lbl" : "obsolete Spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000234",
+      "lbl" : "obsolete Spirochete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000235",
+      "lbl" : "obsolete Spore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000236",
+      "lbl" : "obsolete Square",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000237",
+      "lbl" : "obsolete Star",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000238",
+      "lbl" : "obsolete Star - Dumbbell - Pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000239",
+      "lbl" : "obsolete Tailed",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000024",
+      "lbl" : "obsolete Psychrotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000240",
+      "lbl" : "obsolete Triangular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000241",
+      "lbl" : "obsolete Vibrio",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000242",
+      "lbl" : "obsolete Environmental Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000243",
+      "lbl" : "obsolete Growth Condition",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000244",
+      "lbl" : "obsolete Physiological Trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000245",
+      "lbl" : "obsolete Metabolic Classification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000246",
+      "lbl" : "obsolete Cellular Characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000247",
+      "lbl" : "obsolete Taxonomic Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000248",
+      "lbl" : "obsolete Microbial Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000249",
+      "lbl" : "obsolete Growth Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000025",
+      "lbl" : "obsolete Mesophilie",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000250",
+      "lbl" : "obsolete Structural Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000251",
+      "lbl" : "obsolete Temperature Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000252",
+      "lbl" : "obsolete Salinity Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000253",
+      "lbl" : "obsolete pH Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000254",
+      "lbl" : "obsolete Oxygen Requirement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000255",
+      "lbl" : "obsolete Carbon Source Utilization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000256",
+      "lbl" : "obsolete Energy Acquisition Mode",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000257",
+      "lbl" : "obsolete Electron Donor Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000258",
+      "lbl" : "obsolete Motility Mechanism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000259",
+      "lbl" : "obsolete Motility Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000026",
+      "lbl" : "obsolete Thermotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000260",
+      "lbl" : "obsolete Bacterial Spore Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000261",
+      "lbl" : "obsolete Fungal Spore Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000262",
+      "lbl" : "obsolete Reproductive Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000263",
+      "lbl" : "obsolete Dormancy Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000264",
+      "lbl" : "obsolete Pressure Adaptation Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000265",
+      "lbl" : "obsolete Pressure Tolerance Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000266",
+      "lbl" : "obsolete Genomic Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000267",
+      "lbl" : "obsolete Cell Dimension",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000268",
+      "lbl" : "obsolete Optimal Growth Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000269",
+      "lbl" : "obsolete Growth Range Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000027",
+      "lbl" : "obsolete Thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000270",
+      "lbl" : "obsolete Growth Tolerance Metric",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000271",
+      "lbl" : "obsolete Cell Shape",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000272",
+      "lbl" : "obsolete Cell Arrangement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000273",
+      "lbl" : "obsolete Colony Morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000274",
+      "lbl" : "obsolete Physical Property",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000275",
+      "lbl" : "obsolete Environmental Context",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000276",
+      "lbl" : "obsolete Biological Property",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000277",
+      "lbl" : "obsolete Functional Classification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000278",
+      "lbl" : "obsolete Classification Property",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000279",
+      "lbl" : "obsolete METPO Biological Process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000028",
+      "lbl" : "obsolete Extreme thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000280",
+      "lbl" : "obsolete Measurable Property",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000281",
+      "lbl" : "obsolete Gram-stain negative",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000282",
+      "lbl" : "obsolete Gram-stain positive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000029",
+      "lbl" : "obsolete Hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000030",
+      "lbl" : "obsolete Extreme hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000031",
+      "lbl" : "obsolete Halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000032",
+      "lbl" : "obsolete Non-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000033",
+      "lbl" : "obsolete Slight halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000034",
+      "lbl" : "obsolete Moderate halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000035",
+      "lbl" : "obsolete Extreme halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000036",
+      "lbl" : "obsolete Halotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000037",
+      "lbl" : "obsolete Haloalkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000038",
+      "lbl" : "obsolete Extreme Acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000039",
+      "lbl" : "obsolete Acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000040",
+      "lbl" : "obsolete Neutrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000041",
+      "lbl" : "obsolete Alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000042",
+      "lbl" : "obsolete Acid Tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000043",
+      "lbl" : "obsolete Alkali Tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000044",
+      "lbl" : "obsolete Extreme Alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000045",
+      "lbl" : "obsolete Facultative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000046",
+      "lbl" : "obsolete Obligative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000047",
+      "lbl" : "obsolete Aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000048",
+      "lbl" : "obsolete Anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000049",
+      "lbl" : "obsolete Facultative anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000050",
+      "lbl" : "obsolete Facultative aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000051",
+      "lbl" : "obsolete Microaerophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000052",
+      "lbl" : "obsolete Aerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000053",
+      "lbl" : "obsolete Microaerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000054",
+      "lbl" : "obsolete Aerotolerant anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000055",
+      "lbl" : "obsolete Obligate aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000056",
+      "lbl" : "obsolete Obligate anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000057",
+      "lbl" : "obsolete Oxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000058",
+      "lbl" : "obsolete Anoxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000059",
+      "lbl" : "obsolete Autotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000060",
+      "lbl" : "obsolete Photoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000061",
+      "lbl" : "obsolete Chemoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000062",
+      "lbl" : "obsolete Heterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000063",
+      "lbl" : "obsolete Photoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000064",
+      "lbl" : "obsolete Chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000065",
+      "lbl" : "obsolete Lithotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000066",
+      "lbl" : "obsolete Organotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000067",
+      "lbl" : "obsolete Phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000068",
+      "lbl" : "obsolete Chemotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000069",
+      "lbl" : "obsolete Oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000070",
+      "lbl" : "obsolete Copiotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000071",
+      "lbl" : "obsolete Lithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000072",
+      "lbl" : "obsolete Mixotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000073",
+      "lbl" : "obsolete Lithoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000074",
+      "lbl" : "obsolete Chemoorganoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000075",
+      "lbl" : "obsolete Chemolithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000076",
+      "lbl" : "obsolete Methylotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000077",
+      "lbl" : "obsolete Methanotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000078",
+      "lbl" : "obsolete Carboxydotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000079",
+      "lbl" : "obsolete Hydrogenotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000080",
+      "lbl" : "obsolete Hydrogen oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000081",
+      "lbl" : "obsolete Hydrogen producer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000082",
+      "lbl" : "obsolete Nitrogen fixer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000083",
+      "lbl" : "obsolete Methanogen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000084",
+      "lbl" : "obsolete Sulfate reducer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000085",
+      "lbl" : "obsolete Sulfur oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000086",
+      "lbl" : "obsolete Denitrifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000087",
+      "lbl" : "obsolete Capnophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000088",
+      "lbl" : "obsolete Motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000089",
+      "lbl" : "obsolete Non-motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000090",
+      "lbl" : "obsolete Flagellated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000091",
+      "lbl" : "obsolete Peritrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000092",
+      "lbl" : "obsolete Lophotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000093",
+      "lbl" : "obsolete Monotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000094",
+      "lbl" : "obsolete Ciliated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000095",
+      "lbl" : "obsolete Gliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000096",
+      "lbl" : "obsolete Twitching",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000097",
+      "lbl" : "obsolete Sliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000098",
+      "lbl" : "obsolete Swarming",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000099",
+      "lbl" : "obsolete Endospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000100",
+      "lbl" : "obsolete Exospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001000",
+      "lbl" : "obsolete sensitivity to oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001001",
+      "lbl" : "obsolete sensitivity toward",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001002",
+      "lbl" : "obsolete 'organismal quality'",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001003",
+      "lbl" : "obsolete 'physicial object quality'",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001004",
+      "lbl" : "obsolete 'quality'",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001006",
+      "lbl" : "obsolete size",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001007",
+      "lbl" : "obsolete 1-D extent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001008",
+      "lbl" : "obsolete width",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001009",
+      "lbl" : "obsolete length",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000101",
+      "lbl" : "obsolete Myxospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001010",
+      "lbl" : "obsolete 'prokaryotic metabolically differentiated cell'",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001012",
+      "lbl" : "obsolete heterotrophy",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001013",
+      "lbl" : "obsolete structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001014",
+      "lbl" : "obsolete spore type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001016",
+      "lbl" : "obsolete sensitivity toward pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001017",
+      "lbl" : "obsolete sensitivity toward NaCl",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001018",
+      "lbl" : "obsolete sensitivity toward pH",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001019",
+      "lbl" : "obsolete sensitivity toward temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000102",
+      "lbl" : "obsolete Arthrospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001020",
+      "lbl" : "obsolete metabolic constraints",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001021",
+      "lbl" : "obsolete cell by chemical produced",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000103",
+      "lbl" : "obsolete Conidia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000104",
+      "lbl" : "obsolete Sporangiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000105",
+      "lbl" : "obsolete Zygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000106",
+      "lbl" : "obsolete Akinetes",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000107",
+      "lbl" : "obsolete Chlamydospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000108",
+      "lbl" : "obsolete Sporocysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000109",
+      "lbl" : "obsolete Hypnospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000110",
+      "lbl" : "obsolete Gemmae",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000111",
+      "lbl" : "obsolete Oospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000112",
+      "lbl" : "obsolete Azygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000113",
+      "lbl" : "obsolete Cysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000114",
+      "lbl" : "obsolete Ascospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000115",
+      "lbl" : "obsolete Basidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000116",
+      "lbl" : "obsolete Aleuriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000117",
+      "lbl" : "obsolete Stylospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000118",
+      "lbl" : "obsolete Sclerotia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000119",
+      "lbl" : "obsolete Zoospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000120",
+      "lbl" : "obsolete Teliospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000121",
+      "lbl" : "obsolete Urediniospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000122",
+      "lbl" : "obsolete Pycnidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000123",
+      "lbl" : "obsolete Acriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000124",
+      "lbl" : "obsolete Aplanospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000125",
+      "lbl" : "obsolete Statismospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000126",
+      "lbl" : "obsolete Barotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000127",
+      "lbl" : "obsolete Piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000128",
+      "lbl" : "obsolete Piezotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000129",
+      "lbl" : "obsolete Piezosensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000130",
+      "lbl" : "obsolete Obligate barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000131",
+      "lbl" : "obsolete Facultative barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000132",
+      "lbl" : "obsolete Hyperbarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000133",
+      "lbl" : "obsolete Hypobarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000134",
+      "lbl" : "obsolete Atmospheric pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000135",
+      "lbl" : "obsolete Moderate piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000136",
+      "lbl" : "obsolete Extreme piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000137",
+      "lbl" : "obsolete Stenopiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000138",
+      "lbl" : "obsolete Eurypiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000139",
+      "lbl" : "obsolete Pressure-sensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000140",
+      "lbl" : "obsolete Pressure-resistant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000141",
+      "lbl" : "obsolete Pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000142",
+      "lbl" : "obsolete Piezo-acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000143",
+      "lbl" : "obsolete Piezo-alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000144",
+      "lbl" : "obsolete Piezo-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000145",
+      "lbl" : "obsolete Piezo-psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000146",
+      "lbl" : "obsolete Piezo-thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000147",
+      "lbl" : "obsolete Piezo-lithoautotrophe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000148",
+      "lbl" : "obsolete Piezo-chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000149",
+      "lbl" : "obsolete Piezo-oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000150",
+      "lbl" : "obsolete Piezo-endolithic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000151",
+      "lbl" : "obsolete Piezo-tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000152",
+      "lbl" : "obsolete GC% low ( < 42.65)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000153",
+      "lbl" : "obsolete GC% mid1 (42.65 - 57)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000154",
+      "lbl" : "obsolete GC% mid2 (57 - 66.3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000155",
+      "lbl" : "obsolete GC% high ( > 66.3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000156",
+      "lbl" : "obsolete Cell width uM very low (< 0.5)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000157",
+      "lbl" : "obsolete Cell width uM low (0.5 - 0.65)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000158",
+      "lbl" : "obsolete Cell width uM mid (0.65 - 0.9)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000159",
+      "lbl" : "obsolete Cell width uM high (> 0.9)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000160",
+      "lbl" : "obsolete Cell length uM very low (<= 1.3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000161",
+      "lbl" : "obsolete Cell length uM low (1.3 - 2)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000162",
+      "lbl" : "obsolete Cell length uM mid (2 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000163",
+      "lbl" : "obsolete Cell length uM high (> 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000164",
+      "lbl" : "obsolete Temperature Optimum C very low (<= 10)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000165",
+      "lbl" : "obsolete Temperature Optimum C low (10 - 22)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000166",
+      "lbl" : "obsolete Temperature Optimum C mid1 (22 - 27)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000167",
+      "lbl" : "obsolete Temperature Optimum C mid2 (27 - 30)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000168",
+      "lbl" : "obsolete Temperature Optimum C mid3 (30 - 34)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000169",
+      "lbl" : "obsolete Temperature Optimum C mid4 (34 - 40)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000170",
+      "lbl" : "obsolete Temperature Optimum C high (> 40)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000171",
+      "lbl" : "obsolete Temperature Range C very low (<= 10)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000172",
+      "lbl" : "obsolete Temperature Range C low (10 - 22)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000173",
+      "lbl" : "obsolete Temperature Range C mid1 (22 - 27)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000174",
+      "lbl" : "obsolete Temperature Range C mid2 (27 - 30)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000175",
+      "lbl" : "obsolete Temperature Range C mid3 (30 - 34)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000176",
+      "lbl" : "obsolete Temperature Range C mid4 (34 - 40)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000177",
+      "lbl" : "obsolete Temperature Range C high (> 40)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000178",
+      "lbl" : "obsolete pH Optimum low (0 - 6)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000179",
+      "lbl" : "obsolete pH Optimum mid1 (6 - 7)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000180",
+      "lbl" : "obsolete pH Optimum mid2 (7 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000181",
+      "lbl" : "obsolete pH Optimum high (8 - 14)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000182",
+      "lbl" : "obsolete pH Range very low (0 - 4)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000183",
+      "lbl" : "obsolete pH Range low (4 - 6)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000184",
+      "lbl" : "obsolete pH Range mid1 (6 - 7)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000185",
+      "lbl" : "obsolete pH Range mid2 (7 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000186",
+      "lbl" : "obsolete pH Range mid3 (8 - 10)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000187",
+      "lbl" : "obsolete pH Range high (10 - 14)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000188",
+      "lbl" : "obsolete % NaCl Optimum low (<= 1)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000189",
+      "lbl" : "obsolete % NaCl Optimum mid1 (1 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000190",
+      "lbl" : "obsolete % NaCl Optimum mid2 (3 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000191",
+      "lbl" : "obsolete % NaCl Optimum high (> 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000192",
+      "lbl" : "obsolete % NaCl Range low (<= 1)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000193",
+      "lbl" : "obsolete % NaCl Range mid1 (1 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000194",
+      "lbl" : "obsolete % NaCl Range mid2 (3 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000195",
+      "lbl" : "obsolete % NaCl Range high (> 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000196",
+      "lbl" : "obsolete pH delta very low (<= 1)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000197",
+      "lbl" : "obsolete pH delta low (1 - 2)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000198",
+      "lbl" : "obsolete pH delta mid1 (2 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000199",
+      "lbl" : "obsolete pH delta mid2 (3 - 4)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000200",
+      "lbl" : "obsolete pH delta mid3 (4 - 5)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000201",
+      "lbl" : "obsolete pH delta high (5 - 9)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000202",
+      "lbl" : "obsolete % NaCl delta low (<= 1)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000203",
+      "lbl" : "obsolete % NaCl delta mid2 (1 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000204",
+      "lbl" : "obsolete % NaCl delta mid2 (3 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000205",
+      "lbl" : "obsolete % NaCl delta high (>= 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000206",
+      "lbl" : "obsolete Temperature C delta very low (1 - 5)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000207",
+      "lbl" : "obsolete Temperature C delta low (5 - 10)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000208",
+      "lbl" : "obsolete Temperature C delta mid1 (10 - 20)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000209",
+      "lbl" : "obsolete Temperature C delta mid2 (20 - 30)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000210",
+      "lbl" : "obsolete Temperature C delta high (>= 30)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000211",
+      "lbl" : "obsolete bacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000212",
+      "lbl" : "obsolete branced",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000213",
+      "lbl" : "obsolete coccobacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000214",
+      "lbl" : "obsolete coccus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000215",
+      "lbl" : "obsolete crescent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000216",
+      "lbl" : "obsolete curved",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000217",
+      "lbl" : "obsolete curved spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000218",
+      "lbl" : "obsolete diplococcus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000219",
+      "lbl" : "obsolete disc",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000220",
+      "lbl" : "obsolete dumbbell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000221",
+      "lbl" : "obsolete ellipsoidal",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000222",
+      "lbl" : "obsolete filament",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000223",
+      "lbl" : "obsolete flask",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000224",
+      "lbl" : "obsolete fusiform",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000225",
+      "lbl" : "obsolete helical",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000226",
+      "lbl" : "obsolete irregular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000227",
+      "lbl" : "obsolete oval",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000228",
+      "lbl" : "obsolete ovoid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000229",
+      "lbl" : "obsolete pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000230",
+      "lbl" : "obsolete ring",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000231",
+      "lbl" : "obsolete rod",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000232",
+      "lbl" : "obsolete sphere",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000233",
+      "lbl" : "obsolete spindle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000234",
+      "lbl" : "obsolete spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000235",
+      "lbl" : "obsolete spirochete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000236",
+      "lbl" : "obsolete spore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000237",
+      "lbl" : "obsolete square",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000238",
+      "lbl" : "obsolete star",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000239",
+      "lbl" : "obsolete star - dumbbell - pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000240",
+      "lbl" : "obsolete tailed",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000241",
+      "lbl" : "obsolete triangular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000242",
+      "lbl" : "obsolete vibrio",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000243",
+      "lbl" : "obsolete Environmental Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000244",
+      "lbl" : "obsolete Growth Condition",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000245",
+      "lbl" : "obsolete Physiological Trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000246",
+      "lbl" : "obsolete Metabolic Classification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000247",
+      "lbl" : "obsolete Cellular Characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000248",
+      "lbl" : "obsolete Taxonomic Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000249",
+      "lbl" : "obsolete Microbial Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000250",
+      "lbl" : "obsolete Growth Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000251",
+      "lbl" : "obsolete Structural Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000252",
+      "lbl" : "obsolete Temperature Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000253",
+      "lbl" : "obsolete Salinity Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000254",
+      "lbl" : "obsolete pH Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000255",
+      "lbl" : "obsolete Oxygen Requirement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000256",
+      "lbl" : "obsolete Carbon Source Utilization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000257",
+      "lbl" : "obsolete Energy Acquisition Mode",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000258",
+      "lbl" : "obsolete Electron Donor Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000259",
+      "lbl" : "obsolete Motility Mechanism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000260",
+      "lbl" : "obsolete Motility Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000261",
+      "lbl" : "obsolete Bacterial Spore Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000262",
+      "lbl" : "obsolete Fungal Spore Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000263",
+      "lbl" : "obsolete Reproductive Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000264",
+      "lbl" : "obsolete Dormancy Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000265",
+      "lbl" : "obsolete Pressure Adaptation Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000266",
+      "lbl" : "obsolete Pressure Tolerance Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000267",
+      "lbl" : "obsolete GenomicFeature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000268",
+      "lbl" : "obsolete Cell Dimension",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000269",
+      "lbl" : "obsolete Optimal Growth Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000270",
+      "lbl" : "obsolete Growth Range Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000271",
+      "lbl" : "obsolete Growth Tolerance Metric",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000272",
+      "lbl" : "obsolete Cell Shape",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000273",
+      "lbl" : "obsolete Cell Arrangement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000274",
+      "lbl" : "obsolete Colony Morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000001",
+      "lbl" : "obsolete acid-fast",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000002",
+      "lbl" : "obsolete acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000003",
+      "lbl" : "obsolete active transport",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000004",
+      "lbl" : "obsolete adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000005",
+      "lbl" : "obsolete adaptive trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000006",
+      "lbl" : "obsolete adhesin",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000007",
+      "lbl" : "obsolete adhesion structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000008",
+      "lbl" : "obsolete aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000009",
+      "lbl" : "obsolete aerobic respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000010",
+      "lbl" : "obsolete aerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000011",
+      "lbl" : "obsolete aggregate",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000012",
+      "lbl" : "obsolete akinete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000013",
+      "lbl" : "obsolete alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000014",
+      "lbl" : "obsolete ammonification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000015",
+      "lbl" : "obsolete amylolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000016",
+      "lbl" : "obsolete anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000017",
+      "lbl" : "obsolete anaerobic respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000018",
+      "lbl" : "obsolete anoxygenic photosynthesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000019",
+      "lbl" : "obsolete antibiotic production",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000020",
+      "lbl" : "obsolete antibiotic resistance",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000021",
+      "lbl" : "obsolete antimicrobial resistance",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000022",
+      "lbl" : "obsolete appendage",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000023",
+      "lbl" : "obsolete arthrospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000024",
+      "lbl" : "obsolete ascospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000025",
+      "lbl" : "obsolete autotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000026",
+      "lbl" : "obsolete autotrophic process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000027",
+      "lbl" : "obsolete auxotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000028",
+      "lbl" : "obsolete axial filament",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000029",
+      "lbl" : "obsolete bacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000030",
+      "lbl" : "obsolete barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000031",
+      "lbl" : "obsolete barotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000032",
+      "lbl" : "obsolete basidiospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000033",
+      "lbl" : "obsolete binary fission",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000034",
+      "lbl" : "obsolete biofilm",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000035",
+      "lbl" : "obsolete biofilm component",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000036",
+      "lbl" : "obsolete biofilm formation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000037",
+      "lbl" : "obsolete biogeochemical cycling",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000038",
+      "lbl" : "obsolete bioluminescence",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000039",
+      "lbl" : "obsolete budding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000040",
+      "lbl" : "obsolete buoyancy structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000041",
+      "lbl" : "obsolete capnophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000042",
+      "lbl" : "obsolete capsule",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000043",
+      "lbl" : "obsolete carbon fixation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000044",
+      "lbl" : "obsolete carbon source",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000045",
+      "lbl" : "obsolete carboxydotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000046",
+      "lbl" : "obsolete cell arrangement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000047",
+      "lbl" : "obsolete cell envelope",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000048",
+      "lbl" : "obsolete cell length category",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000049",
+      "lbl" : "obsolete cell shape",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000050",
+      "lbl" : "obsolete cell size",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000051",
+      "lbl" : "obsolete cell wall characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000052",
+      "lbl" : "obsolete cell wall component",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000053",
+      "lbl" : "obsolete cell width category",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000054",
+      "lbl" : "obsolete cellular characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000055",
+      "lbl" : "obsolete cellular component",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000056",
+      "lbl" : "obsolete cellular process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000057",
+      "lbl" : "obsolete cellular product",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000058",
+      "lbl" : "obsolete cellulolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000059",
       "lbl" : "phenotype",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quality that differentiates specific instances of a species from other instances of the same species."
+          "val" : "A quality that differentiates specific instances of a species from other instances of the same species.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PHIPO_0000505"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -51,11 +8298,878 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A biological process that maintain life in an organism."
+          "val" : "A biological process that maintain life in an organism.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0008152"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/MetabolicProcess"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Anthea Guo"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000061",
+      "lbl" : "obsolete chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000062",
+      "lbl" : "obsolete chemotaxis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000063",
+      "lbl" : "obsolete chlamydospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000064",
+      "lbl" : "obsolete class",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000065",
+      "lbl" : "obsolete clinically relevant feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000066",
+      "lbl" : "obsolete coccus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000067",
+      "lbl" : "obsolete cold shock protein",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000068",
+      "lbl" : "obsolete cold shock response",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000069",
+      "lbl" : "obsolete colonization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000070",
+      "lbl" : "obsolete colony elevation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000071",
+      "lbl" : "obsolete colony margin",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000072",
+      "lbl" : "obsolete colony morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000073",
+      "lbl" : "obsolete colony texture",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000074",
+      "lbl" : "obsolete commensalism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000075",
+      "lbl" : "obsolete community behavior",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000076",
+      "lbl" : "obsolete community structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000077",
+      "lbl" : "obsolete compatible solute",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000078",
+      "lbl" : "obsolete competence",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000079",
+      "lbl" : "obsolete component",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000080",
+      "lbl" : "obsolete conidium",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000081",
+      "lbl" : "obsolete conjugation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000082",
+      "lbl" : "obsolete CRISPR",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000083",
+      "lbl" : "obsolete culturability",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000084",
+      "lbl" : "obsolete cyst",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000085",
+      "lbl" : "obsolete death phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000086",
+      "lbl" : "obsolete denitrification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000087",
+      "lbl" : "obsolete developmental process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000088",
+      "lbl" : "obsolete diagnostic enzyme",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000089",
+      "lbl" : "obsolete diagnostic feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000090",
+      "lbl" : "obsolete diazotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000091",
+      "lbl" : "obsolete differentiation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000092",
+      "lbl" : "obsolete dimorphism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000093",
+      "lbl" : "obsolete disc-shaped cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000094",
+      "lbl" : "obsolete domain",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000095",
+      "lbl" : "obsolete dormancy",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000096",
+      "lbl" : "obsolete dormancy structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000097",
+      "lbl" : "obsolete dumbbell-shaped cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000098",
+      "lbl" : "obsolete ecological niche",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000099",
+      "lbl" : "obsolete ecological process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000100",
+      "lbl" : "obsolete ecological trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000101",
+      "lbl" : "obsolete ectosymbiosis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000102",
+      "lbl" : "obsolete electron acceptor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000103",
+      "lbl" : "obsolete electron donor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000104",
+      "lbl" : "obsolete endospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000105",
+      "lbl" : "obsolete endosymbiosis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000106",
+      "lbl" : "obsolete energy metabolism process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000107",
+      "lbl" : "obsolete enzyme activity",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000108",
+      "lbl" : "obsolete epigenetic modification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000109",
+      "lbl" : "obsolete evolutionary process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000110",
+      "lbl" : "obsolete exospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000111",
+      "lbl" : "obsolete exponential phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000112",
+      "lbl" : "obsolete extracellular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000113",
+      "lbl" : "obsolete extracellular polysaccharide",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000114",
+      "lbl" : "obsolete extreme halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000115",
+      "lbl" : "obsolete extremophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000116",
+      "lbl" : "obsolete facultative",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000117",
+      "lbl" : "obsolete facultative anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000118",
+      "lbl" : "obsolete family",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000119",
+      "lbl" : "obsolete fastidious",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000120",
+      "lbl" : "obsolete fermentation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000121",
+      "lbl" : "obsolete filamentous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000122",
+      "lbl" : "obsolete fimbriae",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000123",
+      "lbl" : "obsolete flagellum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000124",
+      "lbl" : "obsolete flask-shaped cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000125",
+      "lbl" : "obsolete fungal spore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000126",
+      "lbl" : "obsolete gas vesicle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -64,15 +9178,781 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs."
+          "val" : "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/GCContent"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC percentage"
+          "val" : "GC percentage",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Luke Wang"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000128",
+      "lbl" : "obsolete high GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000129",
+      "lbl" : "obsolete low GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000130",
+      "lbl" : "obsolete lower-mid GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000131",
+      "lbl" : "obsolete upper-mid GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000132",
+      "lbl" : "obsolete generation time",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000133",
+      "lbl" : "obsolete genetic element",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000134",
+      "lbl" : "obsolete genetic exchange",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000135",
+      "lbl" : "obsolete genetic process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000136",
+      "lbl" : "obsolete genome size",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000137",
+      "lbl" : "obsolete genomic element",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000138",
+      "lbl" : "obsolete genomic island",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000139",
+      "lbl" : "obsolete genomic trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000140",
+      "lbl" : "obsolete genus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000141",
+      "lbl" : "obsolete gliding motility",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000142",
+      "lbl" : "obsolete global regulator",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000143",
+      "lbl" : "obsolete Gram-negative",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000144",
+      "lbl" : "obsolete Gram-positive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000145",
+      "lbl" : "obsolete Gram stain",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000146",
+      "lbl" : "obsolete growth characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000147",
+      "lbl" : "obsolete growth conditions constraints",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000148",
+      "lbl" : "obsolete growth pattern",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000149",
+      "lbl" : "obsolete growth rate",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000150",
+      "lbl" : "obsolete habitat",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000151",
+      "lbl" : "obsolete halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000152",
+      "lbl" : "obsolete halotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000153",
+      "lbl" : "obsolete heat shock protein",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000154",
+      "lbl" : "obsolete heat shock response",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000155",
+      "lbl" : "obsolete hemolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000156",
+      "lbl" : "obsolete heterocyst",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000157",
+      "lbl" : "obsolete heterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000158",
+      "lbl" : "obsolete holdfast",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000159",
+      "lbl" : "obsolete horizontal gene transfer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000160",
+      "lbl" : "obsolete hydrolase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000161",
+      "lbl" : "obsolete hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000162",
+      "lbl" : "obsolete inclusion body",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000163",
+      "lbl" : "obsolete infection",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000164",
+      "lbl" : "obsolete interaction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000165",
+      "lbl" : "obsolete interaction with a phage",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000166",
+      "lbl" : "obsolete interaction with an environment",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000167",
+      "lbl" : "obsolete interaction with host",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000168",
+      "lbl" : "obsolete interaction within a community",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000169",
+      "lbl" : "obsolete intracellular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000170",
+      "lbl" : "obsolete invasion",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000171",
+      "lbl" : "obsolete laboratory characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000172",
+      "lbl" : "obsolete lag phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000173",
+      "lbl" : "obsolete life cycle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000174",
+      "lbl" : "obsolete life cycle phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000175",
+      "lbl" : "obsolete lipolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000176",
+      "lbl" : "obsolete lipopolysaccharide",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000177",
+      "lbl" : "obsolete localization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000178",
+      "lbl" : "obsolete lysogeny",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000179",
+      "lbl" : "obsolete macroscopic trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000180",
+      "lbl" : "obsolete magnetotaxis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000181",
+      "lbl" : "obsolete mesophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000182",
+      "lbl" : "obsolete metabolic partner",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000183",
+      "lbl" : "obsolete metabolic trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000184",
+      "lbl" : "obsolete methanogenesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000185",
+      "lbl" : "obsolete methylation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -81,11 +9961,30 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An object or portion of a substance or mixture of substances that consists of matter"
+          "val" : "An object or portion of a substance or mixture of substances that consists of matter",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/BFO_0000040"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Anthea Guo"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000187",
+      "lbl" : "obsolete process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -98,9 +9997,1478 @@
         }
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000189",
+      "lbl" : "obsolete system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000190",
+      "lbl" : "obsolete microaerophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000191",
+      "lbl" : "obsolete mobile genetic element",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000192",
+      "lbl" : "obsolete moderate halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000193",
+      "lbl" : "obsolete morphological trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000194",
+      "lbl" : "obsolete motility process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000195",
+      "lbl" : "obsolete motility structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000196",
+      "lbl" : "obsolete mutualism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000197",
+      "lbl" : "obsolete mycolic acid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000198",
+      "lbl" : "obsolete mycorrhization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000199",
+      "lbl" : "obsolete neutrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000200",
+      "lbl" : "obsolete nitrification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000201",
+      "lbl" : "obsolete nitrogen fixation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000202",
+      "lbl" : "obsolete nodulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000203",
+      "lbl" : "obsolete nucleoid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000204",
+      "lbl" : "obsolete nutrient utilization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000205",
+      "lbl" : "obsolete obligate",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000206",
+      "lbl" : "obsolete obligate aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000207",
+      "lbl" : "obsolete obligate anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000208",
+      "lbl" : "obsolete oospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000209",
+      "lbl" : "obsolete order",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000210",
+      "lbl" : "obsolete microbe characterized by growth conditions",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000211",
+      "lbl" : "obsolete microbe characterized by nutritional requirement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000212",
+      "lbl" : "obsolete microbe characterized by product produced",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000213",
+      "lbl" : "obsolete microbe characterized by relation to oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000214",
+      "lbl" : "obsolete microbe characterized by relation to ph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000215",
+      "lbl" : "obsolete microbe characterized by relation to pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000216",
+      "lbl" : "obsolete microbe characterized by relation to salt concentration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000217",
+      "lbl" : "obsolete microbe characterized by relation to temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000218",
+      "lbl" : "obsolete microbe characterized by shape",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000219",
+      "lbl" : "obsolete microbe characterized by trophic type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000220",
+      "lbl" : "obsolete osmophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000221",
+      "lbl" : "obsolete osmoregulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000222",
+      "lbl" : "obsolete oxidative stress response",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000223",
+      "lbl" : "obsolete oxidoreductase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000224",
+      "lbl" : "obsolete oxygen requirement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000225",
+      "lbl" : "obsolete oxygenic photosynthesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000226",
+      "lbl" : "obsolete pan-genome",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000227",
+      "lbl" : "obsolete parasitism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000228",
+      "lbl" : "obsolete passive transport",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000229",
+      "lbl" : "obsolete pathogenicity",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000230",
+      "lbl" : "obsolete pathogenicity island",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000231",
+      "lbl" : "obsolete peptidoglycan",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000232",
       "lbl" : "pH delta",
       "type" : "CLASS"
+    }, {
+      "id" : "https://w3id.org/metpo/1000233",
+      "lbl" : "obsolete pH optimum (growth range)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000234",
+      "lbl" : "obsolete pH preference",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000235",
+      "lbl" : "obsolete pH range (growth tolerance)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000236",
+      "lbl" : "obsolete pH tolerance",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000237",
+      "lbl" : "obsolete phage defense",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000238",
+      "lbl" : "obsolete photoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000239",
+      "lbl" : "obsolete photoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000240",
+      "lbl" : "obsolete photosynthesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000241",
+      "lbl" : "obsolete phototaxis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000242",
+      "lbl" : "obsolete phylum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000243",
+      "lbl" : "obsolete physiological process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000244",
+      "lbl" : "obsolete physiological state",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000245",
+      "lbl" : "obsolete physiological trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000246",
+      "lbl" : "obsolete piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000247",
+      "lbl" : "obsolete pigment",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000248",
+      "lbl" : "obsolete pigmentation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000249",
+      "lbl" : "obsolete pilus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000250",
+      "lbl" : "obsolete plant growth promotion",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000251",
+      "lbl" : "obsolete plasmid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000252",
+      "lbl" : "obsolete pleomorphism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000253",
+      "lbl" : "obsolete process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000254",
+      "lbl" : "obsolete prophage",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000255",
+      "lbl" : "obsolete prostheca",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000256",
+      "lbl" : "obsolete protein synthesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000257",
+      "lbl" : "obsolete proteolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000258",
+      "lbl" : "obsolete prototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000259",
+      "lbl" : "obsolete psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000260",
+      "lbl" : "obsolete qualifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000261",
+      "lbl" : "obsolete quorum sensing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000262",
+      "lbl" : "obsolete regulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000263",
+      "lbl" : "obsolete regulatory mechanism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000264",
+      "lbl" : "obsolete reproductive process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000265",
+      "lbl" : "obsolete reproductive structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000266",
+      "lbl" : "obsolete resistance mechanism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000267",
+      "lbl" : "obsolete respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000268",
+      "lbl" : "obsolete restriction-modification system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000269",
+      "lbl" : "obsolete ribosome",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000270",
+      "lbl" : "obsolete S-layer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000271",
+      "lbl" : "obsolete salinity delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000272",
+      "lbl" : "obsolete salinity preference",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000273",
+      "lbl" : "obsolete secondary metabolite",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000274",
+      "lbl" : "obsolete secretion",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000275",
+      "lbl" : "obsolete secretion system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000276",
+      "lbl" : "obsolete sheathed",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000277",
+      "lbl" : "obsolete siderophore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000278",
+      "lbl" : "obsolete sigma factor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000279",
+      "lbl" : "obsolete signaling",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000280",
+      "lbl" : "obsolete slime layer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000281",
+      "lbl" : "obsolete specialized cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000282",
+      "lbl" : "obsolete species",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000283",
+      "lbl" : "obsolete spirillum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000284",
+      "lbl" : "obsolete spirochete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000285",
+      "lbl" : "obsolete sporangiospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000286",
+      "lbl" : "obsolete sporulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000287",
+      "lbl" : "obsolete square cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000288",
+      "lbl" : "obsolete stalk",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000289",
+      "lbl" : "obsolete star-shaped cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000290",
+      "lbl" : "obsolete stationary phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000291",
+      "lbl" : "obsolete storage structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000292",
+      "lbl" : "obsolete strain",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000293",
+      "lbl" : "obsolete stress response",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000294",
+      "lbl" : "obsolete structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000295",
+      "lbl" : "obsolete sulfate reducer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000296",
+      "lbl" : "obsolete swarming",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000297",
+      "lbl" : "obsolete symbiosis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000298",
+      "lbl" : "obsolete symbiotic process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000299",
+      "lbl" : "obsolete syntrophy",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000300",
+      "lbl" : "obsolete taxonomic identifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000301",
+      "lbl" : "obsolete taxonomic rank",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000302",
+      "lbl" : "obsolete teichoic acid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1000303",
       "lbl" : "temperature delta",
@@ -111,7 +11479,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction."
+          "val" : "A temperature phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/OptimumTemperature"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -119,9 +11493,334 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000305",
+      "lbl" : "obsolete temperature preference",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000306",
       "lbl" : "temperature range",
       "type" : "CLASS"
+    }, {
+      "id" : "https://w3id.org/metpo/1000307",
+      "lbl" : "obsolete thermal tolerance",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000308",
+      "lbl" : "obsolete thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000309",
+      "lbl" : "obsolete toxin",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000310",
+      "lbl" : "obsolete transcription factor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000311",
+      "lbl" : "obsolete transduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000312",
+      "lbl" : "obsolete transferase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000313",
+      "lbl" : "obsolete transformation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000314",
+      "lbl" : "obsolete transport system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000315",
+      "lbl" : "obsolete transposon",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000316",
+      "lbl" : "obsolete triangular cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000317",
+      "lbl" : "obsolete trichome",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000318",
+      "lbl" : "obsolete twitching motility",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000319",
+      "lbl" : "obsolete two-component system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000320",
+      "lbl" : "obsolete viable but non-culturable",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000321",
+      "lbl" : "obsolete vibrio",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000322",
+      "lbl" : "obsolete virulence",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000323",
+      "lbl" : "obsolete virulence factor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000324",
+      "lbl" : "obsolete virulence process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000325",
+      "lbl" : "obsolete xylanolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000326",
+      "lbl" : "obsolete zoospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000327",
+      "lbl" : "obsolete zygospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000328",
+      "lbl" : "obsolete pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000329",
+      "lbl" : "obsolete temperature optimum (metabolic activity)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000330",
+      "lbl" : "obsolete temperature range (metabolic viability)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1000331",
       "lbl" : "pH optimum",
@@ -147,7 +11846,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A salinity phenotype with numerical limits that supports the most efficient growth and reproduction of an organism."
+          "val" : "A salinity phenotype with numerical limits that supports the most efficient growth and reproduction of an organism.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/OptimumSalinity"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -169,13 +11874,1228 @@
       "lbl" : "NaCl delta",
       "type" : "CLASS"
     }, {
+      "id" : "https://w3id.org/metpo/1000336",
+      "lbl" : "obsolete psychrotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000337",
+      "lbl" : "obsolete thermotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000338",
+      "lbl" : "obsolete extreme thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000339",
+      "lbl" : "obsolete extreme hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000340",
+      "lbl" : "obsolete non-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000341",
+      "lbl" : "obsolete slight halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000342",
+      "lbl" : "obsolete haloalkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000343",
+      "lbl" : "obsolete extreme acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000344",
+      "lbl" : "obsolete acid tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000345",
+      "lbl" : "obsolete alkali tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000346",
+      "lbl" : "obsolete extreme alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000347",
+      "lbl" : "obsolete facultative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000348",
+      "lbl" : "obsolete obligative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000349",
+      "lbl" : "obsolete facultative aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000350",
+      "lbl" : "obsolete microaerophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000351",
+      "lbl" : "obsolete microaerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000352",
+      "lbl" : "obsolete aerotolerant anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000353",
+      "lbl" : "obsolete obligate aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000354",
+      "lbl" : "obsolete obligate anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000355",
+      "lbl" : "obsolete oxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000356",
+      "lbl" : "obsolete anoxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000357",
+      "lbl" : "obsolete chemoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000358",
+      "lbl" : "obsolete chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000359",
+      "lbl" : "obsolete lithotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000360",
+      "lbl" : "obsolete organotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000361",
+      "lbl" : "obsolete phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000362",
+      "lbl" : "obsolete chemotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000363",
+      "lbl" : "obsolete oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000364",
+      "lbl" : "obsolete copiotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000365",
+      "lbl" : "obsolete lithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000366",
+      "lbl" : "obsolete mixotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000367",
+      "lbl" : "obsolete lithoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000368",
+      "lbl" : "obsolete chemoorganoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000369",
+      "lbl" : "obsolete chemolithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000370",
+      "lbl" : "obsolete methylotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000371",
+      "lbl" : "obsolete methanotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000372",
+      "lbl" : "obsolete hydrogenotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000373",
+      "lbl" : "obsolete hydrogen oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000374",
+      "lbl" : "obsolete hydrogen producer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000375",
+      "lbl" : "obsolete nitrogen fixer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000376",
+      "lbl" : "obsolete methanogen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000377",
+      "lbl" : "obsolete sulfur oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000378",
+      "lbl" : "obsolete denitrifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000379",
+      "lbl" : "obsolete motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000380",
+      "lbl" : "obsolete non-motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000381",
+      "lbl" : "obsolete flagellated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000382",
+      "lbl" : "obsolete peritrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000383",
+      "lbl" : "obsolete lophotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000384",
+      "lbl" : "obsolete monotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000385",
+      "lbl" : "obsolete ciliated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000386",
+      "lbl" : "obsolete gliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000387",
+      "lbl" : "obsolete twitching",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000388",
+      "lbl" : "obsolete sliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000389",
+      "lbl" : "obsolete myxospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000390",
+      "lbl" : "obsolete conidia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000391",
+      "lbl" : "obsolete chlamydospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000392",
+      "lbl" : "obsolete sporocysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000393",
+      "lbl" : "obsolete hypnospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000394",
+      "lbl" : "obsolete gemmae",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000395",
+      "lbl" : "obsolete azygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000396",
+      "lbl" : "obsolete aleuriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000397",
+      "lbl" : "obsolete stylospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000398",
+      "lbl" : "obsolete sclerotia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000399",
+      "lbl" : "obsolete teliospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000400",
+      "lbl" : "obsolete urediniospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000401",
+      "lbl" : "obsolete pycnidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000402",
+      "lbl" : "obsolete acriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000403",
+      "lbl" : "obsolete aplanospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000404",
+      "lbl" : "obsolete statismospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000405",
+      "lbl" : "obsolete piezotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000406",
+      "lbl" : "obsolete piezosensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000407",
+      "lbl" : "obsolete obligate barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000408",
+      "lbl" : "obsolete facultative barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000409",
+      "lbl" : "obsolete hyperbarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000410",
+      "lbl" : "obsolete hypobarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000411",
+      "lbl" : "obsolete atmospheric pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000412",
+      "lbl" : "obsolete moderate piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000413",
+      "lbl" : "obsolete extreme piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000414",
+      "lbl" : "obsolete stenopiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000415",
+      "lbl" : "obsolete eurypiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000416",
+      "lbl" : "obsolete pressure-sensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000417",
+      "lbl" : "obsolete pressure-resistant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000418",
+      "lbl" : "obsolete pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000419",
+      "lbl" : "obsolete piezo-acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000420",
+      "lbl" : "obsolete piezo-alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000421",
+      "lbl" : "obsolete piezo-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000422",
+      "lbl" : "obsolete piezo-psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000423",
+      "lbl" : "obsolete piezo-thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000424",
+      "lbl" : "obsolete piezo-lithoautotrophe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000425",
+      "lbl" : "obsolete piezo-chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000426",
+      "lbl" : "obsolete piezo-oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000427",
+      "lbl" : "obsolete piezo-endolithic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000428",
+      "lbl" : "obsolete piezo-tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000429",
       "lbl" : "GC low",
       "type" : "CLASS",
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC_42.65_57.0"
+          "val" : "GC_42.65_57.0",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -189,7 +13109,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC_>66.3"
+          "val" : "GC_>66.3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -206,7 +13132,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC_57.0_66.3"
+          "val" : "GC_57.0_66.3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -223,11 +13155,121 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC_<=42.65"
+          "val" : "GC_<=42.65",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_min",
           "val" : "66.3"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000433",
+      "lbl" : "obsolete cell width very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000434",
+      "lbl" : "obsolete cell width low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000435",
+      "lbl" : "obsolete cell width mid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000436",
+      "lbl" : "obsolete cell width high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000437",
+      "lbl" : "obsolete cell length very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000438",
+      "lbl" : "obsolete cell length low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000439",
+      "lbl" : "obsolete cell length mid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000440",
+      "lbl" : "obsolete cell length high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -240,7 +13282,13 @@
           "val" : "Psychrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_<=10"
+          "val" : "TO_<=10",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -263,7 +13311,13 @@
           "val" : "Psychrotolerant"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_10_to_22"
+          "val" : "TO_10_to_22",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -283,10 +13337,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_22_to_27"
+          "val" : "TO_22_to_27",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -306,10 +13366,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_27_to_30"
+          "val" : "TO_27_to_30",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -329,10 +13395,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_30_to_34"
+          "val" : "TO_30_to_34",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -352,10 +13424,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_34_to_40"
+          "val" : "TO_34_to_40",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -378,7 +13456,13 @@
           "val" : "Thermophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_>40"
+          "val" : "TO_>40",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -398,7 +13482,13 @@
           "val" : "Psychrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_<=10"
+          "val" : "TR_<=10",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -421,7 +13511,13 @@
           "val" : "Psychrotolerant"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_10_to_22"
+          "val" : "TR_10_to_22",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -441,10 +13537,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_22_to_27"
+          "val" : "TR_22_to_27",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -464,10 +13566,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_27_to_30"
+          "val" : "TR_27_to_30",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -487,10 +13595,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_30_to_34"
+          "val" : "TR_30_to_34",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -510,10 +13624,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_34_to_40"
+          "val" : "TR_34_to_40",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -536,7 +13656,13 @@
           "val" : "Thermophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_>40"
+          "val" : "TR_>40",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -568,7 +13694,13 @@
           "val" : "Obligative acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHO_0_to_6"
+          "val" : "pHO_0_to_6",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -591,7 +13723,13 @@
           "val" : "Neutrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHO_6_to_7"
+          "val" : "pHO_6_to_7",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -617,7 +13755,13 @@
           "val" : "Neutrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHO_7_to_8"
+          "val" : "pHO_7_to_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -643,7 +13787,13 @@
           "val" : "Extreme Alkaliphile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHO_8_to_14"
+          "val" : "pHO_8_to_14",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -675,7 +13825,13 @@
           "val" : "Obligative acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_0_to_4"
+          "val" : "pHR_0_to_4",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -704,7 +13860,13 @@
           "val" : "Obligative acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_4_to_6"
+          "val" : "pHR_4_to_6",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -730,7 +13892,13 @@
           "val" : "Neutrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_6_to_7"
+          "val" : "pHR_6_to_7",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -759,7 +13927,13 @@
           "val" : "Neutrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_7_to_8"
+          "val" : "pHR_7_to_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -788,7 +13962,13 @@
           "val" : "Facultative acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_8_to_10"
+          "val" : "pHR_8_to_10",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -814,7 +13994,13 @@
           "val" : "Extreme Alkaliphile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "10_to_14"
+          "val" : "10_to_14",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -837,7 +14023,13 @@
           "val" : "Non-halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaO_<=1"
+          "val" : "NaO_<=1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -860,7 +14052,13 @@
           "val" : "Slight halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaO_1_to_3"
+          "val" : "NaO_1_to_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -886,7 +14084,13 @@
           "val" : "Moderate halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaO_3_to_8"
+          "val" : "NaO_3_to_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -909,7 +14113,13 @@
           "val" : "Extreme halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaO_>8"
+          "val" : "NaO_>8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -932,7 +14142,13 @@
           "val" : "Non-halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaR_<=1"
+          "val" : "NaR_<=1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -955,7 +14171,13 @@
           "val" : "Slight halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaR_1_to_3"
+          "val" : "NaR_1_to_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -981,7 +14203,13 @@
           "val" : "Moderate halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaR_3_to_8"
+          "val" : "NaR_3_to_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1004,7 +14232,13 @@
           "val" : "Extreme halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaR_>8"
+          "val" : "NaR_>8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1021,7 +14255,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_<=1"
+          "val" : "pHd_<=1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1035,7 +14275,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_1_2"
+          "val" : "pHd_1_2",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1052,7 +14298,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_2_3"
+          "val" : "pHd_2_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1069,7 +14321,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_3_4"
+          "val" : "pHd_3_4",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1086,7 +14344,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_4_5"
+          "val" : "pHd_4_5",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1103,7 +14367,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_5_9"
+          "val" : "pHd_5_9",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1120,7 +14390,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Nad_<=1"
+          "val" : "Nad_<=1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1137,7 +14413,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Nad_1_3"
+          "val" : "Nad_1_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1157,7 +14439,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Nad_3_8"
+          "val" : "Nad_3_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1177,7 +14465,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Nad_>8"
+          "val" : "Nad_>8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1194,7 +14488,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_1_5"
+          "val" : "Td_1_5",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1214,7 +14514,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_5_10"
+          "val" : "Td_5_10",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1234,7 +14540,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_10_20"
+          "val" : "Td_10_20",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1254,7 +14566,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_20_30"
+          "val" : "Td_20_30",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1274,7 +14592,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_>30"
+          "val" : "Td_>30",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1285,12 +14609,499 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000488",
+      "lbl" : "obsolete branched",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000489",
+      "lbl" : "obsolete coccobacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000490",
+      "lbl" : "obsolete crescent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000491",
+      "lbl" : "obsolete curved",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000492",
+      "lbl" : "obsolete curved spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000493",
+      "lbl" : "obsolete diplococcus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000494",
+      "lbl" : "obsolete ellipsoidal",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000495",
+      "lbl" : "obsolete filament",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000496",
+      "lbl" : "obsolete fusiform",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000497",
+      "lbl" : "obsolete helical",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000498",
+      "lbl" : "obsolete irregular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000499",
+      "lbl" : "obsolete oval",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000500",
+      "lbl" : "obsolete ovoid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000501",
+      "lbl" : "obsolete pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000502",
+      "lbl" : "obsolete ring",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000503",
+      "lbl" : "obsolete rod",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000504",
+      "lbl" : "obsolete sphere",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000505",
+      "lbl" : "obsolete spindle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000506",
+      "lbl" : "obsolete spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000507",
+      "lbl" : "obsolete star - dumbbell - pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000508",
+      "lbl" : "obsolete tailed",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000509",
+      "lbl" : "obsolete temperature adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000510",
+      "lbl" : "obsolete salinity adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000511",
+      "lbl" : "obsolete pH adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000512",
+      "lbl" : "obsolete bacterial spore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000513",
+      "lbl" : "obsolete pressure adaptation type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000514",
+      "lbl" : "obsolete pressure tolerance range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000515",
+      "lbl" : "obsolete sensitivity to oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000516",
+      "lbl" : "obsolete sensitivity toward",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000517",
+      "lbl" : "obsolete size",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000518",
+      "lbl" : "obsolete 1-D extent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000519",
+      "lbl" : "obsolete width",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000520",
+      "lbl" : "obsolete length",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000521",
+      "lbl" : "obsolete sensitivity toward pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000522",
+      "lbl" : "obsolete sensitivity toward nacl",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000523",
+      "lbl" : "obsolete sensitivity toward ph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000524",
+      "lbl" : "obsolete sensitivity toward temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000525",
       "lbl" : "microbe",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation."
+          "val" : "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OHMI_0000460"
+            } ]
+          }
         },
         "comments" : [ "METPO is primarily concerned with unicellular, prokaryotic life forms, i.e. bacteria and archaea, including the cases of giant bacteria like Thiomargarita" ],
         "basicPropertyValues" : [ {
@@ -1307,7 +15118,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A material entity that is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances."
+          "val" : "A material entity that is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/CHEBI_24431"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://www.w3.org/2004/02/skos/core#closeMatch",
@@ -1318,6 +15135,32 @@
       "id" : "https://w3id.org/metpo/1000527",
       "lbl" : "enzyme",
       "type" : "CLASS"
+    }, {
+      "id" : "https://w3id.org/metpo/1000528",
+      "lbl" : "obsolete structured susceptibility detail",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000529",
+      "lbl" : "obsolete facultative psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1000531",
       "lbl" : "pH phenotype with numerical limits",
@@ -1378,17 +15221,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that is relating to an organism's oxygen requirements or tolerance for growth."
+          "val" : "A phenotype that is relating to an organism's oxygen requirements or tolerance for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/UPHENO_0049673"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/OxygenTolerance"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.oxygen tolerance.oxygen tolerance"
+          "val" : "Physiology and metabolism.oxygen tolerance.oxygen tolerance",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "metabolism"
+          "val" : "metabolism",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxygen preference"
+          "val" : "oxygen preference",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1397,17 +15267,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which growth occurs in the presence of molecular oxygen (O₂), typically using O₂ as the terminal electron acceptor."
+          "val" : "An oxygen preference in which growth occurs in the presence of molecular oxygen (O₂), typically using O₂ as the terminal electron acceptor.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000173"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005253"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Ox_aerobic"
+          "val" : "Ox_aerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobe"
+          "val" : "aerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic"
+          "val" : "aerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1416,17 +15313,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which growth occurs in the absence of molecular oxygen (O₂)."
+          "val" : "An oxygen preference in which growth occurs in the absence of molecular oxygen (O₂).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000495"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Ox_anaerobic"
+          "val" : "Ox_anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobe"
+          "val" : "anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic"
+          "val" : "anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1435,17 +15356,47 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that requires molecular oxygen (O₂) at concentrations lower than atmospheric."
+          "val" : "An oxygen preference that requires molecular oxygen (O₂) at concentrations lower than atmospheric.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000180"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000515"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005254"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Ox_microerophile"
+          "val" : "Ox_microerophile",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "microaerophile"
+          "val" : "microaerophile",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "microaerophilic"
+          "val" : "microaerophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1454,17 +15405,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which growth can occur with or without molecular oxygen (O₂)."
+          "val" : "An oxygen preference in which growth can occur with or without molecular oxygen (O₂).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001520"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000087"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative"
+          "val" : "facultative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative anaerobe"
+          "val" : "facultative anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative anaerobe"
+          "val" : "facultative anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1473,17 +15451,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that requires molecular oxygen (O₂) for growth."
+          "val" : "An oxygen preference that requires molecular oxygen (O₂) for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000516"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate aerobe"
+          "val" : "obligate aerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate aerobic"
+          "val" : "obligate aerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate aerobic"
+          "val" : "obligate aerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1492,14 +15494,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which molecular oxygen (O₂) inhibits or prevents growth."
+          "val" : "An oxygen preference in which molecular oxygen (O₂) inhibits or prevents growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000504"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate anaerobe"
+          "val" : "obligate anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate anaerobic"
+          "val" : "obligate anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1508,14 +15528,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which growth can occur without oxygen but is capable of aerobic growth."
+          "val" : "An oxygen preference in which growth can occur without oxygen but is capable of aerobic growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000177"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000087"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative"
+          "val" : "facultative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative aerobe"
+          "val" : "facultative aerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1524,14 +15565,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that does not use O₂ for growth but tolerates its presence."
+          "val" : "An oxygen preference that does not use O₂ for growth but tolerates its presence.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000502"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerotolerant"
+          "val" : "aerotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerotolerant"
+          "val" : "aerotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1540,11 +15599,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that tolerates low levels of molecular oxygen (O₂) without requiring it."
+          "val" : "An oxygen preference that tolerates low levels of molecular oxygen (O₂) without requiring it.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000180"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000181"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000087"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000105"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "microaerotolerant"
+          "val" : "microaerotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1553,14 +15633,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An obligately anaerobic where a microorganism does not grow in the presence of oxygen gas (O2)."
+          "val" : "An obligately anaerobic where a microorganism does not grow in the presence of oxygen gas (O2).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000184"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate anaerobic"
+          "val" : "obligate anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "strictly anaerobic"
+          "val" : "strictly anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1569,11 +15667,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that describes a microorganism that can grow with or without molecular oxygen."
+          "val" : "An oxygen preference that describes a microorganism that can grow with or without molecular oxygen.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000087"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Ox_facultative_aerobe_anaerobe"
+          "val" : "Ox_facultative_aerobe_anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1582,17 +15692,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that describes characteristic growth with respect to environmental temperature."
+          "val" : "A phenotype that describes characteristic growth with respect to environmental temperature.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005002"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.culture temp.temperature"
+          "val" : "Physiology and metabolism.culture temp.temperature",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "range_tmp"
+          "val" : "range_tmp",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "temperature preference"
+          "val" : "temperature preference",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1601,17 +15735,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth is favored at low temperatures, typically near or below ~15 °C."
+          "val" : "A temperature preference in which growth is favored at low temperatures, typically near or below ~15 °C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001306"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "psychrophilic"
+          "val" : "psychrophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "psychrophilic"
+          "val" : "psychrophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "psychrophilic"
+          "val" : "psychrophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1620,14 +15778,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth is favored at intermediate temperatures, typically ~20–45 °C."
+          "val" : "A temperature preference in which growth is favored at intermediate temperatures, typically ~20–45 °C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "mesophilic"
+          "val" : "mesophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "mesophilic"
+          "val" : "mesophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1636,17 +15812,47 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth is favored at elevated temperatures, typically ≥45 °C."
+          "val" : "A temperature preference in which growth is favored at elevated temperatures, typically ≥45 °C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000118"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005003"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005004"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "thermophilic"
+          "val" : "thermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "thermophilic"
+          "val" : "thermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "thermophilic"
+          "val" : "thermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1655,14 +15861,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth is favored at very high temperatures, typically ≥80 °C."
+          "val" : "A temperature preference in which growth is favored at very high temperatures, typically ≥80 °C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001538"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "extreme thermophilic"
+          "val" : "extreme thermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "hyperthermophilic"
+          "val" : "hyperthermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1671,11 +15895,29 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth can occur at low temperatures without an obligate low-temperature preference."
+          "val" : "A temperature preference in which growth can occur at low temperatures without an obligate low-temperature preference.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001310"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005006"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005007"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "psychrotolerant"
+          "val" : "psychrotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1684,11 +15926,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth can occur at elevated temperatures without an obligate high-temperature preference."
+          "val" : "A temperature preference in which growth can occur at elevated temperatures without an obligate high-temperature preference.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001286"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "thermotolerant"
+          "val" : "thermotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1697,14 +15951,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism requires high concentrations of salt for growth and survival."
+          "val" : "A halophily preference in which an organism requires high concentrations of salt for growth and survival.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0170002"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001314"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001315"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "halophilic"
+          "val" : "halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "halophilic"
+          "val" : "halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1713,11 +15994,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism requires both high salt concentrations and alkaline pH for optimal growth."
+          "val" : "A halophily preference in which an organism requires both high salt concentrations and alkaline pH for optimal growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001314"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001392"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001554"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "haloalkaliphilic"
+          "val" : "haloalkaliphilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1726,14 +16028,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism can tolerate high salt concentrations but does not require them for growth."
+          "val" : "A halophily preference in which an organism can tolerate high salt concentrations but does not require them for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001316"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "halotolerant"
+          "val" : "halotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "halotolerant"
+          "val" : "halotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1742,14 +16062,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference where growth and proliferation requires high levels of sodium chloride, usually above or about 0.2 M."
+          "val" : "A halophily preference where growth and proliferation requires high levels of sodium chloride, usually above or about 0.2 M.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "moderate-halophilic"
+          "val" : "moderate-halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "moderately halophilic"
+          "val" : "moderately halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1766,10 +16104,22 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "non-halophilic"
+          "val" : "non-halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "non-halophilic"
+          "val" : "non-halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1778,11 +16128,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism requires low to moderate salt concentrations (0.3 to 0.8 M NaCl) for optimal growth."
+          "val" : "A halophily preference in which an organism requires low to moderate salt concentrations (0.3 to 0.8 M NaCl) for optimal growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "slightly halophilic"
+          "val" : "slightly halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1791,11 +16153,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism can only tolerate a narrow range of salinity concentrations and cannot survive significant changes in environmental salt levels."
+          "val" : "A halophily preference in which an organism can only tolerate a narrow range of salinity concentrations and cannot survive significant changes in environmental salt levels.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/SaltTolerance"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "stenohaline"
+          "val" : "stenohaline",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1815,7 +16189,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "euryhaline"
+          "val" : "euryhaline",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1824,14 +16204,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism requires very high salt concentrations (typically 15-30% NaCl or higher) for optimal growth and cannot grow at salt concentrations below approximately 12%."
+          "val" : "A halophily preference in which an organism requires very high salt concentrations (typically 15-30% NaCl or higher) for optimal growth and cannot grow at salt concentrations below approximately 12%.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001314"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "extreme-halophilic"
+          "val" : "extreme-halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "extremely halophilic"
+          "val" : "extremely halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1844,17 +16245,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that is relating to an organism's salt concentration requirements or tolerance for growth."
+          "val" : "A phenotype that is relating to an organism's salt concentration requirements or tolerance for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/SaltTolerance"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.halophily.halophily level"
+          "val" : "Physiology and metabolism.halophily.halophily level",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "range_salinity"
+          "val" : "range_salinity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "salinity preference"
+          "val" : "salinity preference",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1876,13 +16304,25 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.nutrition type.type"
+          "val" : "Physiology and metabolism.nutrition type.type",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
           "val" : "nutritional type"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pathways"
+          "val" : "pathways",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1895,17 +16335,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism produces organic compounds from inorganic carbon sources (primarily carbon dioxide or bicarbonate) using energy from light (photoautotrophy) or from the oxidation of inorganic compounds (chemoautotrophy)."
+          "val" : "A trophic type in which an organism produces organic compounds from inorganic carbon sources (primarily carbon dioxide or bicarbonate) using energy from light (photoautotrophy) or from the oxidation of inorganic compounds (chemoautotrophy).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001456"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_autotroph"
+          "val" : "TT_autotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "autotroph"
+          "val" : "autotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "autotrophy"
+          "val" : "autotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1927,11 +16394,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism uses chemical oxidation of inorganic compounds as the energy source and carbon dioxide as the primary carbon source for biosynthesis."
+          "val" : "A trophic type in which an organism uses chemical oxidation of inorganic compounds as the energy source and carbon dioxide as the primary carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000123"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000124"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000129"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoautolithotroph"
+          "val" : "chemoautolithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1944,11 +16435,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from oxidation of inorganic compounds and carbon from carbon dioxide."
+          "val" : "A trophic type in which an organism obtains energy from oxidation of inorganic compounds and carbon from carbon dioxide.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000123"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000129"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001480"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoautotroph"
+          "val" : "chemoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1957,14 +16472,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains both energy and carbon from organic compounds."
+          "val" : "A trophic type in which an organism obtains both energy and carbon from organic compounds.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000012"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000127"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000132"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic_chemo_heterotrophy"
+          "val" : "aerobic_chemo_heterotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoheterotroph"
+          "val" : "chemoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1973,11 +16518,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from oxidation of inorganic compounds (lithotrophy) and carbon from carbon dioxide."
+          "val" : "A trophic type in which an organism obtains energy from oxidation of inorganic compounds (lithotrophy) and carbon from carbon dioxide.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000511"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemolithoautotroph"
+          "val" : "chemolithoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1986,11 +16543,26 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of inorganic chemical compounds as electron donors for energy generation while utilizing organic compounds as the primary carbon source."
+          "val" : "A trophic type characterized by the use of inorganic chemical compounds as electron donors for energy generation while utilizing organic compounds as the primary carbon source.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000512"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001478"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemolithoheterotroph"
+          "val" : "chemolithoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2003,11 +16575,26 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of inorganic chemical compounds as electron donors and carbon dioxide as the primary carbon source for energy generation and biosynthesis."
+          "val" : "A trophic type characterized by the use of inorganic chemical compounds as electron donors and carbon dioxide as the primary carbon source for energy generation and biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001499"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemolithotroph"
+          "val" : "chemolithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2020,11 +16607,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains both energy and carbon from organic compounds through oxidation."
+          "val" : "A trophic type in which an organism obtains both energy and carbon from organic compounds through oxidation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000127"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000514"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001479"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001481"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoorganoheterotroph"
+          "val" : "chemoorganoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2033,14 +16644,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from chemical oxidation of either inorganic or organic compounds."
+          "val" : "A trophic type in which an organism obtains energy from chemical oxidation of either inorganic or organic compounds.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001458"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_chemotroph"
+          "val" : "TT_chemotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemotroph"
+          "val" : "chemotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2053,11 +16682,30 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "copiotroph"
+          "val" : "copiotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Jed Dongjin Kim-Ozaeta"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000643",
+      "lbl" : "obsolete denitrifying",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -2066,20 +16714,63 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide."
+          "val" : "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001474"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_heterotroph"
+          "val" : "TT_heterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic_heterotrophy"
+          "val" : "aerobic_heterotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "heterotroph"
+          "val" : "heterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "heterotrophic"
+          "val" : "heterotrophic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000645",
+      "lbl" : "obsolete hydrogen-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -2104,11 +16795,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from inorganic electron donors and carbon from carbon dioxide."
+          "val" : "A trophic type in which an organism obtains energy from inorganic electron donors and carbon from carbon dioxide.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000014"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000122"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001477"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001483"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "lithoautotroph"
+          "val" : "lithoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2117,11 +16832,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from the oxidation of inorganic compounds while using organic compounds as the primary carbon source for biosynthesis."
+          "val" : "A trophic type in which an organism obtains energy from the oxidation of inorganic compounds while using organic compounds as the primary carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000014"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000162"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001459"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001478"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "lithoheterotroph"
+          "val" : "lithoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2134,14 +16873,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism uses inorganic compounds as electron donors for energy generation."
+          "val" : "A trophic type in which an organism uses inorganic compounds as electron donors for energy generation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001459"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_lithotroph"
+          "val" : "TT_lithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "lithotroph"
+          "val" : "lithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2158,7 +16915,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "methanotroph"
+          "val" : "methanotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2175,13 +16938,31 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_methylotroph"
+          "val" : "TT_methylotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "methylotroph"
+          "val" : "methylotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "methylotrophy"
+          "val" : "methylotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2190,11 +16971,36 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism can use both organic and inorganic carbon sources for growth."
+          "val" : "A trophic type in which an organism can use both organic and inorganic carbon sources for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001475"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "mixotroph"
+          "val" : "mixotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000653",
+      "lbl" : "obsolete nitrogen-fixing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -2203,14 +17009,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A nutrient adaptation characterized by the ability to thrive in environments with very low nutrient concentrations, typically possessing efficient nutrient uptake and utilization systems."
+          "val" : "A nutrient adaptation characterized by the ability to thrive in environments with very low nutrient concentrations, typically possessing efficient nutrient uptake and utilization systems.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_00002223"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_01000774"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_oligotroph"
+          "val" : "TT_oligotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "oligotroph"
+          "val" : "oligotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2226,14 +17053,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from the oxidation of organic compounds."
+          "val" : "A trophic type in which an organism obtains energy from the oxidation of organic compounds.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000162"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_organotroph"
+          "val" : "TT_organotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "organotroph"
+          "val" : "organotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2242,26 +17090,80 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of light as the energy source and carbon dioxide as the primary carbon source for biosynthesis."
+          "val" : "A trophic type characterized by the use of light as the energy source and carbon dioxide as the primary carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000017"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000121"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001457"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001483"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0006008"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anoxygenic_photoautotrophy"
+          "val" : "anoxygenic_photoautotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anoxygenic_photoautotrophy_hydrogen_oxidation"
+          "val" : "anoxygenic_photoautotrophy_hydrogen_oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anoxygenic_photoautotrophy_iron_oxidation"
+          "val" : "anoxygenic_photoautotrophy_iron_oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anoxygenic_photoautotrophy_sulfur_oxidation"
+          "val" : "anoxygenic_photoautotrophy_sulfur_oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoautotroph"
+          "val" : "photoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoautotrophy"
+          "val" : "photoautotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2274,14 +17176,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism uses light as the energy source and organic compounds as the primary carbon source for biosynthesis."
+          "val" : "A trophic type in which an organism uses light as the energy source and organic compounds as the primary carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000131"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoheterotroph"
+          "val" : "photoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoheterotrophy"
+          "val" : "photoheterotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2294,11 +17214,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism uses light as the energy source and inorganic compounds as electron donors, typically with carbon dioxide as the primary carbon source."
+          "val" : "A trophic type in which an organism uses light as the energy source and inorganic compounds as electron donors, typically with carbon dioxide as the primary carbon source.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001482"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "photolithotroph"
+          "val" : "photolithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2314,11 +17246,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from light and carbon from organic compounds."
+          "val" : "A trophic type in which an organism obtains energy from light and carbon from organic compounds.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000510"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoorganoheterotroph"
+          "val" : "photoorganoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2327,21 +17271,74 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of light as the primary energy source for metabolic processes, regardless of carbon source."
+          "val" : "A trophic type characterized by the use of light as the primary energy source for metabolic processes, regardless of carbon source.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001457"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007064"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_phototroph"
+          "val" : "TT_phototroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic_anoxygenic_phototrophy"
+          "val" : "aerobic_anoxygenic_phototrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "phototroph"
+          "val" : "phototroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Anthea Guo"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000661",
+      "lbl" : "obsolete sulfate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000662",
+      "lbl" : "obsolete sulfur-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -2350,11 +17347,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy through chemical oxidation of organic compounds that also serve as the carbon source for biosynthesis."
+          "val" : "A trophic type in which an organism obtains energy through chemical oxidation of organic compounds that also serve as the carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoorganotroph"
+          "val" : "chemoorganotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2367,11 +17376,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of organic compounds as both electron donors and primary carbon sources for energy generation and biosynthesis."
+          "val" : "A trophic type characterized by the use of organic compounds as both electron donors and primary carbon sources for energy generation and biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000121"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000125"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000126"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000127"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000162"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "organoheterotroph"
+          "val" : "organoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2384,11 +17417,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from light and carbon from carbon dioxide using inorganic electron donors."
+          "val" : "A trophic type in which an organism obtains energy from light and carbon from carbon dioxide using inorganic electron donors.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000500"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "photolithoautotroph"
+          "val" : "photolithoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2397,17 +17442,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that describes the characteristic three-dimensional morphological form of a microbial cell, determined by cell wall structure, cytoskeletal elements, and environmental factors."
+          "val" : "A phenotype that describes the characteristic three-dimensional morphological form of a microbial cell, determined by cell wall structure, cytoskeletal elements, and environmental factors.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000073"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Morphology.cell morphology.cell shape"
+          "val" : "Morphology.cell morphology.cell shape",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell shape"
+          "val" : "cell shape",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell_shape"
+          "val" : "cell_shape",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2423,11 +17492,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape characterized by an elongated, rod cylindrical morphology with relatively parallel sides and rounded ends."
+          "val" : "A cell shape characterized by an elongated, rod cylindrical morphology with relatively parallel sides and rounded ends.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000076"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "bacillus"
+          "val" : "bacillus",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2440,14 +17521,38 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has a spherical or nearly spherical morphology, with roughly equal dimensions in all directions."
+          "val" : "A cell shape in which an organism has a spherical or nearly spherical morphology, with roughly equal dimensions in all directions.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000402"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000075"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000123"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "coccus"
+          "val" : "coccus",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "coccus-shaped"
+          "val" : "coccus-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2461,7 +17566,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "crescent-shaped"
+          "val" : "crescent-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2475,10 +17586,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_curved_spiral"
+          "val" : "S_curved_spiral",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "curved-shaped"
+          "val" : "curved-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2491,11 +17614,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which spherical cells remain attached in pairs following cell division, forming characteristic doublets."
+          "val" : "A cell shape in which spherical cells remain attached in pairs following cell division, forming characteristic doublets.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000117"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "diplococcus-shaped"
+          "val" : "diplococcus-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2509,10 +17644,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_star_dumbbell_pleomorphic"
+          "val" : "S_star_dumbbell_pleomorphic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "dumbbell-shaped"
+          "val" : "dumbbell-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2521,11 +17668,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has an oval or ellipse morphology, elongated along one axis with rounded ends, intermediate between spherical and rod-shaped."
+          "val" : "A cell shape in which an organism has an oval or ellipse morphology, elongated along one axis with rounded ends, intermediate between spherical and rod-shaped.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0000947"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "ellipsoidal"
+          "val" : "ellipsoidal",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2542,13 +17701,31 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_filament"
+          "val" : "S_filament",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "filament"
+          "val" : "filament",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "filament-shaped"
+          "val" : "filament-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2562,10 +17739,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "flask"
+          "val" : "flask",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "flask-shaped"
+          "val" : "flask-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2575,7 +17764,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "helical-shaped"
+          "val" : "helical-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2591,14 +17786,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has an oval morphology, rounded at both ends with one end often slightly broader than the other."
+          "val" : "A cell shape in which an organism has an oval morphology, rounded at both ends with one end often slightly broader than the other.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0001891"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_ovoid"
+          "val" : "S_ovoid",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "ovoid-shaped"
+          "val" : "ovoid-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2611,11 +17824,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape characterized by an ellipsoidal morphology with rounded ends, resembling an elongated sphere."
+          "val" : "A cell shape characterized by an ellipsoidal morphology with rounded ends, resembling an elongated sphere.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007100"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oval-shaped"
+          "val" : "oval-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2628,17 +17853,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape characterized by variable and irregular morphology, where individual cells within a population exhibit multiple distinct shapes."
+          "val" : "A cell shape characterized by variable and irregular morphology, where individual cells within a population exhibit multiple distinct shapes.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000132"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_star_dumbbell_pleomorphic"
+          "val" : "S_star_dumbbell_pleomorphic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pleomorphic"
+          "val" : "pleomorphic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pleomorphic-shaped"
+          "val" : "pleomorphic-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2654,14 +17903,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism forms circular or toroidal structures."
+          "val" : "A cell shape in which an organism forms circular or toroidal structures.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0002539"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "ring"
+          "val" : "ring",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "ring-shaped"
+          "val" : "ring-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2670,14 +17937,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has an elongated, cylindrical morphology with relatively straight sides and rounded or flat ends."
+          "val" : "A cell shape in which an organism has an elongated, cylindrical morphology with relatively straight sides and rounded or flat ends.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000076"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_rod"
+          "val" : "S_rod",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "rod-shaped"
+          "val" : "rod-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2691,7 +17976,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "spore-shaped"
+          "val" : "spore-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2705,10 +17996,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_sphere"
+          "val" : "S_sphere",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "sphere-shaped"
+          "val" : "sphere-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2722,13 +18025,31 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_curved_spiral"
+          "val" : "S_curved_spiral",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "spiral"
+          "val" : "spiral",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "spiral-shaped"
+          "val" : "spiral-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2741,17 +18062,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has multiple radiating projections from a central body."
+          "val" : "A cell shape in which an organism has multiple radiating projections from a central body.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000130"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0002065"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_star_dumbbell_pleomorphic"
+          "val" : "S_star_dumbbell_pleomorphic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "star"
+          "val" : "star",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "star-shaped"
+          "val" : "star-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2760,14 +18108,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has a curved rod or comma morphology, characterized by a short curved cylindrical form with a single arc."
+          "val" : "A cell shape in which an organism has a curved rod or comma morphology, characterized by a short curved cylindrical form with a single arc.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000077"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000086"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "vibrio"
+          "val" : "vibrio",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "vibrio-shaped"
+          "val" : "vibrio-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2781,7 +18150,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "branced"
+          "val" : "branced",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2791,7 +18166,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "coccobacillus"
+          "val" : "coccobacillus",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2804,7 +18185,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "disc"
+          "val" : "disc",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2813,11 +18200,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape that is wide in the middle and tapers at both ends."
+          "val" : "A cell shape that is wide in the middle and tapers at both ends.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0002400"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "fusiform"
+          "val" : "fusiform",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2827,7 +18226,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "irregular"
+          "val" : "irregular",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2837,7 +18242,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "spindle"
+          "val" : "spindle",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2850,11 +18261,29 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has an elongated, tightly coiled helical morphology with periplasmic flagella (endoflagella) located between the cell wall and outer membrane."
+          "val" : "A cell shape in which an organism has an elongated, tightly coiled helical morphology with periplasmic flagella (endoflagella) located between the cell wall and outer membrane.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000086"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000124"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000125"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "spirochete"
+          "val" : "spirochete",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2868,7 +18297,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "square"
+          "val" : "square",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2878,7 +18313,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "tailed"
+          "val" : "tailed",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2888,7 +18329,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "triangular"
+          "val" : "triangular",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2897,14 +18344,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype where microorganisms are grouped based on their ability to retain crystal violet dye in the Gram staining procedure."
+          "val" : "A phenotype where microorganisms are grouped based on their ability to retain crystal violet dye in the Gram staining procedure.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000191"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Morphology.cell morphology.gram stain"
+          "val" : "Morphology.cell morphology.gram stain",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "gram_stain"
+          "val" : "gram_stain",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2920,20 +18385,53 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A gram stain in which an organism retains crystal violet dye and appears purple under microscopy due to a thick peptidoglycan cell wall."
+          "val" : "A gram stain in which an organism retains crystal violet dye and appears purple under microscopy due to a thick peptidoglycan cell wall.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000188"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/GramPositiveBacteria"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "G_positive"
+          "val" : "G_positive",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "gram positive"
+          "val" : "gram positive",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "positive"
+          "val" : "positive",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "positive"
+          "val" : "positive",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2946,16 +18444,40 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "G_negative"
+          "val" : "G_negative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "gram negative"
+          "val" : "gram negative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "negative"
+          "val" : "negative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "negative"
+          "val" : "negative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2968,11 +18490,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A gram stain in which bacteria from the same culture show both gram-positive and gram-negative staining characteristics, often due to age of culture or cell wall degradation."
+          "val" : "A gram stain in which bacteria from the same culture show both gram-positive and gram-negative staining characteristics, often due to age of culture or cell wall degradation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000190"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "variable"
+          "val" : "variable",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2985,17 +18519,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype in which an organism has the capability to move independently through its environment, typically by means of flagella, pili, gliding mechanisms, or other locomotory structures."
+          "val" : "A phenotype in which an organism has the capability to move independently through its environment, typically by means of flagella, pili, gliding mechanisms, or other locomotory structures.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000001"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Morphology.cell morphology.motility"
+          "val" : "Morphology.cell morphology.motility",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "motility"
+          "val" : "motility",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "presence of motility"
+          "val" : "presence of motility",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3008,17 +18566,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motility in which an organism has the ability to move independently using metabolic energy."
+          "val" : "A motility in which an organism has the ability to move independently using metabolic energy.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/CL_0000219"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000005"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "motile"
+          "val" : "motile",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yes"
+          "val" : "yes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yes"
+          "val" : "yes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3027,17 +18612,53 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motility in which an organism lacks the ability to move independently under its own power."
+          "val" : "A motility in which an organism lacks the ability to move independently under its own power.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000133"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007488"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007489"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007490"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/UPHENO_0034076"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "no"
+          "val" : "no",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "no"
+          "val" : "no",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "non-motile"
+          "val" : "non-motile",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3046,11 +18667,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motile in which an organism possesses flagella for locomotion."
+          "val" : "A motile in which an organism possesses flagella for locomotion.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/CL_0011016"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0030317"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000272"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000029"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "flagella"
+          "val" : "flagella",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3059,11 +18701,26 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motility where the flagellum filament of an organism is located in the periplasm and does not extend past the cell envelope."
+          "val" : "A motility where the flagellum filament of an organism is located in the periplasm and does not extend past the cell envelope.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0055040"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000023"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "axial filament"
+          "val" : "axial filament",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3076,11 +18733,29 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motile in which an organism moves smoothly along solid surfaces without flagella or pili."
+          "val" : "A motile in which an organism moves smoothly along solid surfaces without flagella or pili.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0071976"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000437"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000112"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "gliding"
+          "val" : "gliding",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3089,14 +18764,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference characterized by the ability to grow at low temperatures (typically below 20°C) while maintaining optimal growth at moderate temperatures."
+          "val" : "A temperature preference characterized by the ability to grow at low temperatures (typically below 20°C) while maintaining optimal growth at moderate temperatures.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001306"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001417"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005007"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
           "val" : "facultative psychrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative psychrophilic"
+          "val" : "facultative psychrophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3109,7 +18802,22 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference that grows optimally at temperatures above 90°C."
+          "val" : "A temperature preference that grows optimally at temperatures above 90°C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_00002027"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001294"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001538"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005003"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
@@ -3125,7 +18833,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type that involves an organism's physiological and metabolic adaptations to specific nutrient availability."
+          "val" : "A trophic type that involves an organism's physiological and metabolic adaptations to specific nutrient availability.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PHIPO_0001216"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3138,14 +18852,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A metabolism that is characterized by the method of performing cellular respiration, distinguished primarily by the specific terminal electron acceptor utilized for producing cellular energy."
+          "val" : "A metabolism that is characterized by the method of performing cellular respiration, distinguished primarily by the specific terminal electron acceptor utilized for producing cellular energy.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009060"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0045333"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pathways"
+          "val" : "pathways",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "respiration"
+          "val" : "respiration",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3158,7 +18893,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A respiration in which molecular oxygen serves as the terminal electron acceptor in the electron transport chain, generating ATP through oxidative phosphorylation with water as the final product."
+          "val" : "A respiration in which molecular oxygen serves as the terminal electron acceptor in the electron transport chain, generating ATP through oxidative phosphorylation with water as the final product.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009060"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
@@ -3178,7 +18919,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A respiration in which an organism uses electron acceptors other than oxygen for energy production."
+          "val" : "A respiration in which an organism uses electron acceptors other than oxygen for energy production.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009061"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
@@ -3194,7 +18941,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A metabolism that generates ATP through the transfer of electrons from electron donors to electron acceptors via redox reactions, coupled to the pumping of protons across a membrane to create an electrochemical gradient."
+          "val" : "A metabolism that generates ATP through the transfer of electrons from electron donors to electron acceptors via redox reactions, coupled to the pumping of protons across a membrane to create an electrochemical gradient.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0006119"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3216,7 +18969,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A metabolism in which electrons are transferred from an electron donor to an electron acceptor."
+          "val" : "A metabolism in which electrons are transferred from an electron donor to an electron acceptor.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009055"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3237,12 +18996,499 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000807",
+      "lbl" : "obsolete Nitrogen compound respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000808",
+      "lbl" : "obsolete Nitrate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000809",
+      "lbl" : "obsolete Denitrification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000810",
+      "lbl" : "obsolete Dissimilatory nitrate reduction to ammonium",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000811",
+      "lbl" : "obsolete Nitrite reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000812",
+      "lbl" : "obsolete Anaerobic ammonium oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000813",
+      "lbl" : "obsolete Nitric oxide reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000814",
+      "lbl" : "obsolete Nitrous oxide reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000815",
+      "lbl" : "obsolete Sulfur and sulfoxide compound respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000816",
+      "lbl" : "obsolete Sulfate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000817",
+      "lbl" : "obsolete Sulfur reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000818",
+      "lbl" : "obsolete Sulfite reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000819",
+      "lbl" : "obsolete Thiosulfate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000820",
+      "lbl" : "obsolete Sulfoxide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000821",
+      "lbl" : "obsolete Dimethyl sulfoxide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000822",
+      "lbl" : "obsolete Methionine sulfoxide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000823",
+      "lbl" : "obsolete Sulfide oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000824",
+      "lbl" : "obsolete Thiosulfate oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000825",
+      "lbl" : "obsolete Sulfite oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000826",
+      "lbl" : "obsolete Tetrathionate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000827",
+      "lbl" : "obsolete Polysulfide reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000828",
+      "lbl" : "obsolete Metal and metalloid respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000829",
+      "lbl" : "obsolete Iron reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000830",
+      "lbl" : "obsolete Iron oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000831",
+      "lbl" : "obsolete Nitrate-dependent Fe(II) oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000832",
+      "lbl" : "obsolete Manganese reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000833",
+      "lbl" : "obsolete Manganese oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000834",
+      "lbl" : "obsolete Uranium reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000835",
+      "lbl" : "obsolete Vanadium reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000836",
+      "lbl" : "obsolete Chromium reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000837",
+      "lbl" : "obsolete Technetium reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000838",
+      "lbl" : "obsolete Cobalt reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000839",
+      "lbl" : "obsolete Arsenate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000840",
+      "lbl" : "obsolete Arsenite oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000841",
+      "lbl" : "obsolete Selenate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000842",
+      "lbl" : "obsolete Selenite reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000843",
+      "lbl" : "obsolete Carbon and organic compound respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000844",
       "lbl" : "Methanogenesis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions."
+          "val" : "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0015948"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
@@ -3255,7 +19501,13 @@
           "val" : "Carbonate respiration"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "methanogenesis"
+          "val" : "methanogenesis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3278,7 +19530,13 @@
           "val" : "Acetate fermentation"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "acetogenesis"
+          "val" : "acetogenesis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3305,25 +19563,354 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000847",
+      "lbl" : "obsolete Fumarate respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000848",
+      "lbl" : "obsolete Trimethylamine N-oxide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000849",
+      "lbl" : "obsolete Humus respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000850",
+      "lbl" : "obsolete Halogenated compound respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000851",
+      "lbl" : "obsolete Organohalide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000852",
+      "lbl" : "obsolete (Per)chlorate respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000853",
+      "lbl" : "obsolete Perchlorate respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000854",
+      "lbl" : "obsolete Chlorate respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000855",
+      "lbl" : "obsolete Bromate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000856",
+      "lbl" : "obsolete Iodate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000857",
+      "lbl" : "obsolete Nitrite-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000858",
+      "lbl" : "obsolete Nitrate-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000859",
+      "lbl" : "obsolete Hydrogen oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000860",
+      "lbl" : "obsolete Sulfur oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000861",
+      "lbl" : "obsolete Nitrification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000862",
+      "lbl" : "obsolete Complete ammonia oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000863",
+      "lbl" : "obsolete Carbon monoxide oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000864",
+      "lbl" : "obsolete Hydrogenotrophic methanogenesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000865",
+      "lbl" : "obsolete Acetoclastic methanogenesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000866",
+      "lbl" : "obsolete Methylotrophic methanogenesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000867",
+      "lbl" : "obsolete Anaerobic methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000868",
+      "lbl" : "obsolete Lanthanide reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000869",
+      "lbl" : "obsolete Lanthanide oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000870",
       "lbl" : "sporulation",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that is relating to an organism's ability to form dormant, stress-resistant endospores."
+          "val" : "A phenotype that is relating to an organism's ability to form dormant, stress-resistant endospores.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0043934"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "General.keywords"
+          "val" : "General.keywords",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.spore formation.spore formation"
+          "val" : "Physiology and metabolism.spore formation.spore formation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "sporulation"
+          "val" : "sporulation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "sporulation"
+          "val" : "sporulation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3332,17 +19919,47 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A sporulation in which an organism has the ability to produce endospores."
+          "val" : "A sporulation in which an organism has the ability to produce endospores.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0034301"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000017"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/SporeFormation"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "spore"
+          "val" : "spore",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yes"
+          "val" : "yes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yes"
+          "val" : "yes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3351,17 +19968,53 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A sporulation in which an organism lacks the ability to produce endospores."
+          "val" : "A sporulation in which an organism lacks the ability to produce endospores.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000018"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007232"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007236"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007434"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/UPHENO_0083394"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "no"
+          "val" : "no",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "no"
+          "val" : "no",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "no_spore"
+          "val" : "no_spore",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3370,11 +20023,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that inheres in a cell by virtue of its longer dimension when viewed on a plane."
+          "val" : "A phenotype that inheres in a cell by virtue of its longer dimension when viewed on a plane.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OBA_2040145"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell length"
+          "val" : "cell length",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3383,11 +20048,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that inheres in a cell by virtue of its shorter dimension when viewed on a plane."
+          "val" : "A phenotype that inheres in a cell by virtue of its shorter dimension when viewed on a plane.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OBA_2040146"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell width"
+          "val" : "cell width",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3397,7 +20074,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "L_<=1.3"
+          "val" : "L_<=1.3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3414,7 +20097,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "L_1.3_2"
+          "val" : "L_1.3_2",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3434,7 +20123,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "L_2_3"
+          "val" : "L_2_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3454,7 +20149,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "L_>3"
+          "val" : "L_>3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3471,7 +20172,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "W_<=0.5"
+          "val" : "W_<=0.5",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3488,7 +20195,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "W_0.5_0.65"
+          "val" : "W_0.5_0.65",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3508,7 +20221,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "W_0.65_0.9"
+          "val" : "W_0.65_0.9",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3528,7 +20247,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "W_>0.9"
+          "val" : "W_>0.9",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3540,97 +20265,316 @@
       }
     }, {
       "id" : "https://w3id.org/metpo/1001000",
-      "lbl" : "observation",
-      "type" : "CLASS"
-    }, {
-      "id" : "https://w3id.org/metpo/1001001",
-      "lbl" : "optimum temperature observation",
+      "lbl" : "obsolete observation",
       "type" : "CLASS",
       "meta" : {
-        "definition" : {
-          "val" : "An observation that identifies the temperature at which a microorganism exhibits maximum growth rate or metabolic activity."
-        },
         "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Luke Wang"
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1001001",
+      "lbl" : "obsolete optimum temperature observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/1001002",
-      "lbl" : "growth temperature observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete growth temperature observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001003",
-      "lbl" : "temperature range observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete temperature range observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001004",
-      "lbl" : "temperature delta observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete temperature delta observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1001005",
+      "lbl" : "obsolete culture temperature observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1001006",
+      "lbl" : "obsolete culture NaCl observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001007",
-      "lbl" : "growth NaCl observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete growth NaCl observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001008",
-      "lbl" : "NaCl delta observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete NaCl delta observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001009",
-      "lbl" : "NaCl range observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete NaCl range observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001010",
-      "lbl" : "optimum NaCl observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete optimum NaCl observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1001011",
+      "lbl" : "obsolete culture pH observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001012",
-      "lbl" : "growth pH observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete growth pH observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001013",
-      "lbl" : "optimum pH observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete optimum pH observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001014",
-      "lbl" : "pH delta observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete pH delta observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001015",
-      "lbl" : "pH range observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete pH range observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001016",
-      "lbl" : "optimum oxygen observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete optimum oxygen observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001017",
-      "lbl" : "growth oxygen observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete growth oxygen observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001018",
-      "lbl" : "oxygen range observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete oxygen range observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001019",
-      "lbl" : "oxygen delta observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete oxygen delta observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001020",
-      "lbl" : "oxygen observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete oxygen observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001021",
-      "lbl" : "temperature observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete temperature observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001022",
-      "lbl" : "NaCl observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete NaCl observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001023",
-      "lbl" : "pH observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete pH observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001101",
       "lbl" : "biosafety level",
@@ -3641,10 +20585,22 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Safety information.risk assessment.biosafety level"
+          "val" : "Safety information.risk assessment.biosafety level",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "biosafety level"
+          "val" : "biosafety level",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3657,7 +20613,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "1"
+          "val" : "1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3674,7 +20636,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "2"
+          "val" : "2",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3687,10 +20655,22 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "3"
+          "val" : "3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "3**"
+          "val" : "3**",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3707,7 +20687,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "4"
+          "val" : "4",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3720,7 +20706,52 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "5"
+          "val" : "5",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002000",
+      "lbl" : "obsolete Sulfate-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002001",
+      "lbl" : "obsolete Fe(III)-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002002",
+      "lbl" : "obsolete Mn(IV)-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -3738,14 +20769,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A respiration that generates energy through the oxidation of organic compounds without using an external electron acceptor, using organic molecules as both electron donors and final electron acceptors."
+          "val" : "A respiration that generates energy through the oxidation of organic compounds without using an external electron acceptor, using organic molecules as both electron donors and final electron acceptors.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0006113"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "fermentation"
+          "val" : "fermentation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "fermentation"
+          "val" : "fermentation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3766,16 +20815,470 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1002007",
+      "lbl" : "obsolete Sulfur disproportionation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002008",
+      "lbl" : "obsolete Nitrogen fixation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002009",
+      "lbl" : "obsolete Nitrate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002010",
+      "lbl" : "obsolete Anaerobic ammonium-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002011",
+      "lbl" : "obsolete Nitrous oxide-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002012",
+      "lbl" : "obsolete Sulfate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002013",
+      "lbl" : "obsolete Sulfur-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002014",
+      "lbl" : "obsolete Sulfite-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002015",
+      "lbl" : "obsolete Thiosulfate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002016",
+      "lbl" : "obsolete Sulfur-disproportionating",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002017",
+      "lbl" : "obsolete Sulfide-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002018",
+      "lbl" : "obsolete Thiosulfate-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002019",
+      "lbl" : "obsolete Sulfite-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002020",
+      "lbl" : "obsolete Iron-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002021",
+      "lbl" : "obsolete Iron-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002022",
+      "lbl" : "obsolete Nitrate-dependent Fe(II)-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002023",
+      "lbl" : "obsolete Manganese-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002024",
+      "lbl" : "obsolete Manganese-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002025",
+      "lbl" : "obsolete Uranium-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002026",
+      "lbl" : "obsolete Arsenate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002027",
+      "lbl" : "obsolete Selenate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002028",
+      "lbl" : "obsolete Selenite-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002029",
+      "lbl" : "obsolete Perchlorate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002030",
+      "lbl" : "obsolete Chlorate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002031",
+      "lbl" : "obsolete Bromate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002032",
+      "lbl" : "obsolete Iodate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002033",
+      "lbl" : "obsolete Hydrogen-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002034",
+      "lbl" : "obsolete Sulfur-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002035",
+      "lbl" : "obsolete Ammonia oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002036",
+      "lbl" : "obsolete Nitrite oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002037",
+      "lbl" : "obsolete Complete ammonia-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002038",
+      "lbl" : "obsolete Methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002039",
+      "lbl" : "obsolete Carbon monoxide-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002040",
+      "lbl" : "obsolete Nitrogen-fixing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1003000",
       "lbl" : "pH growth preference",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that describes how the rate and extent of population growth are affected by environmental pH."
+          "val" : "A phenotype that describes how the rate and extent of population growth are affected by environmental pH.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005008"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pH growth"
+          "val" : "pH growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3784,7 +21287,16 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference characterized by optimal growth at near-neutral pH values, typically between pH 6.5 and 7.5."
+          "val" : "A pH growth preference characterized by optimal growth at near-neutral pH values, typically between pH 6.5 and 7.5.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005010"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0070046"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3807,7 +21319,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism grows optimally at pH values above 9."
+          "val" : "A pH growth preference in which an organism grows optimally at pH values above 9.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_00002022"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001549"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005010"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3829,7 +21359,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism grows optimally at pH values below 5."
+          "val" : "A pH growth preference in which an organism grows optimally at pH values below 5.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001549"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005010"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007945"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3839,7 +21387,13 @@
           "val" : "acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "acidophilic"
+          "val" : "acidophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3848,7 +21402,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism requires alkaline conditions (typically pH above 8.5) for growth and cannot grow at neutral or acidic pH."
+          "val" : "A pH growth preference in which an organism requires alkaline conditions (typically pH above 8.5) for growth and cannot grow at neutral or acidic pH.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_00002022"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001565"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007771"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007947"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3871,7 +21443,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism can grow at alkaline pH but does not require it."
+          "val" : "A pH growth preference in which an organism can grow at alkaline pH but does not require it.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001558"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007771"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007947"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3890,7 +21480,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference characterized by the requirement for acidic environments (pH below 5.5) for growth, with inability to grow at neutral or alkaline pH values."
+          "val" : "A pH growth preference characterized by the requirement for acidic environments (pH below 5.5) for growth, with inability to grow at neutral or alkaline pH values.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001566"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3913,7 +21509,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference characterized by optimal growth in acidic environments (pH below 5.5) with the capacity to also grow at near-neutral pH values."
+          "val" : "A pH growth preference characterized by optimal growth in acidic environments (pH below 5.5) with the capacity to also grow at near-neutral pH values.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001557"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005010"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007945"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3936,7 +21550,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference characterized by the ability to tolerate acidic environments (typically pH below 5.5) while maintaining optimal growth near neutral pH."
+          "val" : "A pH growth preference characterized by the ability to tolerate acidic environments (typically pH below 5.5) while maintaining optimal growth near neutral pH.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001555"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3956,7 +21576,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism can tolerate alkaline pH but grows optimally at neutral pH."
+          "val" : "A pH growth preference in which an organism can tolerate alkaline pH but grows optimally at neutral pH.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007771"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007947"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3969,11 +21607,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype characterized by the color of pigments produced by a microorganism."
+          "val" : "A phenotype characterized by the color of pigments produced by a microorganism.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0043473"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell color"
+          "val" : "cell color",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3983,7 +21633,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_black"
+          "val" : "Pigment_black",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3993,7 +21649,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_brown"
+          "val" : "Pigment_brown",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4003,7 +21665,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_cream"
+          "val" : "Pigment_cream",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4013,7 +21681,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_green"
+          "val" : "Pigment_green",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4023,7 +21697,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_orange"
+          "val" : "Pigment_orange",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4033,7 +21713,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_pink"
+          "val" : "Pigment_pink",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4043,7 +21729,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_red"
+          "val" : "Pigment_red",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4053,7 +21745,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_white"
+          "val" : "Pigment_white",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4063,10 +21761,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_yellow"
+          "val" : "Pigment_yellow",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yellow pigment"
+          "val" : "yellow pigment",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4076,7 +21786,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_carotenoid"
+          "val" : "Pigment_carotenoid",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4085,14 +21801,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype where a microbe is a pathogen of of some host organism."
+          "val" : "A phenotype where a microbe is a pathogen of of some host organism.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000068"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007284"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "General.keywords"
+          "val" : "General.keywords",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "Safety information.risk assessment"
+          "val" : "Safety information.risk assessment",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4105,7 +21842,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "animal pathogen"
+          "val" : "animal pathogen",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4118,7 +21861,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "plant pathogen"
+          "val" : "plant pathogen",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4127,11 +21876,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pathogen that infects organisms of the species Homo sapiens."
+          "val" : "A pathogen that infects organisms of the species Homo sapiens.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/IDO_0000639"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "human pathogen"
+          "val" : "human pathogen",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4140,12 +21901,18 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A processed material that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms."
+          "val" : "A processed material that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OBI_0000079"
+            } ]
+          }
         },
         "comments" : [ "This class is equivalent to OBI:0000079 'culture medium'. It is included in METPO to serve as the range for growth-related object properties." ],
         "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2004/02/skos/core#closeMatch",
-          "val" : "https://biolink.github.io/biolink-model/ChemicalEntity"
+          "pred" : "http://www.w3.org/2004/02/skos/core#broadMatch",
+          "val" : "https://biolink.github.io/biolink-model/ProcessedMaterial"
         } ]
       }
     }, {
@@ -4154,12 +21921,27 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A two-step biological process in which ammonia is oxidized to nitrite (ammonia oxidation) and nitrite is oxidized to nitrate (nitrite oxidation)."
+          "val" : "A two-step biological process in which ammonia is oxidized to nitrite (ammonia oxidation) and nitrite is oxidized to nitrate (nitrite oxidation).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0019329"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0019332"
+            } ]
+          }
         },
         "comments" : [ "MetaTraits maps to OMIT:0027217 (wrong ontology). Correct GO terms are GO:0019329 (ammonia oxidation) and GO:0019332 (nitrite oxidation)." ],
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "nitrification"
+          "val" : "nitrification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4168,11 +21950,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An assay that tests the ability of an organism to produce indole from tryptophan."
+          "val" : "An assay that tests the ability of an organism to produce indole from tryptophan.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000430"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "indole test"
+          "val" : "indole test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4185,7 +21979,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "indole test"
+          "val" : "indole test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4203,11 +22003,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An assay that tests the ability of an organism to produce and maintain stable acid end products from glucose fermentation."
+          "val" : "An assay that tests the ability of an organism to produce and maintain stable acid end products from glucose fermentation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "SNOMED:5894006"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "methyl red test"
+          "val" : "methyl red test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4220,7 +22032,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "methyl red test"
+          "val" : "methyl red test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4238,11 +22056,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An assay that tests the ability of an organism to produce acetoin from glucose via the butanediol fermentation pathway."
+          "val" : "An assay that tests the ability of an organism to produce acetoin from glucose via the butanediol fermentation pathway.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "SNOMED:66592006"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "voges-proskauer test"
+          "val" : "voges-proskauer test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4255,7 +22085,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "voges-proskauer test"
+          "val" : "voges-proskauer test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4273,11 +22109,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype describing an organism that requires elevated concentrations of carbon dioxide for growth."
+          "val" : "A phenotype describing an organism that requires elevated concentrations of carbon dioxide for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "SNOMED:413748004"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "capnophilic"
+          "val" : "capnophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4286,11 +22134,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype describing the ability of an organism to lyse red blood cells."
+          "val" : "A phenotype describing the ability of an organism to lyse red blood cells.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005117"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "presence of hemolysis"
+          "val" : "presence of hemolysis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4317,11 +22177,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motility phenotype in which flagella are distributed over the entire cell surface."
+          "val" : "A motility phenotype in which flagella are distributed over the entire cell surface.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000078"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "flagellum arrangement"
+          "val" : "flagellum arrangement",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4334,7 +22206,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "flagellum arrangement"
+          "val" : "flagellum arrangement",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4388,11 +22266,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A biological process in which nitrate or nitrite is reduced to gaseous nitrogen compounds (NO, N2O, or N2) under anaerobic or microaerobic conditions."
+          "val" : "A biological process in which nitrate or nitrite is reduced to gaseous nitrogen compounds (NO, N2O, or N2) under anaerobic or microaerobic conditions.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0019333"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "denitrification pathway"
+          "val" : "denitrification pathway",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4401,11 +22291,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A biological process in which atmospheric dinitrogen is reduced to ammonia, catalyzed by nitrogenase."
+          "val" : "A biological process in which atmospheric dinitrogen is reduced to ammonia, catalyzed by nitrogenase.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009399"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "nitrogen fixation"
+          "val" : "nitrogen fixation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4414,11 +22316,50 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources."
+          "val" : "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "inbio:000022"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "generalist"
+          "val" : "generalist",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/9999999",
+      "lbl" : "obsolete obsolete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000000",
+      "lbl" : "obsolete has susceptibility profile",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -4434,7 +22375,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "assimilation"
+          "val" : "assimilation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4445,7 +22392,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds acid from"
+          "val" : "builds acid from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4456,7 +22409,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds base from"
+          "val" : "builds base from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4467,7 +22426,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds gas from"
+          "val" : "builds gas from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4478,7 +22443,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "carbon source"
+          "val" : "carbon source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4489,7 +22460,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "degradation"
+          "val" : "degradation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4500,7 +22477,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "electron acceptor"
+          "val" : "electron acceptor",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4511,7 +22494,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "electron donor"
+          "val" : "electron donor",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4522,7 +22511,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "energy source"
+          "val" : "energy source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4533,7 +22528,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "fermentation"
+          "val" : "fermentation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4544,7 +22545,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "growth"
+          "val" : "growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4555,7 +22562,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "hydrolysis"
+          "val" : "hydrolysis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4566,7 +22579,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "nitrogen source"
+          "val" : "nitrogen source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4577,10 +22596,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "other"
+          "val" : "other",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "utilizes"
+          "val" : "utilizes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4591,7 +22622,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxidation"
+          "val" : "oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4602,7 +22639,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "reduction"
+          "val" : "reduction",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4613,7 +22656,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "required for growth"
+          "val" : "required for growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4624,7 +22673,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "respiration"
+          "val" : "respiration",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4635,7 +22690,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "sulfur source"
+          "val" : "sulfur source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4646,7 +22707,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic catabolization"
+          "val" : "aerobic catabolization",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4657,7 +22724,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic growth"
+          "val" : "aerobic growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4668,7 +22741,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic catabolization"
+          "val" : "anaerobic catabolization",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4679,7 +22758,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth"
+          "val" : "anaerobic growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4690,7 +22775,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth in the dark"
+          "val" : "anaerobic growth in the dark",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4701,7 +22792,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth with light"
+          "val" : "anaerobic growth with light",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4712,7 +22809,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "assimilation"
+          "val" : "assimilation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4723,7 +22826,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds acid from"
+          "val" : "builds acid from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4734,7 +22843,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds base from"
+          "val" : "builds base from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4745,7 +22860,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds gas from"
+          "val" : "builds gas from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4756,7 +22877,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "carbon source"
+          "val" : "carbon source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4767,7 +22894,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic catabolization"
+          "val" : "aerobic catabolization",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4778,7 +22911,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "degradation"
+          "val" : "degradation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4789,7 +22928,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "electron acceptor"
+          "val" : "electron acceptor",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4800,7 +22945,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "electron donor"
+          "val" : "electron donor",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4811,7 +22962,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "energy source"
+          "val" : "energy source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4822,7 +22979,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "fermentation"
+          "val" : "fermentation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4833,7 +22996,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "growth"
+          "val" : "growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4844,7 +23013,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "hydrolysis"
+          "val" : "hydrolysis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4855,7 +23030,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "nitrogen source"
+          "val" : "nitrogen source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4866,10 +23047,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "other"
+          "val" : "other",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "utilizes"
+          "val" : "utilizes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4880,7 +23073,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxidation"
+          "val" : "oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4891,7 +23090,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic growth"
+          "val" : "aerobic growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4902,7 +23107,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "reduction"
+          "val" : "reduction",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4913,7 +23124,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "required for growth"
+          "val" : "required for growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4924,7 +23141,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "respiration"
+          "val" : "respiration",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4935,7 +23158,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "sulfur source"
+          "val" : "sulfur source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4946,7 +23175,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic catabolization"
+          "val" : "anaerobic catabolization",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4957,7 +23192,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth"
+          "val" : "anaerobic growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4968,7 +23209,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth in the dark"
+          "val" : "anaerobic growth in the dark",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4979,58 +23226,98 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth with light"
+          "val" : "anaerobic growth with light",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000052",
-      "lbl" : "has temperature observation",
+      "lbl" : "obsolete has temperature observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a temperature observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000053",
-      "lbl" : "has optimum temperature observation",
+      "lbl" : "obsolete has optimum temperature observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an optimum temperature observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000054",
-      "lbl" : "has growth temperature observation",
+      "lbl" : "obsolete has growth temperature observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth temperature observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000055",
-      "lbl" : "has range temperature observation",
+      "lbl" : "obsolete has range temperature observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth temperature range observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000056",
-      "lbl" : "has temperature delta observation",
+      "lbl" : "obsolete has temperature delta observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a temperature tolerance breadth (delta) observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000057",
+      "lbl" : "obsolete has culture temperature observation",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000101",
@@ -5067,7 +23354,27 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "dismutates"
+          "val" : "dismutates",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000201",
+      "lbl" : "obsolete lyses",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -5078,7 +23385,69 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "produces"
+          "val" : "produces",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000203",
+      "lbl" : "obsolete fixes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000204",
+      "lbl" : "obsolete catabolizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000205",
+      "lbl" : "obsolete mineralizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000206",
+      "lbl" : "obsolete conjugates",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -5112,6 +23481,104 @@
       "type" : "PROPERTY",
       "propertyType" : "OBJECT"
     }, {
+      "id" : "https://w3id.org/metpo/2000213",
+      "lbl" : "obsolete binds",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000214",
+      "lbl" : "obsolete chelates",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000215",
+      "lbl" : "obsolete precipitates",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000216",
+      "lbl" : "obsolete solubilizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000217",
+      "lbl" : "obsolete volatilizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000218",
+      "lbl" : "obsolete crystallizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000219",
+      "lbl" : "obsolete adsorbs",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/2000220",
       "lbl" : "does not disproportionate",
       "type" : "PROPERTY",
@@ -5119,7 +23586,27 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "dismutates"
+          "val" : "dismutates",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000221",
+      "lbl" : "obsolete does not lyse",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -5130,7 +23617,69 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "produces"
+          "val" : "produces",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000223",
+      "lbl" : "obsolete does not fix",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000224",
+      "lbl" : "obsolete does not catabolize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000225",
+      "lbl" : "obsolete does not mineralize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000226",
+      "lbl" : "obsolete does not conjugate",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -5164,14 +23713,102 @@
       "type" : "PROPERTY",
       "propertyType" : "OBJECT"
     }, {
-      "id" : "https://w3id.org/metpo/2000239",
-      "lbl" : "has pH observation",
+      "id" : "https://w3id.org/metpo/2000233",
+      "lbl" : "obsolete does not bind",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a pH observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000234",
+      "lbl" : "obsolete does not chelate",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000235",
+      "lbl" : "obsolete does not precipitate",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000236",
+      "lbl" : "obsolete does not solubilize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000237",
+      "lbl" : "obsolete does not volatilize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000238",
+      "lbl" : "obsolete does not crystallize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000239",
+      "lbl" : "obsolete has pH observation",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000301",
@@ -5181,7 +23818,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.enzymes.[].activity"
+          "val" : "Physiology and metabolism.enzymes.[].activity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5192,7 +23835,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.enzymes.[].activity"
+          "val" : "Physiology and metabolism.enzymes.[].activity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5203,153 +23852,238 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.enzymes.[].activity"
+          "val" : "Physiology and metabolism.enzymes.[].activity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000501",
-      "lbl" : "has optimum pH observation",
+      "lbl" : "obsolete has optimum pH observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an optimum pH observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000502",
-      "lbl" : "has growth pH observation",
+      "lbl" : "obsolete has growth pH observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth pH observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000503",
-      "lbl" : "has range pH observation",
+      "lbl" : "obsolete has range pH observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth pH range observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000504",
-      "lbl" : "has pH delta observation",
+      "lbl" : "obsolete has pH delta observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a pH tolerance breadth (delta) observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000505",
+      "lbl" : "obsolete has culture pH observation",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000506",
-      "lbl" : "has NaCl observation",
+      "lbl" : "obsolete has NaCl observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a NaCl observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000507",
-      "lbl" : "has optimum NaCl observation",
+      "lbl" : "obsolete has optimum NaCl observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an optimum NaCl observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000508",
-      "lbl" : "has growth NaCl observation",
+      "lbl" : "obsolete has growth NaCl observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth NaCl observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000509",
-      "lbl" : "has range NaCl observation",
+      "lbl" : "obsolete has range NaCl observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth NaCl range observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000510",
-      "lbl" : "has NaCl delta observation",
+      "lbl" : "obsolete has NaCl delta observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a NaCl tolerance breadth (delta) observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000511",
-      "lbl" : "has observation",
-      "type" : "PROPERTY",
-      "propertyType" : "OBJECT"
-    }, {
-      "id" : "https://w3id.org/metpo/2000512",
-      "lbl" : "has oxygen observation",
+      "lbl" : "obsolete has observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an oxygen observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000512",
+      "lbl" : "obsolete has oxygen observation",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000513",
-      "lbl" : "has optimum oxygen observation",
+      "lbl" : "obsolete has optimum oxygen observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an optimum oxygen observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000514",
-      "lbl" : "has growth oxygen observation",
+      "lbl" : "obsolete has growth oxygen observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth oxygen observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000515",
-      "lbl" : "has range oxygen observation",
+      "lbl" : "obsolete has range oxygen observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth oxygen range observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000516",
-      "lbl" : "has oxygen delta observation",
+      "lbl" : "obsolete has oxygen delta observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a oxygen tolerance breadth (delta) observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000517",
@@ -5379,7 +24113,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "denitrification"
+          "val" : "denitrification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5390,7 +24130,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "denitrification"
+          "val" : "denitrification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5401,7 +24147,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "ammonification"
+          "val" : "ammonification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5412,7 +24164,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "ammonification"
+          "val" : "ammonification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5423,7 +24181,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxidation in darkness"
+          "val" : "oxidation in darkness",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5434,64 +24198,99 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxidation in darkness"
+          "val" : "oxidation in darkness",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000058",
-      "lbl" : "has observed spot value",
+      "lbl" : "obsolete has observed spot value",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "A reported temperature value (°C) for this observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000059",
-      "lbl" : "has minimum observed value",
+      "lbl" : "obsolete has minimum observed value",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "The minimum temperature (°C) associated with this observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000060",
-      "lbl" : "has maximum observed value",
+      "lbl" : "obsolete has maximum observed value",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "The maximum temperature (°C) associated with this observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000061",
-      "lbl" : "has value comments",
+      "lbl" : "obsolete has value comments",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "Free-text comments associated with this observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000062",
-      "lbl" : "is negative data",
+      "lbl" : "obsolete is negative data",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "True if this observation indicates no growth at the reported temperature (negative result)."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000063",
-      "lbl" : "observation data property",
+      "lbl" : "obsolete observation data property",
       "type" : "PROPERTY",
-      "propertyType" : "DATA"
+      "propertyType" : "DATA",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/2000071",
       "lbl" : "has value",
@@ -5513,7 +24312,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "temperature growth"
+          "val" : "temperature growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5527,7 +24332,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "temperature minimum"
+          "val" : "temperature minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5541,7 +24352,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "temperature maximum"
+          "val" : "temperature maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5555,7 +24372,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pH growth"
+          "val" : "pH growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5569,7 +24392,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pH minimum"
+          "val" : "pH minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5583,7 +24412,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pH maximum"
+          "val" : "pH maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5597,7 +24432,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "salinity growth"
+          "val" : "salinity growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5611,7 +24452,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "salinity minimum"
+          "val" : "salinity minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5625,7 +24472,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "salinity maximum"
+          "val" : "salinity maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5639,7 +24492,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "genome size"
+          "val" : "genome size",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5653,7 +24512,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "estimated genome size"
+          "val" : "estimated genome size",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5667,7 +24532,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "gene count"
+          "val" : "gene count",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5681,7 +24552,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "estimated gene count"
+          "val" : "estimated gene count",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5695,7 +24572,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC percentage"
+          "val" : "GC percentage",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5709,7 +24592,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "coding density"
+          "val" : "coding density",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5723,7 +24612,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell length"
+          "val" : "cell length",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5737,7 +24632,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell width"
+          "val" : "cell width",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5751,7 +24652,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell length minimum"
+          "val" : "cell length minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5765,7 +24672,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell length maximum"
+          "val" : "cell length maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5779,7 +24692,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell width minimum"
+          "val" : "cell width minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5793,7 +24712,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell width maximum"
+          "val" : "cell width maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5817,7 +24742,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "generalism_score"
+          "val" : "generalism_score",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5831,7 +24762,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "habitat_count"
+          "val" : "habitat_count",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5845,7 +24782,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pangenome_openness"
+          "val" : "pangenome_openness",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5859,7 +24802,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "intra_species_nucleotide_diversity"
+          "val" : "intra_species_nucleotide_diversity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5875,6 +24824,14 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000119",
       "lbl" : "definition source",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000231",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.org/dc/terms/contributor",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -5918,6 +24875,10 @@
       "propertyType" : "ANNOTATION"
     }, {
       "id" : "http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://www.w3.org/2004/02/skos/core#broadMatch",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -6762,86 +25723,6 @@
       "pred" : "is_a",
       "obj" : "https://w3id.org/metpo/1000882"
     }, {
-      "sub" : "https://w3id.org/metpo/1001001",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001002",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001003",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001004",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001007",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001008",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001009",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001010",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001012",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001013",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001014",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001015",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001016",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001017",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001018",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001019",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001020",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001021",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001022",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001023",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
       "sub" : "https://w3id.org/metpo/1001101",
       "pred" : "is_a",
       "obj" : "https://w3id.org/metpo/1000188"
@@ -7278,26 +26159,6 @@
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000001"
     }, {
-      "sub" : "https://w3id.org/metpo/2000052",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000511"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000053",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000052"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000054",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000052"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000055",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000052"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000056",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000052"
-    }, {
       "sub" : "https://w3id.org/metpo/2000102",
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000101"
@@ -7366,10 +26227,6 @@
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000230"
     }, {
-      "sub" : "https://w3id.org/metpo/2000239",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000511"
-    }, {
       "sub" : "https://w3id.org/metpo/2000302",
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000301"
@@ -7377,62 +26234,6 @@
       "sub" : "https://w3id.org/metpo/2000303",
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000301"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000501",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000239"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000502",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000239"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000503",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000239"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000504",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000239"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000506",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000511"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000507",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000506"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000508",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000506"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000509",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000506"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000510",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000506"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000512",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000511"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000513",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000512"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000514",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000512"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000515",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000512"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000516",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000512"
     }, {
       "sub" : "https://w3id.org/metpo/2000601",
       "pred" : "subPropertyOf",
@@ -7462,26 +26263,6 @@
       "predicateId" : "https://w3id.org/metpo/2000001",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
       "rangeClassIds" : [ "https://w3id.org/metpo/1000526" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000052",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001021" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000053",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001001" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000054",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001002" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000055",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001003" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000056",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001004" ]
     }, {
       "predicateId" : "https://w3id.org/metpo/2000101",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
@@ -7527,10 +26308,6 @@
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
       "rangeClassIds" : [ "https://w3id.org/metpo/1000526" ]
     }, {
-      "predicateId" : "https://w3id.org/metpo/2000239",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001023" ]
-    }, {
       "predicateId" : "https://w3id.org/metpo/2000301",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
       "rangeClassIds" : [ "https://w3id.org/metpo/1000527" ]
@@ -7542,66 +26319,6 @@
       "predicateId" : "https://w3id.org/metpo/2000303",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
       "rangeClassIds" : [ "https://w3id.org/metpo/1000527" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000501",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001013" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000502",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001012" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000503",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001015" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000504",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001014" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000506",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001022" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000507",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001010" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000508",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001007" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000509",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001009" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000510",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001008" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000511",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001000" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000512",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001020" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000513",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001016" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000514",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001017" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000515",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001018" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000516",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001019" ]
     }, {
       "predicateId" : "https://w3id.org/metpo/2000517",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],

--- a/metpo-full.obo
+++ b/metpo-full.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: https://w3id.org/metpo/metpo/releases/2026-03-24/metpo-full.owl
+data-version: https://w3id.org/metpo/metpo/releases/2026-05-19/metpo-full.owl
 idspace: dce http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
 idspace: metpo https://w3id.org/metpo/ 
@@ -7,13 +7,3815 @@ idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl#
 idspace: qudt http://qudt.org/schema/qudt/ 
 idspace: skos http://www.w3.org/2004/02/skos/core# 
 ontology: https://w3id.org/metpo/metpo/metpo-full.owl
+property_value: dcterms:contributor https://orcid.org/0000-0001-9076-6066
 property_value: dcterms:creator "METPO Development Team" xsd:string
-property_value: dcterms:description "Microbial ecophysiological trait and phenotype ontology" xsd:string
+property_value: dcterms:description "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible." xsd:string
 property_value: dcterms:issued "2024-01-01" xsd:string
 property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
-property_value: dcterms:modified "2025-09-29" xsd:string
-property_value: dcterms:title "METPO" xsd:string
-property_value: owl:versionInfo "2026-03-24" xsd:string
+property_value: dcterms:modified "2026-05-18" xsd:string
+property_value: dcterms:title "METPO: Microbial Ecophysiological Trait and Phenotype Ontology" xsd:string
+property_value: owl:versionInfo "2026-05-19" xsd:string
+property_value: seeAlso https://bioportal.bioontology.org/ontologies/METPO
+property_value: seeAlso https://bioregistry.io/registry/metpo
+property_value: seeAlso https://github.com/berkeleybop/metpo
+
+[Term]
+id: metpo:0000001
+name: obsolete Temperature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000002
+name: obsolete Salinity
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000003
+name: obsolete pH
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000004
+name: obsolete Oxygen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000005
+name: obsolete Trophic type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000006
+name: obsolete Motility
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000007
+name: obsolete Sporulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000008
+name: obsolete Pressure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000009
+name: obsolete GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000001
+name: obsolete Temperature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000010
+name: obsolete Cell Width
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000011
+name: obsolete Cell Length
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000012
+name: obsolete Temperature Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000013
+name: obsolete Temperature Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000014
+name: obsolete pH Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000015
+name: obsolete pH Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000016
+name: obsolete NaCl Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000017
+name: obsolete NaCl Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000018
+name: obsolete pH delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000019
+name: obsolete NaCl delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000002
+name: obsolete Salinity
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000020
+name: obsolete Temperature Delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000021
+name: obsolete METPO Morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000022
+name: obsolete Psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000023
+name: obsolete Psychrotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000024
+name: obsolete Mesophilie
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000025
+name: obsolete Thermotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000026
+name: obsolete Thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000027
+name: obsolete Extreme thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000028
+name: obsolete Hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000029
+name: obsolete Extreme hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000003
+name: obsolete pH
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000030
+name: obsolete Halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000031
+name: obsolete Non-halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000032
+name: obsolete Slight halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000033
+name: obsolete Moderate halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000034
+name: obsolete Extreme halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000035
+name: obsolete Halotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000036
+name: obsolete Haloalkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000037
+name: obsolete Extreme Acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000038
+name: obsolete Acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000039
+name: obsolete Neutrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000004
+name: obsolete Oxygen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000040
+name: obsolete Alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000041
+name: obsolete Acid Tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000042
+name: obsolete Alkali Tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000043
+name: obsolete Extreme Alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000044
+name: obsolete Facultative acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000045
+name: obsolete Obligative acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000046
+name: obsolete Aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000047
+name: obsolete Anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000048
+name: obsolete Facultative anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000049
+name: obsolete Facultative aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000005
+name: obsolete Trophic type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000050
+name: obsolete Microaerophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000051
+name: obsolete Aerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000052
+name: obsolete Microaerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000053
+name: obsolete Aerotolerant anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000054
+name: obsolete Obligate aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000055
+name: obsolete Obligate anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000056
+name: obsolete Oxygenic phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000057
+name: obsolete Anoxygenic phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000058
+name: obsolete Autotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000059
+name: obsolete Photoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000006
+name: obsolete Motility
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000060
+name: obsolete Chemoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000061
+name: obsolete Heterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000062
+name: obsolete Photoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000063
+name: obsolete Chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000064
+name: obsolete Lithotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000065
+name: obsolete Organotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000066
+name: obsolete Phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000067
+name: obsolete Chemotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000068
+name: obsolete Oligotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000069
+name: obsolete Copiotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000007
+name: obsolete Sporulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000070
+name: obsolete Lithoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000071
+name: obsolete Mixotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000072
+name: obsolete Lithoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000073
+name: obsolete Chemoorganoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000074
+name: obsolete Chemolithoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000075
+name: obsolete Methylotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000076
+name: obsolete Methanotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000077
+name: obsolete Carboxydotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000078
+name: obsolete Hydrogenotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000079
+name: obsolete Hydrogen oxidizer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000008
+name: obsolete Pressure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000080
+name: obsolete Hydrogen producer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000081
+name: obsolete Nitrogen fixer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000082
+name: obsolete Methanogen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000083
+name: obsolete Sulfate reducer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000084
+name: obsolete Sulfur oxidizer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000085
+name: obsolete Denitrifier
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000086
+name: obsolete Capnophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000087
+name: obsolete Motile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000088
+name: obsolete Non-motile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000089
+name: obsolete Flagellated
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000009
+name: obsolete GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000090
+name: obsolete Peritrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000091
+name: obsolete Lophotrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000092
+name: obsolete Monotrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000093
+name: obsolete Ciliated
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000094
+name: obsolete Gliding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000095
+name: obsolete Twitching
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000096
+name: obsolete Sliding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000097
+name: obsolete Swarming
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000098
+name: obsolete Endospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000099
+name: obsolete Exospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000010
+name: obsolete Cell Width
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000100
+name: obsolete Myxospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000101
+name: obsolete Arthrospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000102
+name: obsolete Conidia
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000103
+name: obsolete Sporangiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000104
+name: obsolete Zygospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000105
+name: obsolete Akinetes
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000106
+name: obsolete Chlamydospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000107
+name: obsolete Sporocysts
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000108
+name: obsolete Hypnospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000109
+name: obsolete Gemmae
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000011
+name: obsolete Cell Length
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000110
+name: obsolete Oospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000111
+name: obsolete Azygospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000112
+name: obsolete Cysts
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000113
+name: obsolete Ascospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000114
+name: obsolete Basidiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000115
+name: obsolete Aleuriospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000116
+name: obsolete Stylospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000117
+name: obsolete Sclerotia
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000118
+name: obsolete Zoospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000119
+name: obsolete Teliospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000012
+name: obsolete Temperature Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000120
+name: obsolete Urediniospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000121
+name: obsolete Pycnidiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000122
+name: obsolete Acriospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000123
+name: obsolete Aplanospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000124
+name: obsolete Statismospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000125
+name: obsolete Barotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000126
+name: obsolete Piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000127
+name: obsolete Piezotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000128
+name: obsolete Piezosensitive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000129
+name: obsolete Obligate barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000013
+name: obsolete Temperature Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000130
+name: obsolete Facultative barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000131
+name: obsolete Hyperbarophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000132
+name: obsolete Hypobarophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000133
+name: obsolete Atmospheric pressure-adapted
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000134
+name: obsolete Moderate piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000135
+name: obsolete Extreme piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000136
+name: obsolete Stenopiezic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000137
+name: obsolete Eurypiezic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000138
+name: obsolete Pressure-sensitive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000139
+name: obsolete Pressure-resistant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000014
+name: obsolete pH Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000140
+name: obsolete Pressure-adapted
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000141
+name: obsolete Piezo-acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000142
+name: obsolete Piezo-alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000143
+name: obsolete Piezo-halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000144
+name: obsolete Piezo-psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000145
+name: obsolete Piezo-thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000146
+name: obsolete Piezo-lithoautotrophe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000147
+name: obsolete Piezo-chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000148
+name: obsolete Piezo-oligotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000149
+name: obsolete Piezo-endolithic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000015
+name: obsolete pH Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000150
+name: obsolete Piezo-tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000151
+name: obsolete GC low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000152
+name: obsolete GC mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000153
+name: obsolete GC mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000154
+name: obsolete GC high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000155
+name: obsolete Cell width very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000156
+name: obsolete Cell width low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000157
+name: obsolete Cell width mid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000158
+name: obsolete Cell width high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000159
+name: obsolete Cell length very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000016
+name: obsolete NaCl Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000160
+name: obsolete Cell length low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000161
+name: obsolete Cell length mid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000162
+name: obsolete Cell length high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000163
+name: obsolete Temperature Optimum very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000164
+name: obsolete Temperature Optimum low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000165
+name: obsolete Temperature Optimum mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000166
+name: obsolete Temperature Optimum mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000167
+name: obsolete Temperature Optimum mid3
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000168
+name: obsolete Temperature Optimum mid4
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000169
+name: obsolete Temperature Optimum high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000017
+name: obsolete NaCl Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000170
+name: obsolete Temperature Range very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000171
+name: obsolete Temperature Range low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000172
+name: obsolete Temperature Range mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000173
+name: obsolete Temperature Range mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000174
+name: obsolete Temperature Range mid3
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000175
+name: obsolete Temperature Range mid4
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000176
+name: obsolete Temperature Range high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000177
+name: obsolete pH Optimum low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000178
+name: obsolete pH Optimum mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000179
+name: obsolete pH Optimum mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000018
+name: obsolete pH delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000180
+name: obsolete pH Optimum high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000181
+name: obsolete pH Range very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000182
+name: obsolete pH Range low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000183
+name: obsolete pH Range mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000184
+name: obsolete pH Range mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000185
+name: obsolete pH Range mid3
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000186
+name: obsolete pH Range high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000187
+name: obsolete NaCl Optimum low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000188
+name: obsolete NaCl Optimum mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000189
+name: obsolete NaCl Optimum mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000019
+name: obsolete NaCl delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000190
+name: obsolete NaCl Optimum high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000191
+name: obsolete NaCl Range low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000192
+name: obsolete NaCl Range mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000193
+name: obsolete NaCl Range mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000194
+name: obsolete NaCl Range high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000195
+name: obsolete pH Delta very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000196
+name: obsolete pH Delta low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000197
+name: obsolete pH Delta mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000198
+name: obsolete pH Delta mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000199
+name: obsolete pH Delta mid3
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000020
+name: obsolete Temperature Delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000200
+name: obsolete pH Delta high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000201
+name: obsolete NaCl Delta low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000202
+name: obsolete NaCl Delta mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000203
+name: obsolete NaCl Delta mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000204
+name: obsolete NaCl Delta high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000205
+name: obsolete Temperature Delta very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000206
+name: obsolete Temperature Delta low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000207
+name: obsolete Temperature Delta mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000208
+name: obsolete Temperature Delta mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000209
+name: obsolete Temperature Delta high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000021
+name: obsolete Morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000210
+name: obsolete Bacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000211
+name: obsolete Branced
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000212
+name: obsolete Coccobacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000213
+name: obsolete Coccus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000214
+name: obsolete Crescent
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000215
+name: obsolete Curved
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000216
+name: obsolete Curved Spiral
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000217
+name: obsolete Diplococcus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000218
+name: obsolete Disc
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000219
+name: obsolete Dumbbell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000022
+name: obsolete Other
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000220
+name: obsolete Ellipsoidal
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000221
+name: obsolete Filament
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000222
+name: obsolete Flask
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000223
+name: obsolete Fusiform
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000224
+name: obsolete Helical
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000225
+name: obsolete Irregular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000226
+name: obsolete Oval
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000227
+name: obsolete Ovoid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000228
+name: obsolete Pleomorphic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000229
+name: obsolete Ring
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000023
+name: obsolete Psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000230
+name: obsolete Rod
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000231
+name: obsolete Sphere
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000232
+name: obsolete Spindle
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000233
+name: obsolete Spiral
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000234
+name: obsolete Spirochete
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000235
+name: obsolete Spore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000236
+name: obsolete Square
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000237
+name: obsolete Star
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000238
+name: obsolete Star - Dumbbell - Pleomorphic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000239
+name: obsolete Tailed
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000024
+name: obsolete Psychrotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000240
+name: obsolete Triangular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000241
+name: obsolete Vibrio
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000242
+name: obsolete Environmental Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000243
+name: obsolete Growth Condition
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000244
+name: obsolete Physiological Trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000245
+name: obsolete Metabolic Classification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000246
+name: obsolete Cellular Characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000247
+name: obsolete Taxonomic Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000248
+name: obsolete Microbial Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000249
+name: obsolete Growth Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000025
+name: obsolete Mesophilie
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000250
+name: obsolete Structural Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000251
+name: obsolete Temperature Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000252
+name: obsolete Salinity Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000253
+name: obsolete pH Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000254
+name: obsolete Oxygen Requirement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000255
+name: obsolete Carbon Source Utilization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000256
+name: obsolete Energy Acquisition Mode
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000257
+name: obsolete Electron Donor Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000258
+name: obsolete Motility Mechanism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000259
+name: obsolete Motility Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000026
+name: obsolete Thermotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000260
+name: obsolete Bacterial Spore Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000261
+name: obsolete Fungal Spore Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000262
+name: obsolete Reproductive Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000263
+name: obsolete Dormancy Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000264
+name: obsolete Pressure Adaptation Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000265
+name: obsolete Pressure Tolerance Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000266
+name: obsolete Genomic Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000267
+name: obsolete Cell Dimension
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000268
+name: obsolete Optimal Growth Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000269
+name: obsolete Growth Range Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000027
+name: obsolete Thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000270
+name: obsolete Growth Tolerance Metric
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000271
+name: obsolete Cell Shape
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000272
+name: obsolete Cell Arrangement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000273
+name: obsolete Colony Morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000274
+name: obsolete Physical Property
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000275
+name: obsolete Environmental Context
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000276
+name: obsolete Biological Property
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000277
+name: obsolete Functional Classification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000278
+name: obsolete Classification Property
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000279
+name: obsolete METPO Biological Process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000028
+name: obsolete Extreme thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000280
+name: obsolete Measurable Property
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000281
+name: obsolete Gram-stain negative
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000282
+name: obsolete Gram-stain positive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000029
+name: obsolete Hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000030
+name: obsolete Extreme hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000031
+name: obsolete Halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000032
+name: obsolete Non-halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000033
+name: obsolete Slight halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000034
+name: obsolete Moderate halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000035
+name: obsolete Extreme halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000036
+name: obsolete Halotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000037
+name: obsolete Haloalkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000038
+name: obsolete Extreme Acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000039
+name: obsolete Acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000040
+name: obsolete Neutrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000041
+name: obsolete Alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000042
+name: obsolete Acid Tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000043
+name: obsolete Alkali Tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000044
+name: obsolete Extreme Alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000045
+name: obsolete Facultative acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000046
+name: obsolete Obligative acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000047
+name: obsolete Aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000048
+name: obsolete Anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000049
+name: obsolete Facultative anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000050
+name: obsolete Facultative aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000051
+name: obsolete Microaerophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000052
+name: obsolete Aerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000053
+name: obsolete Microaerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000054
+name: obsolete Aerotolerant anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000055
+name: obsolete Obligate aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000056
+name: obsolete Obligate anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000057
+name: obsolete Oxygenic phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000058
+name: obsolete Anoxygenic phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000059
+name: obsolete Autotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000060
+name: obsolete Photoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000061
+name: obsolete Chemoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000062
+name: obsolete Heterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000063
+name: obsolete Photoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000064
+name: obsolete Chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000065
+name: obsolete Lithotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000066
+name: obsolete Organotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000067
+name: obsolete Phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000068
+name: obsolete Chemotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000069
+name: obsolete Oligotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000070
+name: obsolete Copiotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000071
+name: obsolete Lithoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000072
+name: obsolete Mixotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000073
+name: obsolete Lithoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000074
+name: obsolete Chemoorganoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000075
+name: obsolete Chemolithoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000076
+name: obsolete Methylotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000077
+name: obsolete Methanotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000078
+name: obsolete Carboxydotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000079
+name: obsolete Hydrogenotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000080
+name: obsolete Hydrogen oxidizer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000081
+name: obsolete Hydrogen producer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000082
+name: obsolete Nitrogen fixer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000083
+name: obsolete Methanogen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000084
+name: obsolete Sulfate reducer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000085
+name: obsolete Sulfur oxidizer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000086
+name: obsolete Denitrifier
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000087
+name: obsolete Capnophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000088
+name: obsolete Motile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000089
+name: obsolete Non-motile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000090
+name: obsolete Flagellated
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000091
+name: obsolete Peritrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000092
+name: obsolete Lophotrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000093
+name: obsolete Monotrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000094
+name: obsolete Ciliated
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000095
+name: obsolete Gliding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000096
+name: obsolete Twitching
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000097
+name: obsolete Sliding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000098
+name: obsolete Swarming
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000099
+name: obsolete Endospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000100
+name: obsolete Exospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001000
+name: obsolete sensitivity to oxygen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001001
+name: obsolete sensitivity toward
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001002
+name: obsolete 'organismal quality'
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001003
+name: obsolete 'physicial object quality'
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001004
+name: obsolete 'quality'
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001006
+name: obsolete size
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001007
+name: obsolete 1-D extent
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001008
+name: obsolete width
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001009
+name: obsolete length
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000101
+name: obsolete Myxospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001010
+name: obsolete 'prokaryotic metabolically differentiated cell'
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001012
+name: obsolete heterotrophy
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001013
+name: obsolete structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001014
+name: obsolete spore type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001016
+name: obsolete sensitivity toward pressure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001017
+name: obsolete sensitivity toward NaCl
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001018
+name: obsolete sensitivity toward pH
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001019
+name: obsolete sensitivity toward temperature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000102
+name: obsolete Arthrospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001020
+name: obsolete metabolic constraints
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001021
+name: obsolete cell by chemical produced
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000103
+name: obsolete Conidia
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000104
+name: obsolete Sporangiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000105
+name: obsolete Zygospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000106
+name: obsolete Akinetes
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000107
+name: obsolete Chlamydospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000108
+name: obsolete Sporocysts
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000109
+name: obsolete Hypnospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000110
+name: obsolete Gemmae
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000111
+name: obsolete Oospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000112
+name: obsolete Azygospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000113
+name: obsolete Cysts
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000114
+name: obsolete Ascospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000115
+name: obsolete Basidiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000116
+name: obsolete Aleuriospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000117
+name: obsolete Stylospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000118
+name: obsolete Sclerotia
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000119
+name: obsolete Zoospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000120
+name: obsolete Teliospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000121
+name: obsolete Urediniospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000122
+name: obsolete Pycnidiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000123
+name: obsolete Acriospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000124
+name: obsolete Aplanospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000125
+name: obsolete Statismospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000126
+name: obsolete Barotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000127
+name: obsolete Piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000128
+name: obsolete Piezotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000129
+name: obsolete Piezosensitive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000130
+name: obsolete Obligate barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000131
+name: obsolete Facultative barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000132
+name: obsolete Hyperbarophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000133
+name: obsolete Hypobarophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000134
+name: obsolete Atmospheric pressure-adapted
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000135
+name: obsolete Moderate piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000136
+name: obsolete Extreme piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000137
+name: obsolete Stenopiezic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000138
+name: obsolete Eurypiezic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000139
+name: obsolete Pressure-sensitive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000140
+name: obsolete Pressure-resistant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000141
+name: obsolete Pressure-adapted
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000142
+name: obsolete Piezo-acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000143
+name: obsolete Piezo-alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000144
+name: obsolete Piezo-halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000145
+name: obsolete Piezo-psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000146
+name: obsolete Piezo-thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000147
+name: obsolete Piezo-lithoautotrophe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000148
+name: obsolete Piezo-chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000149
+name: obsolete Piezo-oligotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000150
+name: obsolete Piezo-endolithic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000151
+name: obsolete Piezo-tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000152
+name: obsolete GC% low ( < 42.65)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000153
+name: obsolete GC% mid1 (42.65 - 57)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000154
+name: obsolete GC% mid2 (57 - 66.3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000155
+name: obsolete GC% high ( > 66.3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000156
+name: obsolete Cell width uM very low (< 0.5)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000157
+name: obsolete Cell width uM low (0.5 - 0.65)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000158
+name: obsolete Cell width uM mid (0.65 - 0.9)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000159
+name: obsolete Cell width uM high (> 0.9)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000160
+name: obsolete Cell length uM very low (<= 1.3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000161
+name: obsolete Cell length uM low (1.3 - 2)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000162
+name: obsolete Cell length uM mid (2 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000163
+name: obsolete Cell length uM high (> 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000164
+name: obsolete Temperature Optimum C very low (<= 10)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000165
+name: obsolete Temperature Optimum C low (10 - 22)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000166
+name: obsolete Temperature Optimum C mid1 (22 - 27)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000167
+name: obsolete Temperature Optimum C mid2 (27 - 30)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000168
+name: obsolete Temperature Optimum C mid3 (30 - 34)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000169
+name: obsolete Temperature Optimum C mid4 (34 - 40)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000170
+name: obsolete Temperature Optimum C high (> 40)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000171
+name: obsolete Temperature Range C very low (<= 10)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000172
+name: obsolete Temperature Range C low (10 - 22)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000173
+name: obsolete Temperature Range C mid1 (22 - 27)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000174
+name: obsolete Temperature Range C mid2 (27 - 30)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000175
+name: obsolete Temperature Range C mid3 (30 - 34)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000176
+name: obsolete Temperature Range C mid4 (34 - 40)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000177
+name: obsolete Temperature Range C high (> 40)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000178
+name: obsolete pH Optimum low (0 - 6)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000179
+name: obsolete pH Optimum mid1 (6 - 7)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000180
+name: obsolete pH Optimum mid2 (7 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000181
+name: obsolete pH Optimum high (8 - 14)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000182
+name: obsolete pH Range very low (0 - 4)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000183
+name: obsolete pH Range low (4 - 6)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000184
+name: obsolete pH Range mid1 (6 - 7)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000185
+name: obsolete pH Range mid2 (7 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000186
+name: obsolete pH Range mid3 (8 - 10)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000187
+name: obsolete pH Range high (10 - 14)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000188
+name: obsolete % NaCl Optimum low (<= 1)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000189
+name: obsolete % NaCl Optimum mid1 (1 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000190
+name: obsolete % NaCl Optimum mid2 (3 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000191
+name: obsolete % NaCl Optimum high (> 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000192
+name: obsolete % NaCl Range low (<= 1)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000193
+name: obsolete % NaCl Range mid1 (1 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000194
+name: obsolete % NaCl Range mid2 (3 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000195
+name: obsolete % NaCl Range high (> 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000196
+name: obsolete pH delta very low (<= 1)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000197
+name: obsolete pH delta low (1 - 2)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000198
+name: obsolete pH delta mid1 (2 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000199
+name: obsolete pH delta mid2 (3 - 4)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000200
+name: obsolete pH delta mid3 (4 - 5)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000201
+name: obsolete pH delta high (5 - 9)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000202
+name: obsolete % NaCl delta low (<= 1)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000203
+name: obsolete % NaCl delta mid2 (1 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000204
+name: obsolete % NaCl delta mid2 (3 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000205
+name: obsolete % NaCl delta high (>= 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000206
+name: obsolete Temperature C delta very low (1 - 5)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000207
+name: obsolete Temperature C delta low (5 - 10)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000208
+name: obsolete Temperature C delta mid1 (10 - 20)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000209
+name: obsolete Temperature C delta mid2 (20 - 30)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000210
+name: obsolete Temperature C delta high (>= 30)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000211
+name: obsolete bacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000212
+name: obsolete branced
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000213
+name: obsolete coccobacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000214
+name: obsolete coccus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000215
+name: obsolete crescent
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000216
+name: obsolete curved
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000217
+name: obsolete curved spiral
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000218
+name: obsolete diplococcus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000219
+name: obsolete disc
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000220
+name: obsolete dumbbell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000221
+name: obsolete ellipsoidal
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000222
+name: obsolete filament
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000223
+name: obsolete flask
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000224
+name: obsolete fusiform
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000225
+name: obsolete helical
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000226
+name: obsolete irregular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000227
+name: obsolete oval
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000228
+name: obsolete ovoid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000229
+name: obsolete pleomorphic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000230
+name: obsolete ring
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000231
+name: obsolete rod
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000232
+name: obsolete sphere
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000233
+name: obsolete spindle
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000234
+name: obsolete spiral
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000235
+name: obsolete spirochete
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000236
+name: obsolete spore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000237
+name: obsolete square
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000238
+name: obsolete star
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000239
+name: obsolete star - dumbbell - pleomorphic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000240
+name: obsolete tailed
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000241
+name: obsolete triangular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000242
+name: obsolete vibrio
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000243
+name: obsolete Environmental Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000244
+name: obsolete Growth Condition
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000245
+name: obsolete Physiological Trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000246
+name: obsolete Metabolic Classification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000247
+name: obsolete Cellular Characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000248
+name: obsolete Taxonomic Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000249
+name: obsolete Microbial Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000250
+name: obsolete Growth Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000251
+name: obsolete Structural Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000252
+name: obsolete Temperature Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000253
+name: obsolete Salinity Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000254
+name: obsolete pH Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000255
+name: obsolete Oxygen Requirement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000256
+name: obsolete Carbon Source Utilization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000257
+name: obsolete Energy Acquisition Mode
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000258
+name: obsolete Electron Donor Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000259
+name: obsolete Motility Mechanism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000260
+name: obsolete Motility Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000261
+name: obsolete Bacterial Spore Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000262
+name: obsolete Fungal Spore Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000263
+name: obsolete Reproductive Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000264
+name: obsolete Dormancy Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000265
+name: obsolete Pressure Adaptation Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000266
+name: obsolete Pressure Tolerance Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000267
+name: obsolete GenomicFeature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000268
+name: obsolete Cell Dimension
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000269
+name: obsolete Optimal Growth Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000270
+name: obsolete Growth Range Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000271
+name: obsolete Growth Tolerance Metric
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000272
+name: obsolete Cell Shape
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000273
+name: obsolete Cell Arrangement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000274
+name: obsolete Colony Morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000001
+name: obsolete acid-fast
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000002
+name: obsolete acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000003
+name: obsolete active transport
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000004
+name: obsolete adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000005
+name: obsolete adaptive trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000006
+name: obsolete adhesin
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000007
+name: obsolete adhesion structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000008
+name: obsolete aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000009
+name: obsolete aerobic respiration
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000010
+name: obsolete aerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000011
+name: obsolete aggregate
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000012
+name: obsolete akinete
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000013
+name: obsolete alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000014
+name: obsolete ammonification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000015
+name: obsolete amylolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000016
+name: obsolete anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000017
+name: obsolete anaerobic respiration
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000018
+name: obsolete anoxygenic photosynthesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000019
+name: obsolete antibiotic production
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000020
+name: obsolete antibiotic resistance
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000021
+name: obsolete antimicrobial resistance
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000022
+name: obsolete appendage
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000023
+name: obsolete arthrospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000024
+name: obsolete ascospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000025
+name: obsolete autotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000026
+name: obsolete autotrophic process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000027
+name: obsolete auxotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000028
+name: obsolete axial filament
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000029
+name: obsolete bacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000030
+name: obsolete barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000031
+name: obsolete barotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000032
+name: obsolete basidiospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000033
+name: obsolete binary fission
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000034
+name: obsolete biofilm
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000035
+name: obsolete biofilm component
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000036
+name: obsolete biofilm formation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000037
+name: obsolete biogeochemical cycling
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000038
+name: obsolete bioluminescence
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000039
+name: obsolete budding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000040
+name: obsolete buoyancy structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000041
+name: obsolete capnophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000042
+name: obsolete capsule
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000043
+name: obsolete carbon fixation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000044
+name: obsolete carbon source
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000045
+name: obsolete carboxydotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000046
+name: obsolete cell arrangement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000047
+name: obsolete cell envelope
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000048
+name: obsolete cell length category
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000049
+name: obsolete cell shape
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000050
+name: obsolete cell size
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000051
+name: obsolete cell wall characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000052
+name: obsolete cell wall component
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000053
+name: obsolete cell width category
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000054
+name: obsolete cellular characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000055
+name: obsolete cellular component
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000056
+name: obsolete cellular process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000057
+name: obsolete cellular product
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000058
+name: obsolete cellulolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
 
 [Term]
 id: metpo:1000059
@@ -32,6 +3834,402 @@ is_a: metpo:1000630 ! biological process
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
+id: metpo:1000061
+name: obsolete chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000062
+name: obsolete chemotaxis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000063
+name: obsolete chlamydospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000064
+name: obsolete class
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000065
+name: obsolete clinically relevant feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000066
+name: obsolete coccus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000067
+name: obsolete cold shock protein
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000068
+name: obsolete cold shock response
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000069
+name: obsolete colonization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000070
+name: obsolete colony elevation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000071
+name: obsolete colony margin
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000072
+name: obsolete colony morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000073
+name: obsolete colony texture
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000074
+name: obsolete commensalism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000075
+name: obsolete community behavior
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000076
+name: obsolete community structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000077
+name: obsolete compatible solute
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000078
+name: obsolete competence
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000079
+name: obsolete component
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000080
+name: obsolete conidium
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000081
+name: obsolete conjugation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000082
+name: obsolete CRISPR
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000083
+name: obsolete culturability
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000084
+name: obsolete cyst
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000085
+name: obsolete death phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000086
+name: obsolete denitrification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000087
+name: obsolete developmental process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000088
+name: obsolete diagnostic enzyme
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000089
+name: obsolete diagnostic feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000090
+name: obsolete diazotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000091
+name: obsolete differentiation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000092
+name: obsolete dimorphism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000093
+name: obsolete disc-shaped cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000094
+name: obsolete domain
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000095
+name: obsolete dormancy
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000096
+name: obsolete dormancy structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000097
+name: obsolete dumbbell-shaped cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000098
+name: obsolete ecological niche
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000099
+name: obsolete ecological process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000100
+name: obsolete ecological trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000101
+name: obsolete ectosymbiosis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000102
+name: obsolete electron acceptor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000103
+name: obsolete electron donor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000104
+name: obsolete endospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000105
+name: obsolete endosymbiosis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000106
+name: obsolete energy metabolism process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000107
+name: obsolete enzyme activity
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000108
+name: obsolete epigenetic modification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000109
+name: obsolete evolutionary process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000110
+name: obsolete exospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000111
+name: obsolete exponential phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000112
+name: obsolete extracellular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000113
+name: obsolete extracellular polysaccharide
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000114
+name: obsolete extreme halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000115
+name: obsolete extremophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000116
+name: obsolete facultative
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000117
+name: obsolete facultative anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000118
+name: obsolete family
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000119
+name: obsolete fastidious
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000120
+name: obsolete fermentation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000121
+name: obsolete filamentous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000122
+name: obsolete fimbriae
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000123
+name: obsolete flagellum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000124
+name: obsolete flask-shaped cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000125
+name: obsolete fungal spore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000126
+name: obsolete gas vesicle
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
 id: metpo:1000127
 name: GC content
 def: "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs." [] {IAO:0000119="https://purl.dsmz.de/schema/GCContent"}
@@ -40,10 +4238,364 @@ is_a: metpo:1000188 ! quality
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
+id: metpo:1000128
+name: obsolete high GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000129
+name: obsolete low GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000130
+name: obsolete lower-mid GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000131
+name: obsolete upper-mid GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000132
+name: obsolete generation time
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000133
+name: obsolete genetic element
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000134
+name: obsolete genetic exchange
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000135
+name: obsolete genetic process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000136
+name: obsolete genome size
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000137
+name: obsolete genomic element
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000138
+name: obsolete genomic island
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000139
+name: obsolete genomic trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000140
+name: obsolete genus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000141
+name: obsolete gliding motility
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000142
+name: obsolete global regulator
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000143
+name: obsolete Gram-negative
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000144
+name: obsolete Gram-positive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000145
+name: obsolete Gram stain
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000146
+name: obsolete growth characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000147
+name: obsolete growth conditions constraints
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000148
+name: obsolete growth pattern
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000149
+name: obsolete growth rate
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000150
+name: obsolete habitat
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000151
+name: obsolete halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000152
+name: obsolete halotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000153
+name: obsolete heat shock protein
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000154
+name: obsolete heat shock response
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000155
+name: obsolete hemolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000156
+name: obsolete heterocyst
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000157
+name: obsolete heterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000158
+name: obsolete holdfast
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000159
+name: obsolete horizontal gene transfer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000160
+name: obsolete hydrolase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000161
+name: obsolete hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000162
+name: obsolete inclusion body
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000163
+name: obsolete infection
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000164
+name: obsolete interaction
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000165
+name: obsolete interaction with a phage
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000166
+name: obsolete interaction with an environment
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000167
+name: obsolete interaction with host
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000168
+name: obsolete interaction within a community
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000169
+name: obsolete intracellular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000170
+name: obsolete invasion
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000171
+name: obsolete laboratory characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000172
+name: obsolete lag phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000173
+name: obsolete life cycle
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000174
+name: obsolete life cycle phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000175
+name: obsolete lipolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000176
+name: obsolete lipopolysaccharide
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000177
+name: obsolete localization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000178
+name: obsolete lysogeny
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000179
+name: obsolete macroscopic trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000180
+name: obsolete magnetotaxis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000181
+name: obsolete mesophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000182
+name: obsolete metabolic partner
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000183
+name: obsolete metabolic trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000184
+name: obsolete methanogenesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000185
+name: obsolete methylation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
 id: metpo:1000186
 name: material entity
 def: "An object or portion of a substance or mixture of substances that consists of matter" [] {IAO:0000119="BFO:0000040"}
 property_value: IAO:0000117 "Anthea Guo" xsd:string
+
+[Term]
+id: metpo:1000187
+name: obsolete process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
 
 [Term]
 id: metpo:1000188
@@ -51,10 +4603,688 @@ name: quality
 def: "A characteristic of an entity that depends on the entity's existence, size, color, and physiological traits." []
 
 [Term]
+id: metpo:1000189
+name: obsolete system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000190
+name: obsolete microaerophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000191
+name: obsolete mobile genetic element
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000192
+name: obsolete moderate halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000193
+name: obsolete morphological trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000194
+name: obsolete motility process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000195
+name: obsolete motility structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000196
+name: obsolete mutualism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000197
+name: obsolete mycolic acid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000198
+name: obsolete mycorrhization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000199
+name: obsolete neutrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000200
+name: obsolete nitrification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000201
+name: obsolete nitrogen fixation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000202
+name: obsolete nodulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000203
+name: obsolete nucleoid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000204
+name: obsolete nutrient utilization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000205
+name: obsolete obligate
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000206
+name: obsolete obligate aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000207
+name: obsolete obligate anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000208
+name: obsolete oospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000209
+name: obsolete order
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000210
+name: obsolete microbe characterized by growth conditions
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000211
+name: obsolete microbe characterized by nutritional requirement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000212
+name: obsolete microbe characterized by product produced
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000213
+name: obsolete microbe characterized by relation to oxygen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000214
+name: obsolete microbe characterized by relation to ph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000215
+name: obsolete microbe characterized by relation to pressure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000216
+name: obsolete microbe characterized by relation to salt concentration
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000217
+name: obsolete microbe characterized by relation to temperature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000218
+name: obsolete microbe characterized by shape
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000219
+name: obsolete microbe characterized by trophic type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000220
+name: obsolete osmophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000221
+name: obsolete osmoregulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000222
+name: obsolete oxidative stress response
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000223
+name: obsolete oxidoreductase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000224
+name: obsolete oxygen requirement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000225
+name: obsolete oxygenic photosynthesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000226
+name: obsolete pan-genome
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000227
+name: obsolete parasitism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000228
+name: obsolete passive transport
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000229
+name: obsolete pathogenicity
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000230
+name: obsolete pathogenicity island
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000231
+name: obsolete peptidoglycan
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
 id: metpo:1000232
 name: pH delta
 is_a: metpo:1000531 ! pH phenotype with numerical limits
 is_a: metpo:1000534 ! delta phenotype with numerical limits
+
+[Term]
+id: metpo:1000233
+name: obsolete pH optimum (growth range)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000234
+name: obsolete pH preference
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000235
+name: obsolete pH range (growth tolerance)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000236
+name: obsolete pH tolerance
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000237
+name: obsolete phage defense
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000238
+name: obsolete photoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000239
+name: obsolete photoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000240
+name: obsolete photosynthesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000241
+name: obsolete phototaxis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000242
+name: obsolete phylum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000243
+name: obsolete physiological process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000244
+name: obsolete physiological state
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000245
+name: obsolete physiological trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000246
+name: obsolete piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000247
+name: obsolete pigment
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000248
+name: obsolete pigmentation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000249
+name: obsolete pilus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000250
+name: obsolete plant growth promotion
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000251
+name: obsolete plasmid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000252
+name: obsolete pleomorphism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000253
+name: obsolete process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000254
+name: obsolete prophage
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000255
+name: obsolete prostheca
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000256
+name: obsolete protein synthesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000257
+name: obsolete proteolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000258
+name: obsolete prototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000259
+name: obsolete psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000260
+name: obsolete qualifier
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000261
+name: obsolete quorum sensing
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000262
+name: obsolete regulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000263
+name: obsolete regulatory mechanism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000264
+name: obsolete reproductive process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000265
+name: obsolete reproductive structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000266
+name: obsolete resistance mechanism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000267
+name: obsolete respiration
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000268
+name: obsolete restriction-modification system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000269
+name: obsolete ribosome
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000270
+name: obsolete S-layer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000271
+name: obsolete salinity delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000272
+name: obsolete salinity preference
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000273
+name: obsolete secondary metabolite
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000274
+name: obsolete secretion
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000275
+name: obsolete secretion system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000276
+name: obsolete sheathed
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000277
+name: obsolete siderophore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000278
+name: obsolete sigma factor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000279
+name: obsolete signaling
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000280
+name: obsolete slime layer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000281
+name: obsolete specialized cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000282
+name: obsolete species
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000283
+name: obsolete spirillum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000284
+name: obsolete spirochete
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000285
+name: obsolete sporangiospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000286
+name: obsolete sporulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000287
+name: obsolete square cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000288
+name: obsolete stalk
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000289
+name: obsolete star-shaped cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000290
+name: obsolete stationary phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000291
+name: obsolete storage structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000292
+name: obsolete strain
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000293
+name: obsolete stress response
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000294
+name: obsolete structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000295
+name: obsolete sulfate reducer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000296
+name: obsolete swarming
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000297
+name: obsolete symbiosis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000298
+name: obsolete symbiotic process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000299
+name: obsolete syntrophy
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000300
+name: obsolete taxonomic identifier
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000301
+name: obsolete taxonomic rank
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000302
+name: obsolete teichoic acid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
 
 [Term]
 id: metpo:1000303
@@ -71,10 +5301,160 @@ is_a: metpo:1000536 ! optimum phenotype with numerical limits
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
+id: metpo:1000305
+name: obsolete temperature preference
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
 id: metpo:1000306
 name: temperature range
 is_a: metpo:1000533 ! temperature phenotype with numerical limits
 is_a: metpo:1000535 ! growth range phenotype with numerical limits
+
+[Term]
+id: metpo:1000307
+name: obsolete thermal tolerance
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000308
+name: obsolete thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000309
+name: obsolete toxin
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000310
+name: obsolete transcription factor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000311
+name: obsolete transduction
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000312
+name: obsolete transferase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000313
+name: obsolete transformation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000314
+name: obsolete transport system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000315
+name: obsolete transposon
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000316
+name: obsolete triangular cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000317
+name: obsolete trichome
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000318
+name: obsolete twitching motility
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000319
+name: obsolete two-component system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000320
+name: obsolete viable but non-culturable
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000321
+name: obsolete vibrio
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000322
+name: obsolete virulence
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000323
+name: obsolete virulence factor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000324
+name: obsolete virulence process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000325
+name: obsolete xylanolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000326
+name: obsolete zoospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000327
+name: obsolete zygospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000328
+name: obsolete pressure
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000329
+name: obsolete temperature optimum (metabolic activity)
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000330
+name: obsolete temperature range (metabolic viability)
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000331
@@ -112,6 +5492,564 @@ is_a: metpo:1000532 ! salinity phenotype with numerical limits
 is_a: metpo:1000534 ! delta phenotype with numerical limits
 
 [Term]
+id: metpo:1000336
+name: obsolete psychrotolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000337
+name: obsolete thermotolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000338
+name: obsolete extreme thermophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000339
+name: obsolete extreme hyperthermophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000340
+name: obsolete non-halophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000341
+name: obsolete slight halophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000342
+name: obsolete haloalkaliphile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000343
+name: obsolete extreme acidophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000344
+name: obsolete acid tolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000345
+name: obsolete alkali tolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000346
+name: obsolete extreme alkaliphile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000347
+name: obsolete facultative acidophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000348
+name: obsolete obligative acidophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000349
+name: obsolete facultative aerobe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000350
+name: obsolete microaerophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000351
+name: obsolete microaerotolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000352
+name: obsolete aerotolerant anaerobe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000353
+name: obsolete obligate aerobe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000354
+name: obsolete obligate anaerobe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000355
+name: obsolete oxygenic phototroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000356
+name: obsolete anoxygenic phototroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000357
+name: obsolete chemoautotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000358
+name: obsolete chemoheterotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000359
+name: obsolete lithotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000360
+name: obsolete organotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000361
+name: obsolete phototroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000362
+name: obsolete chemotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000363
+name: obsolete oligotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000364
+name: obsolete copiotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000365
+name: obsolete lithoautotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000366
+name: obsolete mixotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000367
+name: obsolete lithoheterotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000368
+name: obsolete chemoorganoheterotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000369
+name: obsolete chemolithoautotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000370
+name: obsolete methylotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000371
+name: obsolete methanotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000372
+name: obsolete hydrogenotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000373
+name: obsolete hydrogen oxidizer
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000374
+name: obsolete hydrogen producer
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000375
+name: obsolete nitrogen fixer
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000376
+name: obsolete methanogen
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000377
+name: obsolete sulfur oxidizer
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000378
+name: obsolete denitrifier
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000379
+name: obsolete motile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000380
+name: obsolete non-motile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000381
+name: obsolete flagellated
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000382
+name: obsolete peritrichous
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000383
+name: obsolete lophotrichous
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000384
+name: obsolete monotrichous
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000385
+name: obsolete ciliated
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000386
+name: obsolete gliding
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000387
+name: obsolete twitching
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000388
+name: obsolete sliding
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000389
+name: obsolete myxospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000390
+name: obsolete conidia
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000391
+name: obsolete chlamydospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000392
+name: obsolete sporocysts
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000393
+name: obsolete hypnospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000394
+name: obsolete gemmae
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000395
+name: obsolete azygospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000396
+name: obsolete aleuriospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000397
+name: obsolete stylospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000398
+name: obsolete sclerotia
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000399
+name: obsolete teliospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000400
+name: obsolete urediniospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000401
+name: obsolete pycnidiospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000402
+name: obsolete acriospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000403
+name: obsolete aplanospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000404
+name: obsolete statismospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000405
+name: obsolete piezotolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000406
+name: obsolete piezosensitive
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000407
+name: obsolete obligate barophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000408
+name: obsolete facultative barophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000409
+name: obsolete hyperbarophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000410
+name: obsolete hypobarophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000411
+name: obsolete atmospheric pressure-adapted
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000412
+name: obsolete moderate piezophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000413
+name: obsolete extreme piezophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000414
+name: obsolete stenopiezic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000415
+name: obsolete eurypiezic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000416
+name: obsolete pressure-sensitive
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000417
+name: obsolete pressure-resistant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000418
+name: obsolete pressure-adapted
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000419
+name: obsolete piezo-acidophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000420
+name: obsolete piezo-alkaliphile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000421
+name: obsolete piezo-halophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000422
+name: obsolete piezo-psychrophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000423
+name: obsolete piezo-thermophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000424
+name: obsolete piezo-lithoautotrophe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000425
+name: obsolete piezo-chemoheterotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000426
+name: obsolete piezo-oligotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000427
+name: obsolete piezo-endolithic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000428
+name: obsolete piezo-tolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000429
 name: GC low
 synonym: "GC_42.65_57.0" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
@@ -142,6 +6080,54 @@ is_a: metpo:1000127 ! GC content
 property_value: metpo:range_min "66.3" xsd:string
 
 [Term]
+id: metpo:1000433
+name: obsolete cell width very low
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000434
+name: obsolete cell width low
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000435
+name: obsolete cell width mid
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000436
+name: obsolete cell width high
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000437
+name: obsolete cell length very low
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000438
+name: obsolete cell length low
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000439
+name: obsolete cell length mid
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000440
+name: obsolete cell length high
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000441
 name: temperature optimum very low
 synonym: "Psychrophile" EXACT []
@@ -164,7 +6150,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000443
 name: temperature optimum mid1
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TO_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000304 ! temperature optimum
 property_value: metpo:range_max "27" xsd:string
@@ -174,7 +6160,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000444
 name: temperature optimum mid2
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TO_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000304 ! temperature optimum
 property_value: metpo:range_max "30" xsd:string
@@ -184,7 +6170,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000445
 name: temperature optimum mid3
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TO_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000304 ! temperature optimum
 property_value: metpo:range_max "34" xsd:string
@@ -194,7 +6180,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000446
 name: temperature optimum mid4
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TO_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000304 ! temperature optimum
 property_value: metpo:range_max "40" xsd:string
@@ -233,7 +6219,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000450
 name: temperature range mid1
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TR_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000306 ! temperature range
 property_value: metpo:range_max "27" xsd:string
@@ -243,7 +6229,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000451
 name: temperature range mid2
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TR_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000306 ! temperature range
 property_value: metpo:range_max "30" xsd:string
@@ -253,7 +6239,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000452
 name: temperature range mid3
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TR_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000306 ! temperature range
 property_value: metpo:range_max "34" xsd:string
@@ -263,7 +6249,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000453
 name: temperature range mid4
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TR_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000306 ! temperature range
 property_value: metpo:range_max "40" xsd:string
@@ -603,6 +6589,228 @@ property_value: metpo:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
+id: metpo:1000488
+name: obsolete branched
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000489
+name: obsolete coccobacillus
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000490
+name: obsolete crescent
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000491
+name: obsolete curved
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000492
+name: obsolete curved spiral
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000493
+name: obsolete diplococcus
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000494
+name: obsolete ellipsoidal
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000495
+name: obsolete filament
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000496
+name: obsolete fusiform
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000497
+name: obsolete helical
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000498
+name: obsolete irregular
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000499
+name: obsolete oval
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000500
+name: obsolete ovoid
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000501
+name: obsolete pleomorphic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000502
+name: obsolete ring
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000503
+name: obsolete rod
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000504
+name: obsolete sphere
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000505
+name: obsolete spindle
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000506
+name: obsolete spiral
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000507
+name: obsolete star - dumbbell - pleomorphic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000508
+name: obsolete tailed
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000509
+name: obsolete temperature adaptation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000510
+name: obsolete salinity adaptation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000511
+name: obsolete pH adaptation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000512
+name: obsolete bacterial spore
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000513
+name: obsolete pressure adaptation type
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000514
+name: obsolete pressure tolerance range
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000515
+name: obsolete sensitivity to oxygen
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000516
+name: obsolete sensitivity toward
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000517
+name: obsolete size
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000518
+name: obsolete 1-D extent
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000519
+name: obsolete width
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000520
+name: obsolete length
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000521
+name: obsolete sensitivity toward pressure
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000522
+name: obsolete sensitivity toward nacl
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000523
+name: obsolete sensitivity toward ph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000524
+name: obsolete sensitivity toward temperature
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000525
 name: microbe
 def: "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation." [] {IAO:0000119="OHMI:0000460"}
@@ -622,6 +6830,18 @@ property_value: skos:closeMatch https://biolink.github.io/biolink-model/Chemical
 id: metpo:1000527
 name: enzyme
 is_a: metpo:1000186 ! material entity
+
+[Term]
+id: metpo:1000528
+name: obsolete structured susceptibility detail
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000529
+name: obsolete facultative psychrophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000531
@@ -998,6 +7218,12 @@ is_a: metpo:1000731 ! nutrient adaptation
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
+id: metpo:1000643
+name: obsolete denitrifying
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000644
 name: heterotrophic
 def: "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide." [] {IAO:0000119="MICRO:0001474"}
@@ -1006,6 +7232,12 @@ synonym: "heterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "heterotrophic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_heterotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000631 ! trophic type
+
+[Term]
+id: metpo:1000645
+name: obsolete hydrogen-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000646
@@ -1062,6 +7294,12 @@ name: mixotrophic
 def: "A trophic type in which an organism can use both organic and inorganic carbon sources for growth." [] {IAO:0000119="MICRO:0001475"}
 synonym: "mixotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:1000631 ! trophic type
+
+[Term]
+id: metpo:1000653
+name: obsolete nitrogen-fixing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000654
@@ -1128,6 +7366,18 @@ synonym: "phototroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_phototroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
+
+[Term]
+id: metpo:1000661
+name: obsolete sulfate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000662
+name: obsolete sulfur-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000663
@@ -1562,6 +7812,228 @@ is_a: metpo:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
+id: metpo:1000807
+name: obsolete Nitrogen compound respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000808
+name: obsolete Nitrate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000809
+name: obsolete Denitrification
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000810
+name: obsolete Dissimilatory nitrate reduction to ammonium
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000811
+name: obsolete Nitrite reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000812
+name: obsolete Anaerobic ammonium oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000813
+name: obsolete Nitric oxide reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000814
+name: obsolete Nitrous oxide reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000815
+name: obsolete Sulfur and sulfoxide compound respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000816
+name: obsolete Sulfate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000817
+name: obsolete Sulfur reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000818
+name: obsolete Sulfite reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000819
+name: obsolete Thiosulfate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000820
+name: obsolete Sulfoxide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000821
+name: obsolete Dimethyl sulfoxide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000822
+name: obsolete Methionine sulfoxide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000823
+name: obsolete Sulfide oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000824
+name: obsolete Thiosulfate oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000825
+name: obsolete Sulfite oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000826
+name: obsolete Tetrathionate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000827
+name: obsolete Polysulfide reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000828
+name: obsolete Metal and metalloid respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000829
+name: obsolete Iron reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000830
+name: obsolete Iron oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000831
+name: obsolete Nitrate-dependent Fe(II) oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000832
+name: obsolete Manganese reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000833
+name: obsolete Manganese oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000834
+name: obsolete Uranium reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000835
+name: obsolete Vanadium reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000836
+name: obsolete Chromium reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000837
+name: obsolete Technetium reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000838
+name: obsolete Cobalt reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000839
+name: obsolete Arsenate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000840
+name: obsolete Arsenite oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000841
+name: obsolete Selenate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000842
+name: obsolete Selenite reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000843
+name: obsolete Carbon and organic compound respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000844
 name: Methanogenesis
 def: "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions." [] {IAO:0000119="GO:0015948"}
@@ -1590,6 +8062,144 @@ def: "A metabolism in which acetate is produced as the sole reduced end product 
 synonym: "Reductive acetyl-CoA pathway" RELATED []
 synonym: "Wood-Ljungdahl pathway" RELATED []
 is_a: metpo:1000060 ! metabolism
+
+[Term]
+id: metpo:1000847
+name: obsolete Fumarate respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000848
+name: obsolete Trimethylamine N-oxide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000849
+name: obsolete Humus respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000850
+name: obsolete Halogenated compound respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000851
+name: obsolete Organohalide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000852
+name: obsolete (Per)chlorate respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000853
+name: obsolete Perchlorate respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000854
+name: obsolete Chlorate respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000855
+name: obsolete Bromate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000856
+name: obsolete Iodate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000857
+name: obsolete Nitrite-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000858
+name: obsolete Nitrate-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000859
+name: obsolete Hydrogen oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000860
+name: obsolete Sulfur oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000861
+name: obsolete Nitrification
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000862
+name: obsolete Complete ammonia oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000863
+name: obsolete Carbon monoxide oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000864
+name: obsolete Hydrogenotrophic methanogenesis
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000865
+name: obsolete Acetoclastic methanogenesis
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000866
+name: obsolete Methylotrophic methanogenesis
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000867
+name: obsolete Anaerobic methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000868
+name: obsolete Lanthanide reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000869
+name: obsolete Lanthanide oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000870
@@ -1703,109 +8313,147 @@ property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
 id: metpo:1001000
-name: observation
+name: obsolete observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001001
-name: optimum temperature observation
-def: "An observation that identifies the temperature at which a microorganism exhibits maximum growth rate or metabolic activity." [] {IAO:0000119="PATO:0000146"}
-is_a: metpo:1001000 ! observation
-property_value: IAO:0000117 "Luke Wang" xsd:string
+name: obsolete optimum temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001002
-name: growth temperature observation
-is_a: metpo:1001000 ! observation
+name: obsolete growth temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001003
-name: temperature range observation
-is_a: metpo:1001000 ! observation
+name: obsolete temperature range observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001004
-name: temperature delta observation
-is_a: metpo:1001000 ! observation
+name: obsolete temperature delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1001005
+name: obsolete culture temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1001006
+name: obsolete culture NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001007
-name: growth NaCl observation
-is_a: metpo:1001000 ! observation
+name: obsolete growth NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001008
-name: NaCl delta observation
-is_a: metpo:1001000 ! observation
+name: obsolete NaCl delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001009
-name: NaCl range observation
-is_a: metpo:1001000 ! observation
+name: obsolete NaCl range observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001010
-name: optimum NaCl observation
-is_a: metpo:1001000 ! observation
+name: obsolete optimum NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1001011
+name: obsolete culture pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001012
-name: growth pH observation
-is_a: metpo:1001000 ! observation
+name: obsolete growth pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001013
-name: optimum pH observation
-is_a: metpo:1001000 ! observation
+name: obsolete optimum pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001014
-name: pH delta observation
-is_a: metpo:1001000 ! observation
+name: obsolete pH delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001015
-name: pH range observation
-is_a: metpo:1001000 ! observation
+name: obsolete pH range observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001016
-name: optimum oxygen observation
-is_a: metpo:1001000 ! observation
+name: obsolete optimum oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001017
-name: growth oxygen observation
-is_a: metpo:1001000 ! observation
+name: obsolete growth oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001018
-name: oxygen range observation
-is_a: metpo:1001000 ! observation
+name: obsolete oxygen range observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001019
-name: oxygen delta observation
-is_a: metpo:1001000 ! observation
+name: obsolete oxygen delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001020
-name: oxygen observation
-is_a: metpo:1001000 ! observation
+name: obsolete oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001021
-name: temperature observation
-is_a: metpo:1001000 ! observation
+name: obsolete temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001022
-name: NaCl observation
-is_a: metpo:1001000 ! observation
+name: obsolete NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001023
-name: pH observation
-is_a: metpo:1001000 ! observation
+name: obsolete pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001101
@@ -1854,6 +8502,24 @@ synonym: "5" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:1001101 ! biosafety level
 
 [Term]
+id: metpo:1002000
+name: obsolete Sulfate-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002001
+name: obsolete Fe(III)-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002002
+name: obsolete Mn(IV)-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1002003
 name: Cable bacteria metabolism
 def: "A metabolism in which electrons are transferred over centimeter-scale distances through multicellular filaments." []
@@ -1874,6 +8540,210 @@ name: Syntrophy
 def: "A metabolism in which the metabolism of one species is thermodynamically dependent on the removal of its products by another species." []
 is_a: metpo:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
+
+[Term]
+id: metpo:1002007
+name: obsolete Sulfur disproportionation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002008
+name: obsolete Nitrogen fixation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002009
+name: obsolete Nitrate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002010
+name: obsolete Anaerobic ammonium-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002011
+name: obsolete Nitrous oxide-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002012
+name: obsolete Sulfate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002013
+name: obsolete Sulfur-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002014
+name: obsolete Sulfite-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002015
+name: obsolete Thiosulfate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002016
+name: obsolete Sulfur-disproportionating
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002017
+name: obsolete Sulfide-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002018
+name: obsolete Thiosulfate-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002019
+name: obsolete Sulfite-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002020
+name: obsolete Iron-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002021
+name: obsolete Iron-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002022
+name: obsolete Nitrate-dependent Fe(II)-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002023
+name: obsolete Manganese-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002024
+name: obsolete Manganese-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002025
+name: obsolete Uranium-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002026
+name: obsolete Arsenate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002027
+name: obsolete Selenate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002028
+name: obsolete Selenite-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002029
+name: obsolete Perchlorate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002030
+name: obsolete Chlorate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002031
+name: obsolete Bromate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002032
+name: obsolete Iodate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002033
+name: obsolete Hydrogen-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002034
+name: obsolete Sulfur-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002035
+name: obsolete Ammonia oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002036
+name: obsolete Nitrite oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002037
+name: obsolete Complete ammonia-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002038
+name: obsolete Methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002039
+name: obsolete Carbon monoxide-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002040
+name: obsolete Nitrogen-fixing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1003000
@@ -2069,7 +8939,7 @@ name: growth medium
 def: "A processed material that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms." [] {IAO:0000119="OBI:0000079"}
 comment: This class is equivalent to OBI:0000079 'culture medium'. It is included in METPO to serve as the range for growth-related object properties.
 is_a: metpo:1000186 ! material entity
-property_value: skos:closeMatch https://biolink.github.io/biolink-model/ChemicalEntity
+property_value: skos:broadMatch https://biolink.github.io/biolink-model/ProcessedMaterial
 
 [Term]
 id: metpo:1005001
@@ -2229,6 +9099,18 @@ name: generalist
 def: "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources." [] {IAO:0000119="inbio:000022"}
 synonym: "generalist" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 is_a: metpo:1000059 ! phenotype
+
+[Term]
+id: metpo:9999999
+name: obsolete obsolete
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000000
+name: obsolete has susceptibility profile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000001
@@ -2540,43 +9422,39 @@ is_a: metpo:2000001 ! organism interacts with chemical
 
 [Typedef]
 id: metpo:2000052
-name: has temperature observation
-def: "Relates a microbe to a temperature observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001021 ! temperature observation
-is_a: metpo:2000511 ! has observation
+name: obsolete has temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000053
-name: has optimum temperature observation
-def: "Relates a microbe to an optimum temperature observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001001 ! optimum temperature observation
-is_a: metpo:2000052 ! has temperature observation
+name: obsolete has optimum temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000054
-name: has growth temperature observation
-def: "Relates a microbe to a growth temperature observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001002 ! growth temperature observation
-is_a: metpo:2000052 ! has temperature observation
+name: obsolete has growth temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000055
-name: has range temperature observation
-def: "Relates a microbe to a growth temperature range observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001003 ! temperature range observation
-is_a: metpo:2000052 ! has temperature observation
+name: obsolete has range temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000056
-name: has temperature delta observation
-def: "Relates a microbe to a temperature tolerance breadth (delta) observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001004 ! temperature delta observation
-is_a: metpo:2000052 ! has temperature observation
+name: obsolete has temperature delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000057
+name: obsolete has culture temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000101
@@ -2606,10 +9484,40 @@ synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:2000001 ! organism interacts with chemical
 
 [Typedef]
+id: metpo:2000201
+name: obsolete lyses
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
 id: metpo:2000202
 name: produces
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:2000001 ! organism interacts with chemical
+
+[Typedef]
+id: metpo:2000203
+name: obsolete fixes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000204
+name: obsolete catabolizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000205
+name: obsolete mineralizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000206
+name: obsolete conjugates
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000207
@@ -2650,16 +9558,88 @@ range: metpo:1000526 ! chemical entity
 is_a: metpo:2000210 ! accumulates
 
 [Typedef]
+id: metpo:2000213
+name: obsolete binds
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000214
+name: obsolete chelates
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000215
+name: obsolete precipitates
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000216
+name: obsolete solubilizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000217
+name: obsolete volatilizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000218
+name: obsolete crystallizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000219
+name: obsolete adsorbs
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
 id: metpo:2000220
 name: does not disproportionate
 synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:2000001 ! organism interacts with chemical
 
 [Typedef]
+id: metpo:2000221
+name: obsolete does not lyse
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
 id: metpo:2000222
 name: does not produce
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:2000001 ! organism interacts with chemical
+
+[Typedef]
+id: metpo:2000223
+name: obsolete does not fix
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000224
+name: obsolete does not catabolize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000225
+name: obsolete does not mineralize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000226
+name: obsolete does not conjugate
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000227
@@ -2700,12 +9680,46 @@ range: metpo:1000526 ! chemical entity
 is_a: metpo:2000230 ! does not accumulate
 
 [Typedef]
+id: metpo:2000233
+name: obsolete does not bind
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000234
+name: obsolete does not chelate
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000235
+name: obsolete does not precipitate
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000236
+name: obsolete does not solubilize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000237
+name: obsolete does not volatilize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000238
+name: obsolete does not crystallize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
 id: metpo:2000239
-name: has pH observation
-def: "Relates a microbe to a pH observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001023 ! pH observation
-is_a: metpo:2000511 ! has observation
+name: obsolete has pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000301
@@ -2732,121 +9746,99 @@ is_a: metpo:2000301 ! enzyme activity analyzed
 
 [Typedef]
 id: metpo:2000501
-name: has optimum pH observation
-def: "Relates a microbe to an optimum pH observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001013 ! optimum pH observation
-is_a: metpo:2000239 ! has pH observation
+name: obsolete has optimum pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000502
-name: has growth pH observation
-def: "Relates a microbe to a growth pH observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001012 ! growth pH observation
-is_a: metpo:2000239 ! has pH observation
+name: obsolete has growth pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000503
-name: has range pH observation
-def: "Relates a microbe to a growth pH range observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001015 ! pH range observation
-is_a: metpo:2000239 ! has pH observation
+name: obsolete has range pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000504
-name: has pH delta observation
-def: "Relates a microbe to a pH tolerance breadth (delta) observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001014 ! pH delta observation
-is_a: metpo:2000239 ! has pH observation
+name: obsolete has pH delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000505
+name: obsolete has culture pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000506
-name: has NaCl observation
-def: "Relates a microbe to a NaCl observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001022 ! NaCl observation
-is_a: metpo:2000511 ! has observation
+name: obsolete has NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000507
-name: has optimum NaCl observation
-def: "Relates a microbe to an optimum NaCl observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001010 ! optimum NaCl observation
-is_a: metpo:2000506 ! has NaCl observation
+name: obsolete has optimum NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000508
-name: has growth NaCl observation
-def: "Relates a microbe to a growth NaCl observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001007 ! growth NaCl observation
-is_a: metpo:2000506 ! has NaCl observation
+name: obsolete has growth NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000509
-name: has range NaCl observation
-def: "Relates a microbe to a growth NaCl range observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001009 ! NaCl range observation
-is_a: metpo:2000506 ! has NaCl observation
+name: obsolete has range NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000510
-name: has NaCl delta observation
-def: "Relates a microbe to a NaCl tolerance breadth (delta) observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001008 ! NaCl delta observation
-is_a: metpo:2000506 ! has NaCl observation
+name: obsolete has NaCl delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000511
-name: has observation
-domain: metpo:1000525 ! microbe
-range: metpo:1001000 ! observation
+name: obsolete has observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000512
-name: has oxygen observation
-def: "Relates a microbe to an oxygen observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001020 ! oxygen observation
-is_a: metpo:2000511 ! has observation
+name: obsolete has oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000513
-name: has optimum oxygen observation
-def: "Relates a microbe to an optimum oxygen observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001016 ! optimum oxygen observation
-is_a: metpo:2000512 ! has oxygen observation
+name: obsolete has optimum oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000514
-name: has growth oxygen observation
-def: "Relates a microbe to a growth oxygen observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001017 ! growth oxygen observation
-is_a: metpo:2000512 ! has oxygen observation
+name: obsolete has growth oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000515
-name: has range oxygen observation
-def: "Relates a microbe to a growth oxygen range observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001018 ! oxygen range observation
-is_a: metpo:2000512 ! has oxygen observation
+name: obsolete has range oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000516
-name: has oxygen delta observation
-def: "Relates a microbe to a oxygen tolerance breadth (delta) observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001019 ! oxygen delta observation
-is_a: metpo:2000512 ! has oxygen observation
+name: obsolete has oxygen delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000517

--- a/metpo-full.owl
+++ b/metpo-full.owl
@@ -15,14 +15,18 @@
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="https://w3id.org/metpo/metpo/metpo-full.owl">
-        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-03-24/metpo-full.owl"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-05-19/metpo-full.owl"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0001-9076-6066"/>
         <dcterms:creator>METPO Development Team</dcterms:creator>
-        <dcterms:description>Microbial ecophysiological trait and phenotype ontology</dcterms:description>
+        <dcterms:description>METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible.</dcterms:description>
         <dcterms:issued>2024-01-01</dcterms:issued>
         <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-        <dcterms:modified>2025-09-29</dcterms:modified>
-        <dcterms:title>METPO</dcterms:title>
-        <owl:versionInfo>2026-03-24</owl:versionInfo>
+        <dcterms:modified>2026-05-18</dcterms:modified>
+        <dcterms:title>METPO: Microbial Ecophysiological Trait and Phenotype Ontology</dcterms:title>
+        <rdfs:seeAlso rdf:resource="https://bioportal.bioontology.org/ontologies/METPO"/>
+        <rdfs:seeAlso rdf:resource="https://bioregistry.io/registry/metpo"/>
+        <rdfs:seeAlso rdf:resource="https://github.com/berkeleybop/metpo"/>
+        <owl:versionInfo>2026-05-19</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -59,6 +63,18 @@
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
         <rdfs:label>definition source</rdfs:label>
     </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000231 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000231"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/contributor -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
     
 
 
@@ -125,6 +141,12 @@
     
 
 
+    <!-- http://www.w3.org/2004/02/skos/core#broadMatch -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#broadMatch"/>
+    
+
+
     <!-- http://www.w3.org/2004/02/skos/core#closeMatch -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#closeMatch"/>
@@ -151,6 +173,16 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- https://w3id.org/metpo/2000000 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000000">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has susceptibility profile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
     
 
 
@@ -981,11 +1013,9 @@
     <!-- https://w3id.org/metpo/2000052 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000052">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000511"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001021"/>
-        <obo:IAO_0000115>Relates a microbe to a temperature observation.</obo:IAO_0000115>
-        <rdfs:label>has temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -993,11 +1023,9 @@
     <!-- https://w3id.org/metpo/2000053 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000053">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000052"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001001"/>
-        <obo:IAO_0000115>Relates a microbe to an optimum temperature observation.</obo:IAO_0000115>
-        <rdfs:label>has optimum temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has optimum temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1005,11 +1033,9 @@
     <!-- https://w3id.org/metpo/2000054 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000054">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000052"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001002"/>
-        <obo:IAO_0000115>Relates a microbe to a growth temperature observation.</obo:IAO_0000115>
-        <rdfs:label>has growth temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has growth temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1017,11 +1043,9 @@
     <!-- https://w3id.org/metpo/2000055 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000055">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000052"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001003"/>
-        <obo:IAO_0000115>Relates a microbe to a growth temperature range observation.</obo:IAO_0000115>
-        <rdfs:label>has range temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has range temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1029,11 +1053,19 @@
     <!-- https://w3id.org/metpo/2000056 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000056">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000052"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001004"/>
-        <obo:IAO_0000115>Relates a microbe to a temperature tolerance breadth (delta) observation.</obo:IAO_0000115>
-        <rdfs:label>has temperature delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has temperature delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000057 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000057">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has culture temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1087,6 +1119,16 @@
     
 
 
+    <!-- https://w3id.org/metpo/2000201 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000201">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lyses</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/metpo/2000202 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000202">
@@ -1100,6 +1142,46 @@
         <owl:annotatedTarget>produces</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/2000203 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000203">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete fixes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000204 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000204">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete catabolizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000205 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000205">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete mineralizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000206 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000206">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete conjugates</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
     
 
 
@@ -1165,6 +1247,76 @@
     
 
 
+    <!-- https://w3id.org/metpo/2000213 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000213">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete binds</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000214 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000214">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chelates</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000215 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000215">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete precipitates</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000216 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000216">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete solubilizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000217 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000217">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete volatilizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000218 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000218">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete crystallizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000219 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000219">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete adsorbs</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/metpo/2000220 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000220">
@@ -1181,6 +1333,16 @@
     
 
 
+    <!-- https://w3id.org/metpo/2000221 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000221">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not lyse</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/metpo/2000222 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000222">
@@ -1194,6 +1356,46 @@
         <owl:annotatedTarget>produces</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/2000223 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not fix</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000224 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000224">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not catabolize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000225 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000225">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not mineralize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000226 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000226">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not conjugate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
     
 
 
@@ -1259,14 +1461,72 @@
     
 
 
+    <!-- https://w3id.org/metpo/2000233 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000233">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not bind</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000234 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000234">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not chelate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000235 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000235">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not precipitate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000236 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000236">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not solubilize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000237 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000237">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not volatilize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000238 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000238">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not crystallize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/metpo/2000239 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000239">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000511"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001023"/>
-        <obo:IAO_0000115>Relates a microbe to a pH observation.</obo:IAO_0000115>
-        <rdfs:label>has pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1327,11 +1587,9 @@
     <!-- https://w3id.org/metpo/2000501 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000501">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000239"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001013"/>
-        <obo:IAO_0000115>Relates a microbe to an optimum pH observation.</obo:IAO_0000115>
-        <rdfs:label>has optimum pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has optimum pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1339,11 +1597,9 @@
     <!-- https://w3id.org/metpo/2000502 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000502">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000239"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001012"/>
-        <obo:IAO_0000115>Relates a microbe to a growth pH observation.</obo:IAO_0000115>
-        <rdfs:label>has growth pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has growth pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1351,11 +1607,9 @@
     <!-- https://w3id.org/metpo/2000503 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000503">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000239"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001015"/>
-        <obo:IAO_0000115>Relates a microbe to a growth pH range observation.</obo:IAO_0000115>
-        <rdfs:label>has range pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has range pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1363,11 +1617,19 @@
     <!-- https://w3id.org/metpo/2000504 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000504">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000239"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001014"/>
-        <obo:IAO_0000115>Relates a microbe to a pH tolerance breadth (delta) observation.</obo:IAO_0000115>
-        <rdfs:label>has pH delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has pH delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000505 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000505">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has culture pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1375,11 +1637,9 @@
     <!-- https://w3id.org/metpo/2000506 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000506">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000511"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001022"/>
-        <obo:IAO_0000115>Relates a microbe to a NaCl observation.</obo:IAO_0000115>
-        <rdfs:label>has NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1387,11 +1647,9 @@
     <!-- https://w3id.org/metpo/2000507 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000507">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000506"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001010"/>
-        <obo:IAO_0000115>Relates a microbe to an optimum NaCl observation.</obo:IAO_0000115>
-        <rdfs:label>has optimum NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has optimum NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1399,11 +1657,9 @@
     <!-- https://w3id.org/metpo/2000508 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000508">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000506"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001007"/>
-        <obo:IAO_0000115>Relates a microbe to a growth NaCl observation.</obo:IAO_0000115>
-        <rdfs:label>has growth NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has growth NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1411,11 +1667,9 @@
     <!-- https://w3id.org/metpo/2000509 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000509">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000506"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001009"/>
-        <obo:IAO_0000115>Relates a microbe to a growth NaCl range observation.</obo:IAO_0000115>
-        <rdfs:label>has range NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has range NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1423,11 +1677,9 @@
     <!-- https://w3id.org/metpo/2000510 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000510">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000506"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001008"/>
-        <obo:IAO_0000115>Relates a microbe to a NaCl tolerance breadth (delta) observation.</obo:IAO_0000115>
-        <rdfs:label>has NaCl delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has NaCl delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1435,9 +1687,9 @@
     <!-- https://w3id.org/metpo/2000511 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000511">
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>has observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1445,11 +1697,9 @@
     <!-- https://w3id.org/metpo/2000512 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000512">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000511"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001020"/>
-        <obo:IAO_0000115>Relates a microbe to an oxygen observation.</obo:IAO_0000115>
-        <rdfs:label>has oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1457,11 +1707,9 @@
     <!-- https://w3id.org/metpo/2000513 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000513">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000512"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001016"/>
-        <obo:IAO_0000115>Relates a microbe to an optimum oxygen observation.</obo:IAO_0000115>
-        <rdfs:label>has optimum oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has optimum oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1469,11 +1717,9 @@
     <!-- https://w3id.org/metpo/2000514 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000514">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000512"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001017"/>
-        <obo:IAO_0000115>Relates a microbe to a growth oxygen observation.</obo:IAO_0000115>
-        <rdfs:label>has growth oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has growth oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1481,11 +1727,9 @@
     <!-- https://w3id.org/metpo/2000515 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000515">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000512"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001018"/>
-        <obo:IAO_0000115>Relates a microbe to a growth oxygen range observation.</obo:IAO_0000115>
-        <rdfs:label>has range oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has range oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1493,11 +1737,9 @@
     <!-- https://w3id.org/metpo/2000516 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000516">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000512"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001019"/>
-        <obo:IAO_0000115>Relates a microbe to a oxygen tolerance breadth (delta) observation.</obo:IAO_0000115>
-        <rdfs:label>has oxygen delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has oxygen delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1634,11 +1876,9 @@
     <!-- https://w3id.org/metpo/2000058 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000058">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
-        <obo:IAO_0000115>A reported temperature value (°C) for this observation.</obo:IAO_0000115>
-        <rdfs:label>has observed spot value</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has observed spot value</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1646,11 +1886,9 @@
     <!-- https://w3id.org/metpo/2000059 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000059">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
-        <obo:IAO_0000115>The minimum temperature (°C) associated with this observation.</obo:IAO_0000115>
-        <rdfs:label>has minimum observed value</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has minimum observed value</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1658,11 +1896,9 @@
     <!-- https://w3id.org/metpo/2000060 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000060">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
-        <obo:IAO_0000115>The maximum temperature (°C) associated with this observation.</obo:IAO_0000115>
-        <rdfs:label>has maximum observed value</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has maximum observed value</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1670,11 +1906,9 @@
     <!-- https://w3id.org/metpo/2000061 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000061">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115>Free-text comments associated with this observation.</obo:IAO_0000115>
-        <rdfs:label>has value comments</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has value comments</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1682,11 +1916,9 @@
     <!-- https://w3id.org/metpo/2000062 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000062">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115>True if this observation indicates no growth at the reported temperature (negative result).</obo:IAO_0000115>
-        <rdfs:label>is negative data</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete is negative data</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1694,7 +1926,9 @@
     <!-- https://w3id.org/metpo/2000063 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000063">
-        <rdfs:label>observation data property</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete observation data property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -2090,7 +2324,7 @@
     <!-- https://w3id.org/metpo/2000730 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000730">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000071"/>
         <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <obo:IAO_0000115>A derived ecological or genomic metric computed from genome or community data.</obo:IAO_0000115>
@@ -2186,6 +2420,6336 @@
     
 
 
+    <!-- https://w3id.org/metpo/0000001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Salinity</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000003 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000003">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000004 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000004">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000005 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000005">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Trophic type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Width</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Length</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000015 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000015">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Salinity</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete METPO Morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000022 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000022">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000023 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000023">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Psychrotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000024 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Mesophilie</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000025 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000025">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Thermotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000026 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000026">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000027 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000027">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000028 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000028">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000029 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000029">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000003 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000003">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000030 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000030">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000031 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000031">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Non-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000032 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000032">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Slight halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000033 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000033">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Moderate halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000034 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000034">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000035 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000035">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Halotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000036 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000036">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000037 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000037">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000038 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000038">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000039 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000039">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Neutrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000004 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000004">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000040 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000040">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000041 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000041">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acid Tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000042 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000042">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000043 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000043">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000044 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000044">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000045 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000045">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000046 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000046">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000047 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000047">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000048 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000048">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000049 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000049">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000005 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000005">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Trophic type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000050 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000050">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microaerophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000051 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000051">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000052 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000052">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microaerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000053 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000053">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000054 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000054">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000055 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000055">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000056 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000056">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000057 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000057">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000058 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000058">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Autotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000059 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000059">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Photoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000060 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000060">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000061 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000061">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Heterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000062 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000062">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Photoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000063 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000063">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000064 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000064">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000065 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000065">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Organotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000066 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000066">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000067 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000067">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000068 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000068">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000069 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000069">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Copiotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000070 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000070">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000071 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000071">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Mixotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000072 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000072">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000073 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000073">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000074 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000074">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000075 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000075">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methylotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000076 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000076">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methanotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000077 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000077">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Carboxydotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000078 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000078">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000079 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000079">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000080 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000080">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogen producer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000081 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000081">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000082 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000082">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methanogen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000083 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000083">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sulfate reducer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000084 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000084">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000085 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000085">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Denitrifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000086 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000086">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Capnophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000087 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000087">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000088 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000088">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Non-motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000089 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000089">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Flagellated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000090 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000090">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Peritrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000091 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000091">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lophotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000092 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000092">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Monotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000093 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000093">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ciliated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000094 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000094">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000095 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000095">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Twitching</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000096 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000096">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000097 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000097">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Swarming</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000098 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000098">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Endospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000099 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000099">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Exospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Width</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000100 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000100">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Myxospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000101 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000101">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Arthrospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000102 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000102">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Conidia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000103 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000103">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporangiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000104 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000104">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Zygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000105 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000105">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Akinetes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000106 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000106">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chlamydospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000107 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000107">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporocysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000108 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000108">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hypnospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000109 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000109">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gemmae</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Length</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000110 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000110">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000111 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000111">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Azygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000112 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000112">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000113 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000113">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ascospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000114 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000114">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Basidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000115 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000115">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aleuriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000116 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000116">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Stylospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000117 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000117">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sclerotia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000118 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000118">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Zoospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000119 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000119">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Teliospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000120 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000120">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Urediniospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000121 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000121">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pycnidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000122 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000122">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000123 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000123">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aplanospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000124 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000124">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Statismospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000125 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000125">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Barotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000126 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000126">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000127 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000127">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000128 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000128">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezosensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000129 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000129">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000130 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000130">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000131 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000131">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hyperbarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000132 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000132">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hypobarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000133 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000133">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000134 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000134">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Moderate piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000135 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000135">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000136 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000136">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Stenopiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000137 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000137">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Eurypiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000138 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000138">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000139 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000139">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-resistant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000140 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000140">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000141 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000141">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000142 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000142">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000143 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000143">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000144 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000144">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000145 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000145">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000146 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000146">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000147 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000147">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000148 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000148">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000149 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000149">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000015 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000015">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000150 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000150">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000151 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000151">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000152 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000152">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000153 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000153">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000154 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000154">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000155 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000155">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000156 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000156">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000157 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000157">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width mid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000158 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000158">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000159 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000159">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000160 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000160">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000161 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000161">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length mid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000162 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000162">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000163 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000163">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000164 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000164">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000165 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000165">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000166 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000166">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000167 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000167">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum mid3</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000168 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000168">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum mid4</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000169 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000169">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000170 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000170">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000171 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000171">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000172 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000172">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000173 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000173">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000174 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000174">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range mid3</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000175 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000175">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range mid4</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000176 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000176">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000177 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000177">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000178 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000178">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000179 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000179">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000180 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000180">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000181 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000181">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000182 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000182">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000183 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000183">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000184 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000184">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000185 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000185">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid3</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000186 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000186">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000187 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000187">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000188 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000188">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000189 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000189">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000190 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000190">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000191 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000191">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000192 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000192">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000193 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000193">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000194 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000194">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000195 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000195">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000196 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000196">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000197 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000197">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000198 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000198">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000199 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000199">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta mid3</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000200 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000200">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000201 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000201">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Delta low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000202 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000202">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000203 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000203">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000204 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000204">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Delta high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000205 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000205">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000206 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000206">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000207 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000207">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000208 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000208">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000209 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000209">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000210 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000210">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Bacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000211 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000211">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Branced</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000212 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000212">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Coccobacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000213 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000213">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Coccus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000214 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000214">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Crescent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000215 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000215">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Curved</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000216 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000216">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Curved Spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000217 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000217">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Diplococcus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000218 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000218">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Disc</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000219 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000219">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Dumbbell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000022 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000022">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Other</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000220 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000220">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ellipsoidal</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000221 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000221">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Filament</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000222 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000222">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Flask</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000223 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Fusiform</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000224 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000224">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Helical</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000225 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000225">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Irregular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000226 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000226">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oval</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000227 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000227">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ovoid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000228 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000228">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000229 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000229">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ring</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000023 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000023">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000230 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000230">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Rod</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000231 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000231">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sphere</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000232 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000232">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Spindle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000233 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000233">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000234 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000234">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Spirochete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000235 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000235">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Spore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000236 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000236">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Square</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000237 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000237">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Star</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000238 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000238">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Star - Dumbbell - Pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000239 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000239">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Tailed</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000024 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Psychrotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000240 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000240">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Triangular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000241 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000241">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Vibrio</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000242 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000242">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Environmental Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000243 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000243">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Condition</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000244 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000244">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Physiological Trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000245 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000245">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Metabolic Classification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000246 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000246">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000247 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000247">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000248 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000248">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000249 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000249">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000025 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000025">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Mesophilie</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000250 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000250">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Structural Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000251 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000251">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000252 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000252">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000253 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000253">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000254 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000254">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000255 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000255">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000256 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000256">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000257 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000257">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Electron Donor Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000258 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000258">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility Mechanism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000259 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000259">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000026 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000026">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Thermotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000260 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000260">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000261 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000261">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000262 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000262">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Reproductive Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000263 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000263">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Dormancy Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000264 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000264">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000265 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000265">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000266 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000266">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Genomic Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000267 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000267">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Dimension</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000268 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000268">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000269 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000269">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000027 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000027">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000270 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000270">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000271 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000271">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Shape</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000272 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000272">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Arrangement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000273 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000273">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Colony Morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000274 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000274">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Physical Property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000275 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000275">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Environmental Context</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000276 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000276">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Biological Property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000277 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000277">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Functional Classification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000278 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000278">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Classification Property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000279 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000279">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete METPO Biological Process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000028 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000028">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000280 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000280">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Measurable Property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000281 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000281">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram-stain negative</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000282 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000282">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram-stain positive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000029 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000029">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000030 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000030">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000031 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000031">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000032 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000032">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Non-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000033 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000033">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Slight halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000034 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000034">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Moderate halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000035 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000035">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000036 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000036">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Halotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000037 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000037">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000038 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000038">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000039 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000039">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000040 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000040">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Neutrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000041 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000041">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000042 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000042">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acid Tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000043 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000043">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000044 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000044">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000045 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000045">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000046 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000046">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000047 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000047">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000048 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000048">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000049 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000049">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000050 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000050">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000051 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000051">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microaerophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000052 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000052">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000053 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000053">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microaerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000054 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000054">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000055 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000055">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000056 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000056">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000057 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000057">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000058 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000058">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000059 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000059">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Autotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000060 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000060">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Photoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000061 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000061">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000062 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000062">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Heterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000063 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000063">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Photoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000064 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000064">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000065 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000065">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000066 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000066">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Organotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000067 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000067">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000068 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000068">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000069 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000069">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000070 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000070">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Copiotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000071 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000071">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000072 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000072">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Mixotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000073 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000073">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000074 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000074">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000075 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000075">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000076 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000076">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methylotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000077 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000077">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methanotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000078 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000078">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Carboxydotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000079 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000079">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000080 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000080">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000081 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000081">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogen producer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000082 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000082">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000083 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000083">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methanogen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000084 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000084">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sulfate reducer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000085 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000085">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000086 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000086">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Denitrifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000087 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000087">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Capnophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000088 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000088">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000089 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000089">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Non-motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000090 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000090">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Flagellated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000091 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000091">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Peritrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000092 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000092">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lophotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000093 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000093">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Monotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000094 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000094">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ciliated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000095 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000095">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000096 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000096">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Twitching</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000097 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000097">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000098 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000098">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Swarming</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000099 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000099">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Endospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000100 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000100">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Exospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001000 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001000">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete &apos;organismal quality&apos;</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001003 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001003">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete &apos;physicial object quality&apos;</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001004 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001004">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete &apos;quality&apos;</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete size</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete 1-D extent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete width</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete length</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000101 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000101">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Myxospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete &apos;prokaryotic metabolically differentiated cell&apos;</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heterotrophy</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spore type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward NaCl</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward pH</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000102 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000102">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Arthrospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete metabolic constraints</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell by chemical produced</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000103 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000103">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Conidia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000104 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000104">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporangiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000105 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000105">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Zygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000106 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000106">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Akinetes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000107 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000107">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chlamydospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000108 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000108">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporocysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000109 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000109">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hypnospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000110 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000110">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gemmae</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000111 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000111">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000112 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000112">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Azygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000113 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000113">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000114 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000114">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ascospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000115 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000115">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Basidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000116 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000116">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aleuriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000117 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000117">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Stylospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000118 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000118">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sclerotia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000119 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000119">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Zoospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000120 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000120">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Teliospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000121 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000121">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Urediniospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000122 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000122">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pycnidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000123 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000123">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000124 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000124">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aplanospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000125 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000125">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Statismospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000126 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000126">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Barotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000127 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000127">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000128 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000128">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000129 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000129">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezosensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000130 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000130">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000131 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000131">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000132 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000132">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hyperbarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000133 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000133">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hypobarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000134 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000134">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000135 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000135">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Moderate piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000136 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000136">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000137 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000137">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Stenopiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000138 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000138">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Eurypiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000139 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000139">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000140 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000140">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-resistant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000141 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000141">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000142 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000142">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000143 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000143">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000144 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000144">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000145 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000145">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000146 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000146">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000147 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000147">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000148 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000148">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000149 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000149">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000150 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000150">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000151 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000151">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000152 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000152">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC% low ( &lt; 42.65)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000153 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000153">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC% mid1 (42.65 - 57)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000154 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000154">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC% mid2 (57 - 66.3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000155 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000155">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC% high ( &gt; 66.3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000156 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000156">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width uM very low (&lt; 0.5)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000157 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000157">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width uM low (0.5 - 0.65)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000158 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000158">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width uM mid (0.65 - 0.9)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000159 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000159">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width uM high (&gt; 0.9)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000160 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000160">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length uM very low (&lt;= 1.3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000161 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000161">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length uM low (1.3 - 2)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000162 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000162">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length uM mid (2 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000163 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000163">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length uM high (&gt; 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000164 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000164">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C very low (&lt;= 10)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000165 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000165">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C low (10 - 22)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000166 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000166">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C mid1 (22 - 27)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000167 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000167">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C mid2 (27 - 30)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000168 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000168">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C mid3 (30 - 34)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000169 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000169">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C mid4 (34 - 40)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000170 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000170">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C high (&gt; 40)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000171 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000171">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C very low (&lt;= 10)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000172 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000172">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C low (10 - 22)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000173 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000173">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C mid1 (22 - 27)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000174 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000174">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C mid2 (27 - 30)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000175 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000175">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C mid3 (30 - 34)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000176 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000176">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C mid4 (34 - 40)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000177 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000177">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C high (&gt; 40)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000178 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000178">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum low (0 - 6)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000179 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000179">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum mid1 (6 - 7)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000180 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000180">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum mid2 (7 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000181 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000181">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum high (8 - 14)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000182 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000182">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range very low (0 - 4)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000183 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000183">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range low (4 - 6)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000184 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000184">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid1 (6 - 7)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000185 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000185">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid2 (7 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000186 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000186">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid3 (8 - 10)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000187 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000187">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range high (10 - 14)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000188 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000188">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Optimum low (&lt;= 1)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000189 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000189">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Optimum mid1 (1 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000190 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000190">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Optimum mid2 (3 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000191 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000191">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Optimum high (&gt; 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000192 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000192">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Range low (&lt;= 1)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000193 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000193">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Range mid1 (1 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000194 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000194">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Range mid2 (3 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000195 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000195">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Range high (&gt; 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000196 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000196">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta very low (&lt;= 1)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000197 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000197">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta low (1 - 2)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000198 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000198">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta mid1 (2 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000199 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000199">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta mid2 (3 - 4)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000200 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000200">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta mid3 (4 - 5)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000201 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000201">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta high (5 - 9)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000202 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000202">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl delta low (&lt;= 1)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000203 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000203">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl delta mid2 (1 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000204 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000204">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl delta mid2 (3 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000205 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000205">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl delta high (&gt;= 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000206 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000206">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta very low (1 - 5)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000207 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000207">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta low (5 - 10)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000208 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000208">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta mid1 (10 - 20)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000209 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000209">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta mid2 (20 - 30)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000210 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000210">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta high (&gt;= 30)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000211 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000211">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete bacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000212 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000212">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete branced</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000213 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000213">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete coccobacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000214 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000214">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete coccus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000215 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000215">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete crescent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000216 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000216">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete curved</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000217 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000217">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete curved spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000218 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000218">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete diplococcus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000219 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000219">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete disc</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000220 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000220">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dumbbell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000221 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000221">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ellipsoidal</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000222 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000222">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete filament</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000223 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete flask</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000224 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000224">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fusiform</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000225 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000225">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete helical</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000226 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000226">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete irregular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000227 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000227">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oval</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000228 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000228">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ovoid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000229 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000229">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000230 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000230">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ring</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000231 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000231">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete rod</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000232 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000232">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sphere</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000233 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000233">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spindle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000234 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000234">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000235 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000235">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spirochete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000236 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000236">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000237 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000237">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete square</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000238 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000238">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete star</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000239 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000239">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000240 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000240">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete tailed</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000241 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000241">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete triangular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000242 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000242">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete vibrio</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000243 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000243">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Environmental Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000244 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000244">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Condition</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000245 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000245">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Physiological Trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000246 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000246">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Metabolic Classification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000247 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000247">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000248 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000248">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000249 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000249">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000250 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000250">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000251 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000251">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Structural Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000252 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000252">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000253 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000253">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000254 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000254">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000255 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000255">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000256 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000256">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000257 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000257">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000258 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000258">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Electron Donor Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000259 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000259">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility Mechanism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000260 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000260">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000261 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000261">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000262 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000262">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000263 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000263">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Reproductive Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000264 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000264">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Dormancy Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000265 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000265">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000266 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000266">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000267 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000267">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GenomicFeature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000268 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000268">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Dimension</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000269 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000269">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000270 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000270">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000271 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000271">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000272 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000272">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Shape</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000273 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000273">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Arrangement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000274 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000274">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Colony Morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete acid-fast</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000003 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000003">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete active transport</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000004 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000004">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000005 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000005">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete adaptive trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete adhesin</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete adhesion structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete aerobic respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete aerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete aggregate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete akinete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ammonification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000015 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000015">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete amylolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete anaerobic respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete anoxygenic photosynthesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete antibiotic production</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete antibiotic resistance</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete antimicrobial resistance</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000022 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000022">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete appendage</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000023 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000023">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete arthrospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000024 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ascospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000025 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000025">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete autotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000026 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000026">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete autotrophic process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000027 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000027">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete auxotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000028 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000028">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete axial filament</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000029 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000029">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete bacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000030 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000030">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000031 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000031">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete barotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000032 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000032">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete basidiospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000033 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000033">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete binary fission</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000034 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000034">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete biofilm</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000035 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000035">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete biofilm component</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000036 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000036">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete biofilm formation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000037 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000037">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete biogeochemical cycling</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000038 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000038">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete bioluminescence</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000039 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000039">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete budding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000040 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000040">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete buoyancy structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000041 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000041">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete capnophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000042 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000042">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete capsule</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000043 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000043">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete carbon fixation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000044 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000044">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete carbon source</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000045 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000045">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete carboxydotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000046 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000046">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell arrangement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000047 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000047">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell envelope</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000048 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000048">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell length category</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000049 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000049">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell shape</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000050 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000050">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell size</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000051 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000051">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell wall characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000052 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000052">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell wall component</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000053 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000053">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell width category</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000054 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000054">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellular characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000055 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000055">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellular component</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000056 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000056">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellular process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000057 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000057">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellular product</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000058 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000058">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellulolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000059 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000059">
@@ -2223,6 +8787,666 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000061 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000061">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000062 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000062">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete chemotaxis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000063 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000063">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete chlamydospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000064 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000064">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete class</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000065 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000065">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete clinically relevant feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000066 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000066">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete coccus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000067 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000067">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cold shock protein</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000068 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000068">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cold shock response</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000069 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000069">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colonization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000070 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000070">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colony elevation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000071 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000071">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colony margin</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000072 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000072">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colony morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000073 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000073">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colony texture</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000074 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000074">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete commensalism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000075 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000075">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete community behavior</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000076 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000076">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete community structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000077 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000077">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete compatible solute</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000078 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000078">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete competence</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000079 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000079">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete component</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000080 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000080">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete conidium</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000081 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000081">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete conjugation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000082 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000082">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete CRISPR</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000083 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000083">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete culturability</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000084 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000084">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cyst</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000085 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000085">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete death phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000086 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000086">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete denitrification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000087 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000087">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete developmental process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000088 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000088">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete diagnostic enzyme</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000089 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000089">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete diagnostic feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000090 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000090">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete diazotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000091 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000091">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete differentiation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000092 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000092">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dimorphism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000093 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000093">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete disc-shaped cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000094 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000094">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete domain</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000095 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000095">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dormancy</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000096 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000096">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dormancy structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000097 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000097">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dumbbell-shaped cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000098 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000098">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ecological niche</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000099 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000099">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ecological process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000100 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000100">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ecological trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000101 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000101">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ectosymbiosis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000102 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000102">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete electron acceptor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000103 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000103">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete electron donor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000104 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000104">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete endospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000105 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000105">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete endosymbiosis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000106 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000106">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete energy metabolism process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000107 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000107">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete enzyme activity</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000108 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000108">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete epigenetic modification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000109 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000109">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete evolutionary process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000110 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000110">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete exospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000111 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000111">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete exponential phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000112 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000112">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete extracellular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000113 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000113">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete extracellular polysaccharide</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000114 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000114">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete extreme halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000115 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000115">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete extremophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000116 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000116">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete facultative</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000117 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000117">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete facultative anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000118 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000118">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete family</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000119 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000119">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fastidious</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000120 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000120">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fermentation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000121 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000121">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete filamentous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000122 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000122">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fimbriae</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000123 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000123">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete flagellum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000124 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000124">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete flask-shaped cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000125 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000125">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fungal spore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000126 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000126">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete gas vesicle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000127 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000127">
@@ -2247,6 +9471,586 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000128 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000128">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete high GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000129 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000129">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete low GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000130 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000130">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lower-mid GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000131 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000131">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete upper-mid GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000132 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000132">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete generation time</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000133 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000133">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genetic element</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000134 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000134">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genetic exchange</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000135 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000135">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genetic process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000136 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000136">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genome size</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000137 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000137">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genomic element</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000138 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000138">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genomic island</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000139 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000139">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genomic trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000140 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000140">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000141 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000141">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete gliding motility</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000142 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000142">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete global regulator</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000143 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000143">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram-negative</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000144 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000144">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram-positive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000145 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000145">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram stain</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000146 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000146">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete growth characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000147 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000147">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete growth conditions constraints</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000148 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000148">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete growth pattern</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000149 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000149">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete growth rate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000150 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000150">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete habitat</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000151 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000151">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000152 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000152">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete halotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000153 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000153">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heat shock protein</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000154 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000154">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heat shock response</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000155 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000155">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete hemolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000156 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000156">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heterocyst</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000157 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000157">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000158 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000158">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete holdfast</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000159 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000159">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete horizontal gene transfer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000160 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000160">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete hydrolase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000161 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000161">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000162 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000162">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete inclusion body</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000163 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000163">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete infection</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000164 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000164">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000165 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000165">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction with a phage</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000166 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000166">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction with an environment</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000167 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000167">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction with host</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000168 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000168">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction within a community</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000169 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000169">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete intracellular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000170 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000170">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete invasion</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000171 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000171">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete laboratory characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000172 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000172">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lag phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000173 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000173">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete life cycle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000174 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000174">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete life cycle phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000175 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000175">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lipolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000176 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000176">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lipopolysaccharide</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000177 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000177">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete localization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000178 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000178">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lysogeny</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000179 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000179">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete macroscopic trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000180 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000180">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete magnetotaxis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000181 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000181">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mesophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000182 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000182">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete metabolic partner</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000183 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000183">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete metabolic trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000184 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000184">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete methanogenesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000185 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000185">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete methylation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000186 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000186">
@@ -2263,11 +10067,451 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000187 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000187">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000188 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000188">
         <obo:IAO_0000115>A characteristic of an entity that depends on the entity&apos;s existence, size, color, and physiological traits.</obo:IAO_0000115>
         <rdfs:label>quality</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000189 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000189">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000190 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000190">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microaerophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000191 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000191">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mobile genetic element</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000192 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000192">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete moderate halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000193 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000193">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete morphological trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000194 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000194">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete motility process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000195 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000195">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete motility structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000196 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000196">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mutualism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000197 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000197">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mycolic acid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000198 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000198">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mycorrhization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000199 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000199">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete neutrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000200 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000200">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nitrification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000201 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000201">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nitrogen fixation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000202 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000202">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nodulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000203 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000203">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nucleoid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000204 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000204">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nutrient utilization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000205 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000205">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete obligate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000206 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000206">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete obligate aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000207 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000207">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete obligate anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000208 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000208">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000209 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000209">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete order</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000210 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000210">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by growth conditions</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000211 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000211">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by nutritional requirement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000212 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000212">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by product produced</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000213 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000213">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000214 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000214">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to ph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000215 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000215">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000216 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000216">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to salt concentration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000217 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000217">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000218 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000218">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by shape</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000219 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000219">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by trophic type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000220 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000220">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete osmophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000221 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000221">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete osmoregulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000222 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000222">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oxidative stress response</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000223 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oxidoreductase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000224 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000224">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oxygen requirement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000225 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000225">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oxygenic photosynthesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000226 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000226">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pan-genome</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000227 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000227">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete parasitism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000228 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000228">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete passive transport</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000229 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000229">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pathogenicity</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000230 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000230">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pathogenicity island</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000231 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000231">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete peptidoglycan</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -2278,6 +10522,706 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000531"/>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000534"/>
         <rdfs:label>pH delta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000233 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000233">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH optimum (growth range)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000234 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000234">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH preference</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000235 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000235">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH range (growth tolerance)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000236 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000236">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH tolerance</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000237 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000237">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete phage defense</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000238 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000238">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete photoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000239 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000239">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete photoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000240 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000240">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete photosynthesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000241 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000241">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete phototaxis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000242 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000242">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete phylum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000243 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000243">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete physiological process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000244 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000244">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete physiological state</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000245 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000245">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete physiological trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000246 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000246">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000247 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000247">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pigment</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000248 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000248">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pigmentation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000249 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000249">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pilus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000250 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000250">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete plant growth promotion</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000251 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000251">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete plasmid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000252 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000252">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pleomorphism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000253 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000253">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000254 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000254">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete prophage</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000255 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000255">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete prostheca</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000256 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000256">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete protein synthesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000257 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000257">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete proteolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000258 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000258">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete prototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000259 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000259">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000260 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000260">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete qualifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000261 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000261">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete quorum sensing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000262 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000262">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete regulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000263 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000263">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete regulatory mechanism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000264 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000264">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete reproductive process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000265 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000265">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete reproductive structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000266 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000266">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete resistance mechanism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000267 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000267">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000268 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000268">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete restriction-modification system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000269 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000269">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ribosome</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000270 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000270">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete S-layer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000271 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000271">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete salinity delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000272 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000272">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete salinity preference</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000273 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000273">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete secondary metabolite</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000274 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000274">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete secretion</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000275 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000275">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete secretion system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000276 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000276">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sheathed</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000277 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000277">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete siderophore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000278 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000278">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sigma factor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000279 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000279">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete signaling</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000280 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000280">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete slime layer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000281 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000281">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete specialized cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000282 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000282">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete species</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000283 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000283">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spirillum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000284 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000284">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spirochete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000285 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000285">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sporangiospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000286 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000286">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sporulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000287 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000287">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete square cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000288 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000288">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete stalk</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000289 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000289">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete star-shaped cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000290 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000290">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete stationary phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000291 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000291">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete storage structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000292 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000292">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete strain</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000293 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000293">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete stress response</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000294 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000294">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000295 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000295">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sulfate reducer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000296 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000296">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete swarming</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000297 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000297">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete symbiosis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000298 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000298">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete symbiotic process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000299 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000299">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete syntrophy</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000300 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000300">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete taxonomic identifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000301 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000301">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete taxonomic rank</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000302 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000302">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete teichoic acid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -2310,12 +11254,262 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000305 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000305">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete temperature preference</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000306 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000306">
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000533"/>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000535"/>
         <rdfs:label>temperature range</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000307 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000307">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete thermal tolerance</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000308 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000308">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000309 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000309">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete toxin</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000310 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000310">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transcription factor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000311 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000311">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000312 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000312">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transferase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000313 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000313">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transformation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000314 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000314">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transport system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000315 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000315">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transposon</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000316 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000316">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete triangular cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000317 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000317">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete trichome</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000318 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000318">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete twitching motility</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000319 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000319">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete two-component system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000320 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000320">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete viable but non-culturable</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000321 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000321">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete vibrio</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000322 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000322">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete virulence</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000323 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000323">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete virulence factor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000324 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000324">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete virulence process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000325 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000325">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete xylanolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000326 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000326">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete zoospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000327 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000327">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete zygospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000328 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000328">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000329 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000329">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature optimum (metabolic activity)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000330 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000330">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature range (metabolic viability)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -2377,6 +11571,936 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000532"/>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000534"/>
         <rdfs:label>NaCl delta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000336 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000336">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete psychrotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000337 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000337">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete thermotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000338 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000338">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000339 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000339">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000340 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000340">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete non-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000341 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000341">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete slight halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000342 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000342">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete haloalkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000343 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000343">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000344 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000344">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete acid tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000345 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000345">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete alkali tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000346 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000346">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000347 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000347">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete facultative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000348 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000348">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obligative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000349 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000349">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete facultative aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000350 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000350">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete microaerophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000351 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000351">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete microaerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000352 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000352">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete aerotolerant anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000353 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000353">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obligate aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000354 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000354">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obligate anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000355 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000355">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000356 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000356">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete anoxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000357 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000357">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000358 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000358">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000359 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000359">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lithotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000360 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000360">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete organotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000361 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000361">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000362 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000362">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000363 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000363">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000364 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000364">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete copiotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000365 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000365">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000366 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000366">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete mixotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000367 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000367">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lithoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000368 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000368">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemoorganoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000369 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000369">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemolithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000370 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000370">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete methylotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000371 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000371">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete methanotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000372 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000372">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hydrogenotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000373 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000373">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hydrogen oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000374 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000374">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hydrogen producer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000375 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000375">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete nitrogen fixer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000376 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000376">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete methanogen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000377 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000377">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sulfur oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000378 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000378">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete denitrifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000379 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000379">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000380 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000380">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete non-motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000381 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000381">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete flagellated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000382 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000382">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete peritrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000383 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000383">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lophotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000384 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000384">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete monotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000385 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000385">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete ciliated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000386 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000386">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete gliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000387 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000387">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete twitching</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000388 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000388">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000389 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000389">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete myxospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000390 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000390">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete conidia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000391 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000391">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chlamydospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000392 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000392">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sporocysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000393 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000393">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hypnospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000394 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000394">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete gemmae</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000395 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000395">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete azygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000396 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000396">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete aleuriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000397 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000397">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete stylospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000398 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000398">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sclerotia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000399 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000399">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete teliospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000400 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000400">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete urediniospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000401 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000401">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pycnidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000402 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000402">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete acriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000403 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000403">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete aplanospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000404 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000404">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete statismospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000405 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000405">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000406 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000406">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezosensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000407 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000407">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obligate barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000408 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000408">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete facultative barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000409 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000409">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hyperbarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000410 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000410">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hypobarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000411 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000411">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete atmospheric pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000412 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000412">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete moderate piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000413 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000413">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000414 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000414">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete stenopiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000415 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000415">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete eurypiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000416 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000416">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure-sensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000417 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000417">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure-resistant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000418 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000418">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000419 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000419">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000420 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000420">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000421 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000421">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000422 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000422">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000423 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000423">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000424 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000424">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-lithoautotrophe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000425 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000425">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000426 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000426">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000427 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000427">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-endolithic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000428 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000428">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -2537,6 +12661,86 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000433 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000433">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell width very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000434 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000434">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell width low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000435 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000435">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell width mid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000436 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000436">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell width high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000437 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000437">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell length very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000438 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000438">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell length low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000439 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000439">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell length mid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000440 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000440">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell length high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000441 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000441">
@@ -2648,7 +12852,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000304"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid1</rdfs:label>
         <metpo:range_max>27</metpo:range_max>
@@ -2691,7 +12895,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000304"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid2</rdfs:label>
         <metpo:range_max>30</metpo:range_max>
@@ -2734,7 +12938,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000304"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid3</rdfs:label>
         <metpo:range_max>34</metpo:range_max>
@@ -2777,7 +12981,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000304"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid4</rdfs:label>
         <metpo:range_max>40</metpo:range_max>
@@ -2942,7 +13146,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000306"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid1</rdfs:label>
         <metpo:range_max>27</metpo:range_max>
@@ -2985,7 +13189,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000306"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid2</rdfs:label>
         <metpo:range_max>30</metpo:range_max>
@@ -3028,7 +13232,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000306"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid3</rdfs:label>
         <metpo:range_max>34</metpo:range_max>
@@ -3071,7 +13275,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000306"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid4</rdfs:label>
         <metpo:range_max>40</metpo:range_max>
@@ -4513,6 +14717,376 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000488 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000488">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete branched</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000489 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000489">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete coccobacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000490 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000490">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete crescent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000491 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000491">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete curved</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000492 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000492">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete curved spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000493 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000493">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete diplococcus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000494 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000494">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete ellipsoidal</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000495 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000495">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete filament</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000496 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000496">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete fusiform</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000497 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000497">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete helical</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000498 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000498">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete irregular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000499 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000499">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oval</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000500 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000500">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete ovoid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000501 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000501">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000502 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000502">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete ring</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000503 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000503">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete rod</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000504 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000504">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sphere</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000505 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000505">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete spindle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000506 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000506">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000507 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000507">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000508 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000508">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete tailed</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000509 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000509">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000510 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000510">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete salinity adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000511 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000511">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pH adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000512 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000512">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete bacterial spore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000513 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000513">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure adaptation type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000514 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000514">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure tolerance range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000515 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000515">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000516 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000516">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000517 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000517">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete size</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000518 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000518">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete 1-D extent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000519 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000519">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete width</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000520 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000520">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete length</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000521 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000521">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000522 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000522">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward nacl</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000523 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000523">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward ph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000524 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000524">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000525 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000525">
@@ -4554,6 +15128,26 @@
     <owl:Class rdf:about="https://w3id.org/metpo/1000527">
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000186"/>
         <rdfs:label>enzyme</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000528 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000528">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete structured susceptibility detail</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000529 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000529">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete facultative psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -5825,6 +16419,16 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000643 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000643">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete denitrifying</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000644 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000644">
@@ -5866,6 +16470,16 @@
         <owl:annotatedTarget>heterotrophic</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://github.com/jmadin/bacteria_archaea_traits"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/1000645 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000645">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hydrogen-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
     
 
 
@@ -6036,6 +16650,16 @@
         <owl:annotatedTarget>mixotroph</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/1000653 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000653">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete nitrogen-fixing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
     
 
 
@@ -6281,6 +16905,26 @@
         <owl:annotatedTarget>phototroph</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/1000661 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000661">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sulfate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000662 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000662">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sulfur-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
     
 
 
@@ -7634,6 +18278,376 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000807 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000807">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrogen compound respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000808 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000808">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000809 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000809">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Denitrification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000810 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000810">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Dissimilatory nitrate reduction to ammonium</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000811 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000811">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrite reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000812 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000812">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Anaerobic ammonium oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000813 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000813">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitric oxide reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000814 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000814">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrous oxide reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000815 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000815">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur and sulfoxide compound respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000816 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000816">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000817 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000817">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000818 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000818">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfite reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000819 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000819">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Thiosulfate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000820 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000820">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfoxide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000821 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000821">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Dimethyl sulfoxide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000822 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000822">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Methionine sulfoxide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000823 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000823">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfide oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000824 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000824">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Thiosulfate oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000825 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000825">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfite oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000826 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000826">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Tetrathionate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000827 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000827">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Polysulfide reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000828 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000828">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Metal and metalloid respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000829 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000829">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iron reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000830 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000830">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iron oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000831 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000831">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate-dependent Fe(II) oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000832 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000832">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Manganese reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000833 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000833">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Manganese oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000834 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000834">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Uranium reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000835 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000835">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Vanadium reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000836 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000836">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Chromium reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000837 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000837">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Technetium reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000838 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000838">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Cobalt reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000839 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000839">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Arsenate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000840 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000840">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Arsenite oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000841 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000841">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Selenate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000842 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000842">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Selenite reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000843 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000843">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Carbon and organic compound respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000844 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000844">
@@ -7690,6 +18704,236 @@
         <oboInOwl:hasRelatedSynonym>Reductive acetyl-CoA pathway</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>Wood-Ljungdahl pathway</oboInOwl:hasRelatedSynonym>
         <rdfs:label>Homoacetogenesis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000847 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000847">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Fumarate respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000848 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000848">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Trimethylamine N-oxide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000849 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000849">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Humus respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000850 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000850">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Halogenated compound respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000851 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000851">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Organohalide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000852 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000852">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete (Per)chlorate respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000853 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000853">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Perchlorate respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000854 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000854">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Chlorate respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000855 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000855">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Bromate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000856 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000856">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iodate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000857 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000857">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrite-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000858 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000858">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000859 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000859">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Hydrogen oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000860 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000860">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000861 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000861">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000862 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000862">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Complete ammonia oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000863 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000863">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Carbon monoxide oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000864 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000864">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Hydrogenotrophic methanogenesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000865 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000865">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Acetoclastic methanogenesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000866 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000866">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Methylotrophic methanogenesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000867 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000867">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Anaerobic methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000868 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000868">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Lanthanide reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000869 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000869">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Lanthanide oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8184,7 +19428,9 @@
     <!-- https://w3id.org/metpo/1001000 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001000">
-        <rdfs:label>observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8192,25 +19438,19 @@
     <!-- https://w3id.org/metpo/1001001 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001001">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <obo:IAO_0000115>An observation that identifies the temperature at which a microorganism exhibits maximum growth rate or metabolic activity.</obo:IAO_0000115>
-        <obo:IAO_0000117>Luke Wang</obo:IAO_0000117>
-        <rdfs:label>optimum temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete optimum temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1001001"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget>An observation that identifies the temperature at which a microorganism exhibits maximum growth rate or metabolic activity.</owl:annotatedTarget>
-        <obo:IAO_0000119 rdf:resource="http://purl.obolibrary.org/obo/PATO_0000146"/>
-    </owl:Axiom>
     
 
 
     <!-- https://w3id.org/metpo/1001002 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001002">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>growth temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete growth temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8218,8 +19458,9 @@
     <!-- https://w3id.org/metpo/1001003 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001003">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>temperature range observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature range observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8227,8 +19468,29 @@
     <!-- https://w3id.org/metpo/1001004 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001004">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>temperature delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1001005 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1001005">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete culture temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1001006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1001006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete culture NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8236,8 +19498,9 @@
     <!-- https://w3id.org/metpo/1001007 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001007">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>growth NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete growth NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8245,8 +19508,9 @@
     <!-- https://w3id.org/metpo/1001008 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001008">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>NaCl delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete NaCl delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8254,8 +19518,9 @@
     <!-- https://w3id.org/metpo/1001009 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001009">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>NaCl range observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete NaCl range observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8263,8 +19528,19 @@
     <!-- https://w3id.org/metpo/1001010 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001010">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>optimum NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete optimum NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1001011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1001011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete culture pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8272,8 +19548,9 @@
     <!-- https://w3id.org/metpo/1001012 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001012">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>growth pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete growth pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8281,8 +19558,9 @@
     <!-- https://w3id.org/metpo/1001013 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001013">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>optimum pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete optimum pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8290,8 +19568,9 @@
     <!-- https://w3id.org/metpo/1001014 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001014">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>pH delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pH delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8299,8 +19578,9 @@
     <!-- https://w3id.org/metpo/1001015 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001015">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>pH range observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pH range observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8308,8 +19588,9 @@
     <!-- https://w3id.org/metpo/1001016 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001016">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>optimum oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete optimum oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8317,8 +19598,9 @@
     <!-- https://w3id.org/metpo/1001017 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001017">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>growth oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete growth oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8326,8 +19608,9 @@
     <!-- https://w3id.org/metpo/1001018 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001018">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>oxygen range observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oxygen range observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8335,8 +19618,9 @@
     <!-- https://w3id.org/metpo/1001019 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001019">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>oxygen delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oxygen delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8344,8 +19628,9 @@
     <!-- https://w3id.org/metpo/1001020 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001020">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8353,8 +19638,9 @@
     <!-- https://w3id.org/metpo/1001021 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001021">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8362,8 +19648,9 @@
     <!-- https://w3id.org/metpo/1001022 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001022">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8371,8 +19658,9 @@
     <!-- https://w3id.org/metpo/1001023 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001023">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8495,6 +19783,36 @@
     
 
 
+    <!-- https://w3id.org/metpo/1002000 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002000">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfate-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Fe(III)-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Mn(IV)-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1002003 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1002003">
@@ -8542,6 +19860,346 @@
         <obo:IAO_0000115>A metabolism in which the metabolism of one species is thermodynamically dependent on the removal of its products by another species.</obo:IAO_0000115>
         <obo:IAO_0000117>Jed Dongjin Kim-Ozaeta</obo:IAO_0000117>
         <rdfs:label>Syntrophy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur disproportionation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrogen fixation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Anaerobic ammonium-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrous oxide-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfite-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002015 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002015">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Thiosulfate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur-disproportionating</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfide-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Thiosulfate-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfite-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iron-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iron-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002022 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002022">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate-dependent Fe(II)-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002023 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002023">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Manganese-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002024 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Manganese-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002025 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002025">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Uranium-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002026 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002026">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Arsenate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002027 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002027">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Selenate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002028 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002028">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Selenite-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002029 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002029">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Perchlorate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002030 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002030">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Chlorate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002031 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002031">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Bromate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002032 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002032">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iodate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002033 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002033">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Hydrogen-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002034 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002034">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002035 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002035">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Ammonia oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002036 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002036">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrite oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002037 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002037">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Complete ammonia-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002038 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002038">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002039 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002039">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Carbon monoxide-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002040 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002040">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrogen-fixing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -9059,7 +20717,7 @@
         <obo:IAO_0000115>A processed material that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms.</obo:IAO_0000115>
         <rdfs:comment>This class is equivalent to OBI:0000079 &apos;culture medium&apos;. It is included in METPO to serve as the range for growth-related object properties.</rdfs:comment>
         <rdfs:label>growth medium</rdfs:label>
-        <skos:closeMatch rdf:resource="https://biolink.github.io/biolink-model/ChemicalEntity"/>
+        <skos:broadMatch rdf:resource="https://biolink.github.io/biolink-model/ProcessedMaterial"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1004005"/>
@@ -9278,15 +20936,15 @@
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1005025"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
-        <owl:annotatedTarget>presence of hemolysis</owl:annotatedTarget>
-        <obo:IAO_0000119 rdf:resource="https://metatraits.embl.de/"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1005025"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>A phenotype describing the ability of an organism to lyse red blood cells.</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="http://purl.obolibrary.org/obo/OMP_0005117"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1005025"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>presence of hemolysis</owl:annotatedTarget>
+        <obo:IAO_0000119 rdf:resource="https://metatraits.embl.de/"/>
     </owl:Axiom>
     
 
@@ -9467,6 +21125,16 @@
         <owl:annotatedTarget>generalist</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://metatraits.embl.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/9999999 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/9999999">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obsolete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
 </rdf:RDF>
 
 

--- a/metpo.json
+++ b/metpo.json
@@ -3,11 +3,14 @@
     "id" : "https://w3id.org/metpo/metpo.json",
     "meta" : {
       "basicPropertyValues" : [ {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0001-9076-6066"
+      }, {
         "pred" : "http://purl.org/dc/terms/creator",
         "val" : "METPO Development Team"
       }, {
         "pred" : "http://purl.org/dc/terms/description",
-        "val" : "Microbial ecophysiological trait and phenotype ontology"
+        "val" : "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible."
       }, {
         "pred" : "http://purl.org/dc/terms/issued",
         "val" : "2024-01-01"
@@ -16,23 +19,8267 @@
         "val" : "https://creativecommons.org/licenses/by/4.0/"
       }, {
         "pred" : "http://purl.org/dc/terms/modified",
-        "val" : "2025-09-29"
+        "val" : "2026-05-18"
       }, {
         "pred" : "http://purl.org/dc/terms/title",
-        "val" : "METPO"
+        "val" : "METPO: Microbial Ecophysiological Trait and Phenotype Ontology"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://bioportal.bioontology.org/ontologies/METPO"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://bioregistry.io/registry/metpo"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+        "val" : "https://github.com/berkeleybop/metpo"
       }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-03-24"
+        "val" : "2026-05-19"
       } ],
-      "version" : "https://w3id.org/metpo/metpo/releases/2026-03-24/metpo.json"
+      "version" : "https://w3id.org/metpo/metpo/releases/2026-05-19/metpo.json"
     },
     "nodes" : [ {
+      "id" : "https://w3id.org/metpo/0000001",
+      "lbl" : "obsolete Temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000002",
+      "lbl" : "obsolete Salinity",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000003",
+      "lbl" : "obsolete pH",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000004",
+      "lbl" : "obsolete Oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000005",
+      "lbl" : "obsolete Trophic type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000006",
+      "lbl" : "obsolete Motility",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000007",
+      "lbl" : "obsolete Sporulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000008",
+      "lbl" : "obsolete Pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000009",
+      "lbl" : "obsolete GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000001",
+      "lbl" : "obsolete Temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000010",
+      "lbl" : "obsolete Cell Width",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000011",
+      "lbl" : "obsolete Cell Length",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000012",
+      "lbl" : "obsolete Temperature Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000013",
+      "lbl" : "obsolete Temperature Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000014",
+      "lbl" : "obsolete pH Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000015",
+      "lbl" : "obsolete pH Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000016",
+      "lbl" : "obsolete NaCl Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000017",
+      "lbl" : "obsolete NaCl Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000018",
+      "lbl" : "obsolete pH delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000019",
+      "lbl" : "obsolete NaCl delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000002",
+      "lbl" : "obsolete Salinity",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000020",
+      "lbl" : "obsolete Temperature Delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000021",
+      "lbl" : "obsolete METPO Morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000022",
+      "lbl" : "obsolete Psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000023",
+      "lbl" : "obsolete Psychrotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000024",
+      "lbl" : "obsolete Mesophilie",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000025",
+      "lbl" : "obsolete Thermotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000026",
+      "lbl" : "obsolete Thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000027",
+      "lbl" : "obsolete Extreme thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000028",
+      "lbl" : "obsolete Hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000029",
+      "lbl" : "obsolete Extreme hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000003",
+      "lbl" : "obsolete pH",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000030",
+      "lbl" : "obsolete Halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000031",
+      "lbl" : "obsolete Non-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000032",
+      "lbl" : "obsolete Slight halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000033",
+      "lbl" : "obsolete Moderate halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000034",
+      "lbl" : "obsolete Extreme halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000035",
+      "lbl" : "obsolete Halotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000036",
+      "lbl" : "obsolete Haloalkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000037",
+      "lbl" : "obsolete Extreme Acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000038",
+      "lbl" : "obsolete Acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000039",
+      "lbl" : "obsolete Neutrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000004",
+      "lbl" : "obsolete Oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000040",
+      "lbl" : "obsolete Alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000041",
+      "lbl" : "obsolete Acid Tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000042",
+      "lbl" : "obsolete Alkali Tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000043",
+      "lbl" : "obsolete Extreme Alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000044",
+      "lbl" : "obsolete Facultative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000045",
+      "lbl" : "obsolete Obligative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000046",
+      "lbl" : "obsolete Aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000047",
+      "lbl" : "obsolete Anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000048",
+      "lbl" : "obsolete Facultative anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000049",
+      "lbl" : "obsolete Facultative aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000005",
+      "lbl" : "obsolete Trophic type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000050",
+      "lbl" : "obsolete Microaerophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000051",
+      "lbl" : "obsolete Aerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000052",
+      "lbl" : "obsolete Microaerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000053",
+      "lbl" : "obsolete Aerotolerant anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000054",
+      "lbl" : "obsolete Obligate aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000055",
+      "lbl" : "obsolete Obligate anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000056",
+      "lbl" : "obsolete Oxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000057",
+      "lbl" : "obsolete Anoxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000058",
+      "lbl" : "obsolete Autotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000059",
+      "lbl" : "obsolete Photoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000006",
+      "lbl" : "obsolete Motility",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000060",
+      "lbl" : "obsolete Chemoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000061",
+      "lbl" : "obsolete Heterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000062",
+      "lbl" : "obsolete Photoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000063",
+      "lbl" : "obsolete Chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000064",
+      "lbl" : "obsolete Lithotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000065",
+      "lbl" : "obsolete Organotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000066",
+      "lbl" : "obsolete Phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000067",
+      "lbl" : "obsolete Chemotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000068",
+      "lbl" : "obsolete Oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000069",
+      "lbl" : "obsolete Copiotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000007",
+      "lbl" : "obsolete Sporulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000070",
+      "lbl" : "obsolete Lithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000071",
+      "lbl" : "obsolete Mixotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000072",
+      "lbl" : "obsolete Lithoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000073",
+      "lbl" : "obsolete Chemoorganoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000074",
+      "lbl" : "obsolete Chemolithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000075",
+      "lbl" : "obsolete Methylotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000076",
+      "lbl" : "obsolete Methanotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000077",
+      "lbl" : "obsolete Carboxydotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000078",
+      "lbl" : "obsolete Hydrogenotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000079",
+      "lbl" : "obsolete Hydrogen oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000008",
+      "lbl" : "obsolete Pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000080",
+      "lbl" : "obsolete Hydrogen producer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000081",
+      "lbl" : "obsolete Nitrogen fixer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000082",
+      "lbl" : "obsolete Methanogen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000083",
+      "lbl" : "obsolete Sulfate reducer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000084",
+      "lbl" : "obsolete Sulfur oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000085",
+      "lbl" : "obsolete Denitrifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000086",
+      "lbl" : "obsolete Capnophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000087",
+      "lbl" : "obsolete Motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000088",
+      "lbl" : "obsolete Non-motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000089",
+      "lbl" : "obsolete Flagellated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000009",
+      "lbl" : "obsolete GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000090",
+      "lbl" : "obsolete Peritrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000091",
+      "lbl" : "obsolete Lophotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000092",
+      "lbl" : "obsolete Monotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000093",
+      "lbl" : "obsolete Ciliated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000094",
+      "lbl" : "obsolete Gliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000095",
+      "lbl" : "obsolete Twitching",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000096",
+      "lbl" : "obsolete Sliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000097",
+      "lbl" : "obsolete Swarming",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000098",
+      "lbl" : "obsolete Endospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000099",
+      "lbl" : "obsolete Exospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000010",
+      "lbl" : "obsolete Cell Width",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000100",
+      "lbl" : "obsolete Myxospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000101",
+      "lbl" : "obsolete Arthrospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000102",
+      "lbl" : "obsolete Conidia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000103",
+      "lbl" : "obsolete Sporangiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000104",
+      "lbl" : "obsolete Zygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000105",
+      "lbl" : "obsolete Akinetes",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000106",
+      "lbl" : "obsolete Chlamydospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000107",
+      "lbl" : "obsolete Sporocysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000108",
+      "lbl" : "obsolete Hypnospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000109",
+      "lbl" : "obsolete Gemmae",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000011",
+      "lbl" : "obsolete Cell Length",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000110",
+      "lbl" : "obsolete Oospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000111",
+      "lbl" : "obsolete Azygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000112",
+      "lbl" : "obsolete Cysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000113",
+      "lbl" : "obsolete Ascospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000114",
+      "lbl" : "obsolete Basidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000115",
+      "lbl" : "obsolete Aleuriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000116",
+      "lbl" : "obsolete Stylospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000117",
+      "lbl" : "obsolete Sclerotia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000118",
+      "lbl" : "obsolete Zoospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000119",
+      "lbl" : "obsolete Teliospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000012",
+      "lbl" : "obsolete Temperature Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000120",
+      "lbl" : "obsolete Urediniospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000121",
+      "lbl" : "obsolete Pycnidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000122",
+      "lbl" : "obsolete Acriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000123",
+      "lbl" : "obsolete Aplanospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000124",
+      "lbl" : "obsolete Statismospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000125",
+      "lbl" : "obsolete Barotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000126",
+      "lbl" : "obsolete Piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000127",
+      "lbl" : "obsolete Piezotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000128",
+      "lbl" : "obsolete Piezosensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000129",
+      "lbl" : "obsolete Obligate barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000013",
+      "lbl" : "obsolete Temperature Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000130",
+      "lbl" : "obsolete Facultative barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000131",
+      "lbl" : "obsolete Hyperbarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000132",
+      "lbl" : "obsolete Hypobarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000133",
+      "lbl" : "obsolete Atmospheric pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000134",
+      "lbl" : "obsolete Moderate piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000135",
+      "lbl" : "obsolete Extreme piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000136",
+      "lbl" : "obsolete Stenopiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000137",
+      "lbl" : "obsolete Eurypiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000138",
+      "lbl" : "obsolete Pressure-sensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000139",
+      "lbl" : "obsolete Pressure-resistant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000014",
+      "lbl" : "obsolete pH Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000140",
+      "lbl" : "obsolete Pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000141",
+      "lbl" : "obsolete Piezo-acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000142",
+      "lbl" : "obsolete Piezo-alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000143",
+      "lbl" : "obsolete Piezo-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000144",
+      "lbl" : "obsolete Piezo-psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000145",
+      "lbl" : "obsolete Piezo-thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000146",
+      "lbl" : "obsolete Piezo-lithoautotrophe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000147",
+      "lbl" : "obsolete Piezo-chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000148",
+      "lbl" : "obsolete Piezo-oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000149",
+      "lbl" : "obsolete Piezo-endolithic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000015",
+      "lbl" : "obsolete pH Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000150",
+      "lbl" : "obsolete Piezo-tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000151",
+      "lbl" : "obsolete GC low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000152",
+      "lbl" : "obsolete GC mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000153",
+      "lbl" : "obsolete GC mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000154",
+      "lbl" : "obsolete GC high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000155",
+      "lbl" : "obsolete Cell width very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000156",
+      "lbl" : "obsolete Cell width low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000157",
+      "lbl" : "obsolete Cell width mid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000158",
+      "lbl" : "obsolete Cell width high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000159",
+      "lbl" : "obsolete Cell length very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000016",
+      "lbl" : "obsolete NaCl Optimum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000160",
+      "lbl" : "obsolete Cell length low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000161",
+      "lbl" : "obsolete Cell length mid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000162",
+      "lbl" : "obsolete Cell length high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000163",
+      "lbl" : "obsolete Temperature Optimum very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000164",
+      "lbl" : "obsolete Temperature Optimum low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000165",
+      "lbl" : "obsolete Temperature Optimum mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000166",
+      "lbl" : "obsolete Temperature Optimum mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000167",
+      "lbl" : "obsolete Temperature Optimum mid3",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000168",
+      "lbl" : "obsolete Temperature Optimum mid4",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000169",
+      "lbl" : "obsolete Temperature Optimum high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000017",
+      "lbl" : "obsolete NaCl Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000170",
+      "lbl" : "obsolete Temperature Range very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000171",
+      "lbl" : "obsolete Temperature Range low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000172",
+      "lbl" : "obsolete Temperature Range mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000173",
+      "lbl" : "obsolete Temperature Range mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000174",
+      "lbl" : "obsolete Temperature Range mid3",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000175",
+      "lbl" : "obsolete Temperature Range mid4",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000176",
+      "lbl" : "obsolete Temperature Range high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000177",
+      "lbl" : "obsolete pH Optimum low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000178",
+      "lbl" : "obsolete pH Optimum mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000179",
+      "lbl" : "obsolete pH Optimum mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000018",
+      "lbl" : "obsolete pH delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000180",
+      "lbl" : "obsolete pH Optimum high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000181",
+      "lbl" : "obsolete pH Range very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000182",
+      "lbl" : "obsolete pH Range low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000183",
+      "lbl" : "obsolete pH Range mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000184",
+      "lbl" : "obsolete pH Range mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000185",
+      "lbl" : "obsolete pH Range mid3",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000186",
+      "lbl" : "obsolete pH Range high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000187",
+      "lbl" : "obsolete NaCl Optimum low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000188",
+      "lbl" : "obsolete NaCl Optimum mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000189",
+      "lbl" : "obsolete NaCl Optimum mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000019",
+      "lbl" : "obsolete NaCl delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000190",
+      "lbl" : "obsolete NaCl Optimum high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000191",
+      "lbl" : "obsolete NaCl Range low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000192",
+      "lbl" : "obsolete NaCl Range mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000193",
+      "lbl" : "obsolete NaCl Range mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000194",
+      "lbl" : "obsolete NaCl Range high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000195",
+      "lbl" : "obsolete pH Delta very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000196",
+      "lbl" : "obsolete pH Delta low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000197",
+      "lbl" : "obsolete pH Delta mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000198",
+      "lbl" : "obsolete pH Delta mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000199",
+      "lbl" : "obsolete pH Delta mid3",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000020",
+      "lbl" : "obsolete Temperature Delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000200",
+      "lbl" : "obsolete pH Delta high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000201",
+      "lbl" : "obsolete NaCl Delta low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000202",
+      "lbl" : "obsolete NaCl Delta mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000203",
+      "lbl" : "obsolete NaCl Delta mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000204",
+      "lbl" : "obsolete NaCl Delta high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000205",
+      "lbl" : "obsolete Temperature Delta very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000206",
+      "lbl" : "obsolete Temperature Delta low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000207",
+      "lbl" : "obsolete Temperature Delta mid1",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000208",
+      "lbl" : "obsolete Temperature Delta mid2",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000209",
+      "lbl" : "obsolete Temperature Delta high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000021",
+      "lbl" : "obsolete Morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000210",
+      "lbl" : "obsolete Bacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000211",
+      "lbl" : "obsolete Branced",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000212",
+      "lbl" : "obsolete Coccobacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000213",
+      "lbl" : "obsolete Coccus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000214",
+      "lbl" : "obsolete Crescent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000215",
+      "lbl" : "obsolete Curved",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000216",
+      "lbl" : "obsolete Curved Spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000217",
+      "lbl" : "obsolete Diplococcus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000218",
+      "lbl" : "obsolete Disc",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000219",
+      "lbl" : "obsolete Dumbbell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000022",
+      "lbl" : "obsolete Other",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000220",
+      "lbl" : "obsolete Ellipsoidal",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000221",
+      "lbl" : "obsolete Filament",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000222",
+      "lbl" : "obsolete Flask",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000223",
+      "lbl" : "obsolete Fusiform",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000224",
+      "lbl" : "obsolete Helical",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000225",
+      "lbl" : "obsolete Irregular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000226",
+      "lbl" : "obsolete Oval",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000227",
+      "lbl" : "obsolete Ovoid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000228",
+      "lbl" : "obsolete Pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000229",
+      "lbl" : "obsolete Ring",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000023",
+      "lbl" : "obsolete Psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000230",
+      "lbl" : "obsolete Rod",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000231",
+      "lbl" : "obsolete Sphere",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000232",
+      "lbl" : "obsolete Spindle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000233",
+      "lbl" : "obsolete Spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000234",
+      "lbl" : "obsolete Spirochete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000235",
+      "lbl" : "obsolete Spore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000236",
+      "lbl" : "obsolete Square",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000237",
+      "lbl" : "obsolete Star",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000238",
+      "lbl" : "obsolete Star - Dumbbell - Pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000239",
+      "lbl" : "obsolete Tailed",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000024",
+      "lbl" : "obsolete Psychrotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000240",
+      "lbl" : "obsolete Triangular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000241",
+      "lbl" : "obsolete Vibrio",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000242",
+      "lbl" : "obsolete Environmental Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000243",
+      "lbl" : "obsolete Growth Condition",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000244",
+      "lbl" : "obsolete Physiological Trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000245",
+      "lbl" : "obsolete Metabolic Classification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000246",
+      "lbl" : "obsolete Cellular Characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000247",
+      "lbl" : "obsolete Taxonomic Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000248",
+      "lbl" : "obsolete Microbial Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000249",
+      "lbl" : "obsolete Growth Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000025",
+      "lbl" : "obsolete Mesophilie",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000250",
+      "lbl" : "obsolete Structural Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000251",
+      "lbl" : "obsolete Temperature Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000252",
+      "lbl" : "obsolete Salinity Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000253",
+      "lbl" : "obsolete pH Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000254",
+      "lbl" : "obsolete Oxygen Requirement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000255",
+      "lbl" : "obsolete Carbon Source Utilization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000256",
+      "lbl" : "obsolete Energy Acquisition Mode",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000257",
+      "lbl" : "obsolete Electron Donor Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000258",
+      "lbl" : "obsolete Motility Mechanism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000259",
+      "lbl" : "obsolete Motility Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000026",
+      "lbl" : "obsolete Thermotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000260",
+      "lbl" : "obsolete Bacterial Spore Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000261",
+      "lbl" : "obsolete Fungal Spore Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000262",
+      "lbl" : "obsolete Reproductive Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000263",
+      "lbl" : "obsolete Dormancy Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000264",
+      "lbl" : "obsolete Pressure Adaptation Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000265",
+      "lbl" : "obsolete Pressure Tolerance Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000266",
+      "lbl" : "obsolete Genomic Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000267",
+      "lbl" : "obsolete Cell Dimension",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000268",
+      "lbl" : "obsolete Optimal Growth Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000269",
+      "lbl" : "obsolete Growth Range Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000027",
+      "lbl" : "obsolete Thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000270",
+      "lbl" : "obsolete Growth Tolerance Metric",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000271",
+      "lbl" : "obsolete Cell Shape",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000272",
+      "lbl" : "obsolete Cell Arrangement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000273",
+      "lbl" : "obsolete Colony Morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000274",
+      "lbl" : "obsolete Physical Property",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000275",
+      "lbl" : "obsolete Environmental Context",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000276",
+      "lbl" : "obsolete Biological Property",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000277",
+      "lbl" : "obsolete Functional Classification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000278",
+      "lbl" : "obsolete Classification Property",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000279",
+      "lbl" : "obsolete METPO Biological Process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000028",
+      "lbl" : "obsolete Extreme thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000280",
+      "lbl" : "obsolete Measurable Property",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000281",
+      "lbl" : "obsolete Gram-stain negative",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0000282",
+      "lbl" : "obsolete Gram-stain positive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000029",
+      "lbl" : "obsolete Hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000030",
+      "lbl" : "obsolete Extreme hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000031",
+      "lbl" : "obsolete Halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000032",
+      "lbl" : "obsolete Non-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000033",
+      "lbl" : "obsolete Slight halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000034",
+      "lbl" : "obsolete Moderate halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000035",
+      "lbl" : "obsolete Extreme halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000036",
+      "lbl" : "obsolete Halotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000037",
+      "lbl" : "obsolete Haloalkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000038",
+      "lbl" : "obsolete Extreme Acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000039",
+      "lbl" : "obsolete Acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000040",
+      "lbl" : "obsolete Neutrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000041",
+      "lbl" : "obsolete Alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000042",
+      "lbl" : "obsolete Acid Tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000043",
+      "lbl" : "obsolete Alkali Tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000044",
+      "lbl" : "obsolete Extreme Alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000045",
+      "lbl" : "obsolete Facultative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000046",
+      "lbl" : "obsolete Obligative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000047",
+      "lbl" : "obsolete Aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000048",
+      "lbl" : "obsolete Anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000049",
+      "lbl" : "obsolete Facultative anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000050",
+      "lbl" : "obsolete Facultative aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000051",
+      "lbl" : "obsolete Microaerophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000052",
+      "lbl" : "obsolete Aerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000053",
+      "lbl" : "obsolete Microaerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000054",
+      "lbl" : "obsolete Aerotolerant anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000055",
+      "lbl" : "obsolete Obligate aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000056",
+      "lbl" : "obsolete Obligate anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000057",
+      "lbl" : "obsolete Oxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000058",
+      "lbl" : "obsolete Anoxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000059",
+      "lbl" : "obsolete Autotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000060",
+      "lbl" : "obsolete Photoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000061",
+      "lbl" : "obsolete Chemoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000062",
+      "lbl" : "obsolete Heterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000063",
+      "lbl" : "obsolete Photoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000064",
+      "lbl" : "obsolete Chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000065",
+      "lbl" : "obsolete Lithotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000066",
+      "lbl" : "obsolete Organotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000067",
+      "lbl" : "obsolete Phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000068",
+      "lbl" : "obsolete Chemotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000069",
+      "lbl" : "obsolete Oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000070",
+      "lbl" : "obsolete Copiotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000071",
+      "lbl" : "obsolete Lithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000072",
+      "lbl" : "obsolete Mixotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000073",
+      "lbl" : "obsolete Lithoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000074",
+      "lbl" : "obsolete Chemoorganoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000075",
+      "lbl" : "obsolete Chemolithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000076",
+      "lbl" : "obsolete Methylotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000077",
+      "lbl" : "obsolete Methanotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000078",
+      "lbl" : "obsolete Carboxydotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000079",
+      "lbl" : "obsolete Hydrogenotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000080",
+      "lbl" : "obsolete Hydrogen oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000081",
+      "lbl" : "obsolete Hydrogen producer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000082",
+      "lbl" : "obsolete Nitrogen fixer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000083",
+      "lbl" : "obsolete Methanogen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000084",
+      "lbl" : "obsolete Sulfate reducer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000085",
+      "lbl" : "obsolete Sulfur oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000086",
+      "lbl" : "obsolete Denitrifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000087",
+      "lbl" : "obsolete Capnophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000088",
+      "lbl" : "obsolete Motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000089",
+      "lbl" : "obsolete Non-motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000090",
+      "lbl" : "obsolete Flagellated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000091",
+      "lbl" : "obsolete Peritrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000092",
+      "lbl" : "obsolete Lophotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000093",
+      "lbl" : "obsolete Monotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000094",
+      "lbl" : "obsolete Ciliated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000095",
+      "lbl" : "obsolete Gliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000096",
+      "lbl" : "obsolete Twitching",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000097",
+      "lbl" : "obsolete Sliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000098",
+      "lbl" : "obsolete Swarming",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000099",
+      "lbl" : "obsolete Endospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000100",
+      "lbl" : "obsolete Exospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001000",
+      "lbl" : "obsolete sensitivity to oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001001",
+      "lbl" : "obsolete sensitivity toward",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001002",
+      "lbl" : "obsolete 'organismal quality'",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001003",
+      "lbl" : "obsolete 'physicial object quality'",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001004",
+      "lbl" : "obsolete 'quality'",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001006",
+      "lbl" : "obsolete size",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001007",
+      "lbl" : "obsolete 1-D extent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001008",
+      "lbl" : "obsolete width",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001009",
+      "lbl" : "obsolete length",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000101",
+      "lbl" : "obsolete Myxospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001010",
+      "lbl" : "obsolete 'prokaryotic metabolically differentiated cell'",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001012",
+      "lbl" : "obsolete heterotrophy",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001013",
+      "lbl" : "obsolete structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001014",
+      "lbl" : "obsolete spore type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001016",
+      "lbl" : "obsolete sensitivity toward pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001017",
+      "lbl" : "obsolete sensitivity toward NaCl",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001018",
+      "lbl" : "obsolete sensitivity toward pH",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001019",
+      "lbl" : "obsolete sensitivity toward temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000102",
+      "lbl" : "obsolete Arthrospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001020",
+      "lbl" : "obsolete metabolic constraints",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/0001021",
+      "lbl" : "obsolete cell by chemical produced",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000103",
+      "lbl" : "obsolete Conidia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000104",
+      "lbl" : "obsolete Sporangiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000105",
+      "lbl" : "obsolete Zygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000106",
+      "lbl" : "obsolete Akinetes",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000107",
+      "lbl" : "obsolete Chlamydospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000108",
+      "lbl" : "obsolete Sporocysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000109",
+      "lbl" : "obsolete Hypnospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000110",
+      "lbl" : "obsolete Gemmae",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000111",
+      "lbl" : "obsolete Oospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000112",
+      "lbl" : "obsolete Azygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000113",
+      "lbl" : "obsolete Cysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000114",
+      "lbl" : "obsolete Ascospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000115",
+      "lbl" : "obsolete Basidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000116",
+      "lbl" : "obsolete Aleuriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000117",
+      "lbl" : "obsolete Stylospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000118",
+      "lbl" : "obsolete Sclerotia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000119",
+      "lbl" : "obsolete Zoospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000120",
+      "lbl" : "obsolete Teliospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000121",
+      "lbl" : "obsolete Urediniospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000122",
+      "lbl" : "obsolete Pycnidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000123",
+      "lbl" : "obsolete Acriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000124",
+      "lbl" : "obsolete Aplanospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000125",
+      "lbl" : "obsolete Statismospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000126",
+      "lbl" : "obsolete Barotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000127",
+      "lbl" : "obsolete Piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000128",
+      "lbl" : "obsolete Piezotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000129",
+      "lbl" : "obsolete Piezosensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000130",
+      "lbl" : "obsolete Obligate barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000131",
+      "lbl" : "obsolete Facultative barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000132",
+      "lbl" : "obsolete Hyperbarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000133",
+      "lbl" : "obsolete Hypobarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000134",
+      "lbl" : "obsolete Atmospheric pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000135",
+      "lbl" : "obsolete Moderate piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000136",
+      "lbl" : "obsolete Extreme piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000137",
+      "lbl" : "obsolete Stenopiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000138",
+      "lbl" : "obsolete Eurypiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000139",
+      "lbl" : "obsolete Pressure-sensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000140",
+      "lbl" : "obsolete Pressure-resistant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000141",
+      "lbl" : "obsolete Pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000142",
+      "lbl" : "obsolete Piezo-acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000143",
+      "lbl" : "obsolete Piezo-alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000144",
+      "lbl" : "obsolete Piezo-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000145",
+      "lbl" : "obsolete Piezo-psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000146",
+      "lbl" : "obsolete Piezo-thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000147",
+      "lbl" : "obsolete Piezo-lithoautotrophe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000148",
+      "lbl" : "obsolete Piezo-chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000149",
+      "lbl" : "obsolete Piezo-oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000150",
+      "lbl" : "obsolete Piezo-endolithic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000151",
+      "lbl" : "obsolete Piezo-tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000152",
+      "lbl" : "obsolete GC% low ( < 42.65)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000153",
+      "lbl" : "obsolete GC% mid1 (42.65 - 57)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000154",
+      "lbl" : "obsolete GC% mid2 (57 - 66.3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000155",
+      "lbl" : "obsolete GC% high ( > 66.3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000156",
+      "lbl" : "obsolete Cell width uM very low (< 0.5)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000157",
+      "lbl" : "obsolete Cell width uM low (0.5 - 0.65)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000158",
+      "lbl" : "obsolete Cell width uM mid (0.65 - 0.9)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000159",
+      "lbl" : "obsolete Cell width uM high (> 0.9)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000160",
+      "lbl" : "obsolete Cell length uM very low (<= 1.3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000161",
+      "lbl" : "obsolete Cell length uM low (1.3 - 2)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000162",
+      "lbl" : "obsolete Cell length uM mid (2 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000163",
+      "lbl" : "obsolete Cell length uM high (> 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000164",
+      "lbl" : "obsolete Temperature Optimum C very low (<= 10)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000165",
+      "lbl" : "obsolete Temperature Optimum C low (10 - 22)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000166",
+      "lbl" : "obsolete Temperature Optimum C mid1 (22 - 27)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000167",
+      "lbl" : "obsolete Temperature Optimum C mid2 (27 - 30)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000168",
+      "lbl" : "obsolete Temperature Optimum C mid3 (30 - 34)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000169",
+      "lbl" : "obsolete Temperature Optimum C mid4 (34 - 40)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000170",
+      "lbl" : "obsolete Temperature Optimum C high (> 40)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000171",
+      "lbl" : "obsolete Temperature Range C very low (<= 10)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000172",
+      "lbl" : "obsolete Temperature Range C low (10 - 22)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000173",
+      "lbl" : "obsolete Temperature Range C mid1 (22 - 27)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000174",
+      "lbl" : "obsolete Temperature Range C mid2 (27 - 30)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000175",
+      "lbl" : "obsolete Temperature Range C mid3 (30 - 34)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000176",
+      "lbl" : "obsolete Temperature Range C mid4 (34 - 40)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000177",
+      "lbl" : "obsolete Temperature Range C high (> 40)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000178",
+      "lbl" : "obsolete pH Optimum low (0 - 6)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000179",
+      "lbl" : "obsolete pH Optimum mid1 (6 - 7)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000180",
+      "lbl" : "obsolete pH Optimum mid2 (7 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000181",
+      "lbl" : "obsolete pH Optimum high (8 - 14)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000182",
+      "lbl" : "obsolete pH Range very low (0 - 4)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000183",
+      "lbl" : "obsolete pH Range low (4 - 6)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000184",
+      "lbl" : "obsolete pH Range mid1 (6 - 7)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000185",
+      "lbl" : "obsolete pH Range mid2 (7 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000186",
+      "lbl" : "obsolete pH Range mid3 (8 - 10)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000187",
+      "lbl" : "obsolete pH Range high (10 - 14)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000188",
+      "lbl" : "obsolete % NaCl Optimum low (<= 1)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000189",
+      "lbl" : "obsolete % NaCl Optimum mid1 (1 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000190",
+      "lbl" : "obsolete % NaCl Optimum mid2 (3 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000191",
+      "lbl" : "obsolete % NaCl Optimum high (> 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000192",
+      "lbl" : "obsolete % NaCl Range low (<= 1)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000193",
+      "lbl" : "obsolete % NaCl Range mid1 (1 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000194",
+      "lbl" : "obsolete % NaCl Range mid2 (3 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000195",
+      "lbl" : "obsolete % NaCl Range high (> 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000196",
+      "lbl" : "obsolete pH delta very low (<= 1)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000197",
+      "lbl" : "obsolete pH delta low (1 - 2)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000198",
+      "lbl" : "obsolete pH delta mid1 (2 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000199",
+      "lbl" : "obsolete pH delta mid2 (3 - 4)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000200",
+      "lbl" : "obsolete pH delta mid3 (4 - 5)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000201",
+      "lbl" : "obsolete pH delta high (5 - 9)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000202",
+      "lbl" : "obsolete % NaCl delta low (<= 1)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000203",
+      "lbl" : "obsolete % NaCl delta mid2 (1 - 3)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000204",
+      "lbl" : "obsolete % NaCl delta mid2 (3 - 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000205",
+      "lbl" : "obsolete % NaCl delta high (>= 8)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000206",
+      "lbl" : "obsolete Temperature C delta very low (1 - 5)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000207",
+      "lbl" : "obsolete Temperature C delta low (5 - 10)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000208",
+      "lbl" : "obsolete Temperature C delta mid1 (10 - 20)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000209",
+      "lbl" : "obsolete Temperature C delta mid2 (20 - 30)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000210",
+      "lbl" : "obsolete Temperature C delta high (>= 30)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000211",
+      "lbl" : "obsolete bacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000212",
+      "lbl" : "obsolete branced",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000213",
+      "lbl" : "obsolete coccobacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000214",
+      "lbl" : "obsolete coccus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000215",
+      "lbl" : "obsolete crescent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000216",
+      "lbl" : "obsolete curved",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000217",
+      "lbl" : "obsolete curved spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000218",
+      "lbl" : "obsolete diplococcus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000219",
+      "lbl" : "obsolete disc",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000220",
+      "lbl" : "obsolete dumbbell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000221",
+      "lbl" : "obsolete ellipsoidal",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000222",
+      "lbl" : "obsolete filament",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000223",
+      "lbl" : "obsolete flask",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000224",
+      "lbl" : "obsolete fusiform",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000225",
+      "lbl" : "obsolete helical",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000226",
+      "lbl" : "obsolete irregular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000227",
+      "lbl" : "obsolete oval",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000228",
+      "lbl" : "obsolete ovoid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000229",
+      "lbl" : "obsolete pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000230",
+      "lbl" : "obsolete ring",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000231",
+      "lbl" : "obsolete rod",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000232",
+      "lbl" : "obsolete sphere",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000233",
+      "lbl" : "obsolete spindle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000234",
+      "lbl" : "obsolete spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000235",
+      "lbl" : "obsolete spirochete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000236",
+      "lbl" : "obsolete spore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000237",
+      "lbl" : "obsolete square",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000238",
+      "lbl" : "obsolete star",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000239",
+      "lbl" : "obsolete star - dumbbell - pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000240",
+      "lbl" : "obsolete tailed",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000241",
+      "lbl" : "obsolete triangular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000242",
+      "lbl" : "obsolete vibrio",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000243",
+      "lbl" : "obsolete Environmental Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000244",
+      "lbl" : "obsolete Growth Condition",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000245",
+      "lbl" : "obsolete Physiological Trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000246",
+      "lbl" : "obsolete Metabolic Classification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000247",
+      "lbl" : "obsolete Cellular Characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000248",
+      "lbl" : "obsolete Taxonomic Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000249",
+      "lbl" : "obsolete Microbial Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000250",
+      "lbl" : "obsolete Growth Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000251",
+      "lbl" : "obsolete Structural Feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000252",
+      "lbl" : "obsolete Temperature Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000253",
+      "lbl" : "obsolete Salinity Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000254",
+      "lbl" : "obsolete pH Adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000255",
+      "lbl" : "obsolete Oxygen Requirement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000256",
+      "lbl" : "obsolete Carbon Source Utilization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000257",
+      "lbl" : "obsolete Energy Acquisition Mode",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000258",
+      "lbl" : "obsolete Electron Donor Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000259",
+      "lbl" : "obsolete Motility Mechanism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000260",
+      "lbl" : "obsolete Motility Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000261",
+      "lbl" : "obsolete Bacterial Spore Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000262",
+      "lbl" : "obsolete Fungal Spore Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000263",
+      "lbl" : "obsolete Reproductive Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000264",
+      "lbl" : "obsolete Dormancy Structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000265",
+      "lbl" : "obsolete Pressure Adaptation Type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000266",
+      "lbl" : "obsolete Pressure Tolerance Range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000267",
+      "lbl" : "obsolete GenomicFeature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000268",
+      "lbl" : "obsolete Cell Dimension",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000269",
+      "lbl" : "obsolete Optimal Growth Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000270",
+      "lbl" : "obsolete Growth Range Parameter",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000271",
+      "lbl" : "obsolete Growth Tolerance Metric",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000272",
+      "lbl" : "obsolete Cell Shape",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000273",
+      "lbl" : "obsolete Cell Arrangement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/000274",
+      "lbl" : "obsolete Colony Morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000001",
+      "lbl" : "obsolete acid-fast",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000002",
+      "lbl" : "obsolete acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000003",
+      "lbl" : "obsolete active transport",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000004",
+      "lbl" : "obsolete adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000005",
+      "lbl" : "obsolete adaptive trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000006",
+      "lbl" : "obsolete adhesin",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000007",
+      "lbl" : "obsolete adhesion structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000008",
+      "lbl" : "obsolete aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000009",
+      "lbl" : "obsolete aerobic respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000010",
+      "lbl" : "obsolete aerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000011",
+      "lbl" : "obsolete aggregate",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000012",
+      "lbl" : "obsolete akinete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000013",
+      "lbl" : "obsolete alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000014",
+      "lbl" : "obsolete ammonification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000015",
+      "lbl" : "obsolete amylolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000016",
+      "lbl" : "obsolete anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000017",
+      "lbl" : "obsolete anaerobic respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000018",
+      "lbl" : "obsolete anoxygenic photosynthesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000019",
+      "lbl" : "obsolete antibiotic production",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000020",
+      "lbl" : "obsolete antibiotic resistance",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000021",
+      "lbl" : "obsolete antimicrobial resistance",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000022",
+      "lbl" : "obsolete appendage",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000023",
+      "lbl" : "obsolete arthrospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000024",
+      "lbl" : "obsolete ascospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000025",
+      "lbl" : "obsolete autotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000026",
+      "lbl" : "obsolete autotrophic process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000027",
+      "lbl" : "obsolete auxotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000028",
+      "lbl" : "obsolete axial filament",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000029",
+      "lbl" : "obsolete bacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000030",
+      "lbl" : "obsolete barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000031",
+      "lbl" : "obsolete barotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000032",
+      "lbl" : "obsolete basidiospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000033",
+      "lbl" : "obsolete binary fission",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000034",
+      "lbl" : "obsolete biofilm",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000035",
+      "lbl" : "obsolete biofilm component",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000036",
+      "lbl" : "obsolete biofilm formation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000037",
+      "lbl" : "obsolete biogeochemical cycling",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000038",
+      "lbl" : "obsolete bioluminescence",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000039",
+      "lbl" : "obsolete budding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000040",
+      "lbl" : "obsolete buoyancy structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000041",
+      "lbl" : "obsolete capnophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000042",
+      "lbl" : "obsolete capsule",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000043",
+      "lbl" : "obsolete carbon fixation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000044",
+      "lbl" : "obsolete carbon source",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000045",
+      "lbl" : "obsolete carboxydotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000046",
+      "lbl" : "obsolete cell arrangement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000047",
+      "lbl" : "obsolete cell envelope",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000048",
+      "lbl" : "obsolete cell length category",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000049",
+      "lbl" : "obsolete cell shape",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000050",
+      "lbl" : "obsolete cell size",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000051",
+      "lbl" : "obsolete cell wall characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000052",
+      "lbl" : "obsolete cell wall component",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000053",
+      "lbl" : "obsolete cell width category",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000054",
+      "lbl" : "obsolete cellular characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000055",
+      "lbl" : "obsolete cellular component",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000056",
+      "lbl" : "obsolete cellular process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000057",
+      "lbl" : "obsolete cellular product",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000058",
+      "lbl" : "obsolete cellulolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000059",
       "lbl" : "phenotype",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quality that differentiates specific instances of a species from other instances of the same species."
+          "val" : "A quality that differentiates specific instances of a species from other instances of the same species.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PHIPO_0000505"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -51,11 +8298,878 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A biological process that maintain life in an organism."
+          "val" : "A biological process that maintain life in an organism.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0008152"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/MetabolicProcess"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Anthea Guo"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000061",
+      "lbl" : "obsolete chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000062",
+      "lbl" : "obsolete chemotaxis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000063",
+      "lbl" : "obsolete chlamydospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000064",
+      "lbl" : "obsolete class",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000065",
+      "lbl" : "obsolete clinically relevant feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000066",
+      "lbl" : "obsolete coccus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000067",
+      "lbl" : "obsolete cold shock protein",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000068",
+      "lbl" : "obsolete cold shock response",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000069",
+      "lbl" : "obsolete colonization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000070",
+      "lbl" : "obsolete colony elevation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000071",
+      "lbl" : "obsolete colony margin",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000072",
+      "lbl" : "obsolete colony morphology",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000073",
+      "lbl" : "obsolete colony texture",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000074",
+      "lbl" : "obsolete commensalism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000075",
+      "lbl" : "obsolete community behavior",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000076",
+      "lbl" : "obsolete community structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000077",
+      "lbl" : "obsolete compatible solute",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000078",
+      "lbl" : "obsolete competence",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000079",
+      "lbl" : "obsolete component",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000080",
+      "lbl" : "obsolete conidium",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000081",
+      "lbl" : "obsolete conjugation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000082",
+      "lbl" : "obsolete CRISPR",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000083",
+      "lbl" : "obsolete culturability",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000084",
+      "lbl" : "obsolete cyst",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000085",
+      "lbl" : "obsolete death phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000086",
+      "lbl" : "obsolete denitrification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000087",
+      "lbl" : "obsolete developmental process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000088",
+      "lbl" : "obsolete diagnostic enzyme",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000089",
+      "lbl" : "obsolete diagnostic feature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000090",
+      "lbl" : "obsolete diazotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000091",
+      "lbl" : "obsolete differentiation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000092",
+      "lbl" : "obsolete dimorphism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000093",
+      "lbl" : "obsolete disc-shaped cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000094",
+      "lbl" : "obsolete domain",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000095",
+      "lbl" : "obsolete dormancy",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000096",
+      "lbl" : "obsolete dormancy structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000097",
+      "lbl" : "obsolete dumbbell-shaped cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000098",
+      "lbl" : "obsolete ecological niche",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000099",
+      "lbl" : "obsolete ecological process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000100",
+      "lbl" : "obsolete ecological trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000101",
+      "lbl" : "obsolete ectosymbiosis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000102",
+      "lbl" : "obsolete electron acceptor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000103",
+      "lbl" : "obsolete electron donor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000104",
+      "lbl" : "obsolete endospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000105",
+      "lbl" : "obsolete endosymbiosis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000106",
+      "lbl" : "obsolete energy metabolism process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000107",
+      "lbl" : "obsolete enzyme activity",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000108",
+      "lbl" : "obsolete epigenetic modification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000109",
+      "lbl" : "obsolete evolutionary process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000110",
+      "lbl" : "obsolete exospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000111",
+      "lbl" : "obsolete exponential phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000112",
+      "lbl" : "obsolete extracellular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000113",
+      "lbl" : "obsolete extracellular polysaccharide",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000114",
+      "lbl" : "obsolete extreme halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000115",
+      "lbl" : "obsolete extremophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000116",
+      "lbl" : "obsolete facultative",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000117",
+      "lbl" : "obsolete facultative anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000118",
+      "lbl" : "obsolete family",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000119",
+      "lbl" : "obsolete fastidious",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000120",
+      "lbl" : "obsolete fermentation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000121",
+      "lbl" : "obsolete filamentous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000122",
+      "lbl" : "obsolete fimbriae",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000123",
+      "lbl" : "obsolete flagellum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000124",
+      "lbl" : "obsolete flask-shaped cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000125",
+      "lbl" : "obsolete fungal spore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000126",
+      "lbl" : "obsolete gas vesicle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -64,15 +9178,781 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs."
+          "val" : "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/GCContent"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC percentage"
+          "val" : "GC percentage",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Luke Wang"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000128",
+      "lbl" : "obsolete high GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000129",
+      "lbl" : "obsolete low GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000130",
+      "lbl" : "obsolete lower-mid GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000131",
+      "lbl" : "obsolete upper-mid GC content",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000132",
+      "lbl" : "obsolete generation time",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000133",
+      "lbl" : "obsolete genetic element",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000134",
+      "lbl" : "obsolete genetic exchange",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000135",
+      "lbl" : "obsolete genetic process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000136",
+      "lbl" : "obsolete genome size",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000137",
+      "lbl" : "obsolete genomic element",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000138",
+      "lbl" : "obsolete genomic island",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000139",
+      "lbl" : "obsolete genomic trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000140",
+      "lbl" : "obsolete genus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000141",
+      "lbl" : "obsolete gliding motility",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000142",
+      "lbl" : "obsolete global regulator",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000143",
+      "lbl" : "obsolete Gram-negative",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000144",
+      "lbl" : "obsolete Gram-positive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000145",
+      "lbl" : "obsolete Gram stain",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000146",
+      "lbl" : "obsolete growth characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000147",
+      "lbl" : "obsolete growth conditions constraints",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000148",
+      "lbl" : "obsolete growth pattern",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000149",
+      "lbl" : "obsolete growth rate",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000150",
+      "lbl" : "obsolete habitat",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000151",
+      "lbl" : "obsolete halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000152",
+      "lbl" : "obsolete halotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000153",
+      "lbl" : "obsolete heat shock protein",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000154",
+      "lbl" : "obsolete heat shock response",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000155",
+      "lbl" : "obsolete hemolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000156",
+      "lbl" : "obsolete heterocyst",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000157",
+      "lbl" : "obsolete heterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000158",
+      "lbl" : "obsolete holdfast",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000159",
+      "lbl" : "obsolete horizontal gene transfer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000160",
+      "lbl" : "obsolete hydrolase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000161",
+      "lbl" : "obsolete hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000162",
+      "lbl" : "obsolete inclusion body",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000163",
+      "lbl" : "obsolete infection",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000164",
+      "lbl" : "obsolete interaction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000165",
+      "lbl" : "obsolete interaction with a phage",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000166",
+      "lbl" : "obsolete interaction with an environment",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000167",
+      "lbl" : "obsolete interaction with host",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000168",
+      "lbl" : "obsolete interaction within a community",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000169",
+      "lbl" : "obsolete intracellular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000170",
+      "lbl" : "obsolete invasion",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000171",
+      "lbl" : "obsolete laboratory characteristic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000172",
+      "lbl" : "obsolete lag phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000173",
+      "lbl" : "obsolete life cycle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000174",
+      "lbl" : "obsolete life cycle phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000175",
+      "lbl" : "obsolete lipolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000176",
+      "lbl" : "obsolete lipopolysaccharide",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000177",
+      "lbl" : "obsolete localization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000178",
+      "lbl" : "obsolete lysogeny",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000179",
+      "lbl" : "obsolete macroscopic trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000180",
+      "lbl" : "obsolete magnetotaxis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000181",
+      "lbl" : "obsolete mesophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000182",
+      "lbl" : "obsolete metabolic partner",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000183",
+      "lbl" : "obsolete metabolic trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000184",
+      "lbl" : "obsolete methanogenesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000185",
+      "lbl" : "obsolete methylation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -81,11 +9961,30 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An object or portion of a substance or mixture of substances that consists of matter"
+          "val" : "An object or portion of a substance or mixture of substances that consists of matter",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/BFO_0000040"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Anthea Guo"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000187",
+      "lbl" : "obsolete process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -98,9 +9997,1478 @@
         }
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000189",
+      "lbl" : "obsolete system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000190",
+      "lbl" : "obsolete microaerophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000191",
+      "lbl" : "obsolete mobile genetic element",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000192",
+      "lbl" : "obsolete moderate halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000193",
+      "lbl" : "obsolete morphological trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000194",
+      "lbl" : "obsolete motility process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000195",
+      "lbl" : "obsolete motility structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000196",
+      "lbl" : "obsolete mutualism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000197",
+      "lbl" : "obsolete mycolic acid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000198",
+      "lbl" : "obsolete mycorrhization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000199",
+      "lbl" : "obsolete neutrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000200",
+      "lbl" : "obsolete nitrification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000201",
+      "lbl" : "obsolete nitrogen fixation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000202",
+      "lbl" : "obsolete nodulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000203",
+      "lbl" : "obsolete nucleoid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000204",
+      "lbl" : "obsolete nutrient utilization",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000205",
+      "lbl" : "obsolete obligate",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000206",
+      "lbl" : "obsolete obligate aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000207",
+      "lbl" : "obsolete obligate anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000208",
+      "lbl" : "obsolete oospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000209",
+      "lbl" : "obsolete order",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000210",
+      "lbl" : "obsolete microbe characterized by growth conditions",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000211",
+      "lbl" : "obsolete microbe characterized by nutritional requirement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000212",
+      "lbl" : "obsolete microbe characterized by product produced",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000213",
+      "lbl" : "obsolete microbe characterized by relation to oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000214",
+      "lbl" : "obsolete microbe characterized by relation to ph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000215",
+      "lbl" : "obsolete microbe characterized by relation to pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000216",
+      "lbl" : "obsolete microbe characterized by relation to salt concentration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000217",
+      "lbl" : "obsolete microbe characterized by relation to temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000218",
+      "lbl" : "obsolete microbe characterized by shape",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000219",
+      "lbl" : "obsolete microbe characterized by trophic type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000220",
+      "lbl" : "obsolete osmophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000221",
+      "lbl" : "obsolete osmoregulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000222",
+      "lbl" : "obsolete oxidative stress response",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000223",
+      "lbl" : "obsolete oxidoreductase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000224",
+      "lbl" : "obsolete oxygen requirement",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000225",
+      "lbl" : "obsolete oxygenic photosynthesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000226",
+      "lbl" : "obsolete pan-genome",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000227",
+      "lbl" : "obsolete parasitism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000228",
+      "lbl" : "obsolete passive transport",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000229",
+      "lbl" : "obsolete pathogenicity",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000230",
+      "lbl" : "obsolete pathogenicity island",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000231",
+      "lbl" : "obsolete peptidoglycan",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000232",
       "lbl" : "pH delta",
       "type" : "CLASS"
+    }, {
+      "id" : "https://w3id.org/metpo/1000233",
+      "lbl" : "obsolete pH optimum (growth range)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000234",
+      "lbl" : "obsolete pH preference",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000235",
+      "lbl" : "obsolete pH range (growth tolerance)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000236",
+      "lbl" : "obsolete pH tolerance",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000237",
+      "lbl" : "obsolete phage defense",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000238",
+      "lbl" : "obsolete photoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000239",
+      "lbl" : "obsolete photoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000240",
+      "lbl" : "obsolete photosynthesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000241",
+      "lbl" : "obsolete phototaxis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000242",
+      "lbl" : "obsolete phylum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000243",
+      "lbl" : "obsolete physiological process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000244",
+      "lbl" : "obsolete physiological state",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000245",
+      "lbl" : "obsolete physiological trait",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000246",
+      "lbl" : "obsolete piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000247",
+      "lbl" : "obsolete pigment",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000248",
+      "lbl" : "obsolete pigmentation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000249",
+      "lbl" : "obsolete pilus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000250",
+      "lbl" : "obsolete plant growth promotion",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000251",
+      "lbl" : "obsolete plasmid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000252",
+      "lbl" : "obsolete pleomorphism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000253",
+      "lbl" : "obsolete process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000254",
+      "lbl" : "obsolete prophage",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000255",
+      "lbl" : "obsolete prostheca",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000256",
+      "lbl" : "obsolete protein synthesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000257",
+      "lbl" : "obsolete proteolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000258",
+      "lbl" : "obsolete prototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000259",
+      "lbl" : "obsolete psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000260",
+      "lbl" : "obsolete qualifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000261",
+      "lbl" : "obsolete quorum sensing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000262",
+      "lbl" : "obsolete regulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000263",
+      "lbl" : "obsolete regulatory mechanism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000264",
+      "lbl" : "obsolete reproductive process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000265",
+      "lbl" : "obsolete reproductive structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000266",
+      "lbl" : "obsolete resistance mechanism",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000267",
+      "lbl" : "obsolete respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000268",
+      "lbl" : "obsolete restriction-modification system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000269",
+      "lbl" : "obsolete ribosome",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000270",
+      "lbl" : "obsolete S-layer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000271",
+      "lbl" : "obsolete salinity delta",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000272",
+      "lbl" : "obsolete salinity preference",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000273",
+      "lbl" : "obsolete secondary metabolite",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000274",
+      "lbl" : "obsolete secretion",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000275",
+      "lbl" : "obsolete secretion system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000276",
+      "lbl" : "obsolete sheathed",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000277",
+      "lbl" : "obsolete siderophore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000278",
+      "lbl" : "obsolete sigma factor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000279",
+      "lbl" : "obsolete signaling",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000280",
+      "lbl" : "obsolete slime layer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000281",
+      "lbl" : "obsolete specialized cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000282",
+      "lbl" : "obsolete species",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000283",
+      "lbl" : "obsolete spirillum",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000284",
+      "lbl" : "obsolete spirochete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000285",
+      "lbl" : "obsolete sporangiospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000286",
+      "lbl" : "obsolete sporulation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000287",
+      "lbl" : "obsolete square cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000288",
+      "lbl" : "obsolete stalk",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000289",
+      "lbl" : "obsolete star-shaped cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000290",
+      "lbl" : "obsolete stationary phase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000291",
+      "lbl" : "obsolete storage structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000292",
+      "lbl" : "obsolete strain",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000293",
+      "lbl" : "obsolete stress response",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000294",
+      "lbl" : "obsolete structure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000295",
+      "lbl" : "obsolete sulfate reducer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000296",
+      "lbl" : "obsolete swarming",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000297",
+      "lbl" : "obsolete symbiosis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000298",
+      "lbl" : "obsolete symbiotic process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000299",
+      "lbl" : "obsolete syntrophy",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000300",
+      "lbl" : "obsolete taxonomic identifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000301",
+      "lbl" : "obsolete taxonomic rank",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000302",
+      "lbl" : "obsolete teichoic acid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1000303",
       "lbl" : "temperature delta",
@@ -111,7 +11479,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction."
+          "val" : "A temperature phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/OptimumTemperature"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -119,9 +11493,334 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000305",
+      "lbl" : "obsolete temperature preference",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000306",
       "lbl" : "temperature range",
       "type" : "CLASS"
+    }, {
+      "id" : "https://w3id.org/metpo/1000307",
+      "lbl" : "obsolete thermal tolerance",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000308",
+      "lbl" : "obsolete thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000309",
+      "lbl" : "obsolete toxin",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000310",
+      "lbl" : "obsolete transcription factor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000311",
+      "lbl" : "obsolete transduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000312",
+      "lbl" : "obsolete transferase",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000313",
+      "lbl" : "obsolete transformation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000314",
+      "lbl" : "obsolete transport system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000315",
+      "lbl" : "obsolete transposon",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000316",
+      "lbl" : "obsolete triangular cell",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000317",
+      "lbl" : "obsolete trichome",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000318",
+      "lbl" : "obsolete twitching motility",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000319",
+      "lbl" : "obsolete two-component system",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000320",
+      "lbl" : "obsolete viable but non-culturable",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000321",
+      "lbl" : "obsolete vibrio",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000322",
+      "lbl" : "obsolete virulence",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000323",
+      "lbl" : "obsolete virulence factor",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000324",
+      "lbl" : "obsolete virulence process",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000325",
+      "lbl" : "obsolete xylanolysis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000326",
+      "lbl" : "obsolete zoospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000327",
+      "lbl" : "obsolete zygospore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000328",
+      "lbl" : "obsolete pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000329",
+      "lbl" : "obsolete temperature optimum (metabolic activity)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000330",
+      "lbl" : "obsolete temperature range (metabolic viability)",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1000331",
       "lbl" : "pH optimum",
@@ -147,7 +11846,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A salinity phenotype with numerical limits that supports the most efficient growth and reproduction of an organism."
+          "val" : "A salinity phenotype with numerical limits that supports the most efficient growth and reproduction of an organism.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/OptimumSalinity"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -169,13 +11874,1228 @@
       "lbl" : "NaCl delta",
       "type" : "CLASS"
     }, {
+      "id" : "https://w3id.org/metpo/1000336",
+      "lbl" : "obsolete psychrotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000337",
+      "lbl" : "obsolete thermotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000338",
+      "lbl" : "obsolete extreme thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000339",
+      "lbl" : "obsolete extreme hyperthermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000340",
+      "lbl" : "obsolete non-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000341",
+      "lbl" : "obsolete slight halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000342",
+      "lbl" : "obsolete haloalkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000343",
+      "lbl" : "obsolete extreme acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000344",
+      "lbl" : "obsolete acid tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000345",
+      "lbl" : "obsolete alkali tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000346",
+      "lbl" : "obsolete extreme alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000347",
+      "lbl" : "obsolete facultative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000348",
+      "lbl" : "obsolete obligative acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000349",
+      "lbl" : "obsolete facultative aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000350",
+      "lbl" : "obsolete microaerophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000351",
+      "lbl" : "obsolete microaerotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000352",
+      "lbl" : "obsolete aerotolerant anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000353",
+      "lbl" : "obsolete obligate aerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000354",
+      "lbl" : "obsolete obligate anaerobe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000355",
+      "lbl" : "obsolete oxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000356",
+      "lbl" : "obsolete anoxygenic phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000357",
+      "lbl" : "obsolete chemoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000358",
+      "lbl" : "obsolete chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000359",
+      "lbl" : "obsolete lithotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000360",
+      "lbl" : "obsolete organotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000361",
+      "lbl" : "obsolete phototroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000362",
+      "lbl" : "obsolete chemotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000363",
+      "lbl" : "obsolete oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000364",
+      "lbl" : "obsolete copiotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000365",
+      "lbl" : "obsolete lithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000366",
+      "lbl" : "obsolete mixotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000367",
+      "lbl" : "obsolete lithoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000368",
+      "lbl" : "obsolete chemoorganoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000369",
+      "lbl" : "obsolete chemolithoautotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000370",
+      "lbl" : "obsolete methylotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000371",
+      "lbl" : "obsolete methanotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000372",
+      "lbl" : "obsolete hydrogenotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000373",
+      "lbl" : "obsolete hydrogen oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000374",
+      "lbl" : "obsolete hydrogen producer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000375",
+      "lbl" : "obsolete nitrogen fixer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000376",
+      "lbl" : "obsolete methanogen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000377",
+      "lbl" : "obsolete sulfur oxidizer",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000378",
+      "lbl" : "obsolete denitrifier",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000379",
+      "lbl" : "obsolete motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000380",
+      "lbl" : "obsolete non-motile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000381",
+      "lbl" : "obsolete flagellated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000382",
+      "lbl" : "obsolete peritrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000383",
+      "lbl" : "obsolete lophotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000384",
+      "lbl" : "obsolete monotrichous",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000385",
+      "lbl" : "obsolete ciliated",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000386",
+      "lbl" : "obsolete gliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000387",
+      "lbl" : "obsolete twitching",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000388",
+      "lbl" : "obsolete sliding",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000389",
+      "lbl" : "obsolete myxospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000390",
+      "lbl" : "obsolete conidia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000391",
+      "lbl" : "obsolete chlamydospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000392",
+      "lbl" : "obsolete sporocysts",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000393",
+      "lbl" : "obsolete hypnospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000394",
+      "lbl" : "obsolete gemmae",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000395",
+      "lbl" : "obsolete azygospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000396",
+      "lbl" : "obsolete aleuriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000397",
+      "lbl" : "obsolete stylospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000398",
+      "lbl" : "obsolete sclerotia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000399",
+      "lbl" : "obsolete teliospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000400",
+      "lbl" : "obsolete urediniospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000401",
+      "lbl" : "obsolete pycnidiospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000402",
+      "lbl" : "obsolete acriospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000403",
+      "lbl" : "obsolete aplanospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000404",
+      "lbl" : "obsolete statismospores",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000405",
+      "lbl" : "obsolete piezotolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000406",
+      "lbl" : "obsolete piezosensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000407",
+      "lbl" : "obsolete obligate barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000408",
+      "lbl" : "obsolete facultative barophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000409",
+      "lbl" : "obsolete hyperbarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000410",
+      "lbl" : "obsolete hypobarophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000411",
+      "lbl" : "obsolete atmospheric pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000412",
+      "lbl" : "obsolete moderate piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000413",
+      "lbl" : "obsolete extreme piezophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000414",
+      "lbl" : "obsolete stenopiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000415",
+      "lbl" : "obsolete eurypiezic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000416",
+      "lbl" : "obsolete pressure-sensitive",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000417",
+      "lbl" : "obsolete pressure-resistant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000418",
+      "lbl" : "obsolete pressure-adapted",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000419",
+      "lbl" : "obsolete piezo-acidophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000420",
+      "lbl" : "obsolete piezo-alkaliphile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000421",
+      "lbl" : "obsolete piezo-halophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000422",
+      "lbl" : "obsolete piezo-psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000423",
+      "lbl" : "obsolete piezo-thermophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000424",
+      "lbl" : "obsolete piezo-lithoautotrophe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000425",
+      "lbl" : "obsolete piezo-chemoheterotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000426",
+      "lbl" : "obsolete piezo-oligotroph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000427",
+      "lbl" : "obsolete piezo-endolithic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000428",
+      "lbl" : "obsolete piezo-tolerant",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000429",
       "lbl" : "GC low",
       "type" : "CLASS",
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC_42.65_57.0"
+          "val" : "GC_42.65_57.0",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -189,7 +13109,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC_>66.3"
+          "val" : "GC_>66.3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -206,7 +13132,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC_57.0_66.3"
+          "val" : "GC_57.0_66.3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -223,11 +13155,121 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC_<=42.65"
+          "val" : "GC_<=42.65",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_min",
           "val" : "66.3"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000433",
+      "lbl" : "obsolete cell width very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000434",
+      "lbl" : "obsolete cell width low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000435",
+      "lbl" : "obsolete cell width mid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000436",
+      "lbl" : "obsolete cell width high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000437",
+      "lbl" : "obsolete cell length very low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000438",
+      "lbl" : "obsolete cell length low",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000439",
+      "lbl" : "obsolete cell length mid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000440",
+      "lbl" : "obsolete cell length high",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -240,7 +13282,13 @@
           "val" : "Psychrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_<=10"
+          "val" : "TO_<=10",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -263,7 +13311,13 @@
           "val" : "Psychrotolerant"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_10_to_22"
+          "val" : "TO_10_to_22",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -283,10 +13337,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_22_to_27"
+          "val" : "TO_22_to_27",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -306,10 +13366,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_27_to_30"
+          "val" : "TO_27_to_30",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -329,10 +13395,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_30_to_34"
+          "val" : "TO_30_to_34",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -352,10 +13424,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_34_to_40"
+          "val" : "TO_34_to_40",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -378,7 +13456,13 @@
           "val" : "Thermophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TO_>40"
+          "val" : "TO_>40",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -398,7 +13482,13 @@
           "val" : "Psychrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_<=10"
+          "val" : "TR_<=10",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -421,7 +13511,13 @@
           "val" : "Psychrotolerant"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_10_to_22"
+          "val" : "TR_10_to_22",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -441,10 +13537,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_22_to_27"
+          "val" : "TR_22_to_27",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -464,10 +13566,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_27_to_30"
+          "val" : "TR_27_to_30",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -487,10 +13595,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_30_to_34"
+          "val" : "TR_30_to_34",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -510,10 +13624,16 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Mesophilie"
+          "val" : "mesophilic"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_34_to_40"
+          "val" : "TR_34_to_40",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -536,7 +13656,13 @@
           "val" : "Thermophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "TR_>40"
+          "val" : "TR_>40",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -568,7 +13694,13 @@
           "val" : "Obligative acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHO_0_to_6"
+          "val" : "pHO_0_to_6",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -591,7 +13723,13 @@
           "val" : "Neutrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHO_6_to_7"
+          "val" : "pHO_6_to_7",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -617,7 +13755,13 @@
           "val" : "Neutrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHO_7_to_8"
+          "val" : "pHO_7_to_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -643,7 +13787,13 @@
           "val" : "Extreme Alkaliphile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHO_8_to_14"
+          "val" : "pHO_8_to_14",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -675,7 +13825,13 @@
           "val" : "Obligative acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_0_to_4"
+          "val" : "pHR_0_to_4",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -704,7 +13860,13 @@
           "val" : "Obligative acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_4_to_6"
+          "val" : "pHR_4_to_6",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -730,7 +13892,13 @@
           "val" : "Neutrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_6_to_7"
+          "val" : "pHR_6_to_7",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -759,7 +13927,13 @@
           "val" : "Neutrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_7_to_8"
+          "val" : "pHR_7_to_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -788,7 +13962,13 @@
           "val" : "Facultative acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHR_8_to_10"
+          "val" : "pHR_8_to_10",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -814,7 +13994,13 @@
           "val" : "Extreme Alkaliphile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "10_to_14"
+          "val" : "10_to_14",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -837,7 +14023,13 @@
           "val" : "Non-halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaO_<=1"
+          "val" : "NaO_<=1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -860,7 +14052,13 @@
           "val" : "Slight halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaO_1_to_3"
+          "val" : "NaO_1_to_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -886,7 +14084,13 @@
           "val" : "Moderate halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaO_3_to_8"
+          "val" : "NaO_3_to_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -909,7 +14113,13 @@
           "val" : "Extreme halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaO_>8"
+          "val" : "NaO_>8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -932,7 +14142,13 @@
           "val" : "Non-halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaR_<=1"
+          "val" : "NaR_<=1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -955,7 +14171,13 @@
           "val" : "Slight halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaR_1_to_3"
+          "val" : "NaR_1_to_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -981,7 +14203,13 @@
           "val" : "Moderate halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaR_3_to_8"
+          "val" : "NaR_3_to_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1004,7 +14232,13 @@
           "val" : "Extreme halophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "NaR_>8"
+          "val" : "NaR_>8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1021,7 +14255,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_<=1"
+          "val" : "pHd_<=1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1035,7 +14275,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_1_2"
+          "val" : "pHd_1_2",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1052,7 +14298,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_2_3"
+          "val" : "pHd_2_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1069,7 +14321,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_3_4"
+          "val" : "pHd_3_4",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1086,7 +14344,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_4_5"
+          "val" : "pHd_4_5",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1103,7 +14367,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pHd_5_9"
+          "val" : "pHd_5_9",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "https://w3id.org/metpo/range_max",
@@ -1120,7 +14390,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Nad_<=1"
+          "val" : "Nad_<=1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1137,7 +14413,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Nad_1_3"
+          "val" : "Nad_1_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1157,7 +14439,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Nad_3_8"
+          "val" : "Nad_3_8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1177,7 +14465,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Nad_>8"
+          "val" : "Nad_>8",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1194,7 +14488,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_1_5"
+          "val" : "Td_1_5",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1214,7 +14514,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_5_10"
+          "val" : "Td_5_10",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1234,7 +14540,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_10_20"
+          "val" : "Td_10_20",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1254,7 +14566,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_20_30"
+          "val" : "Td_20_30",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1274,7 +14592,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Td_>30"
+          "val" : "Td_>30",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -1285,12 +14609,499 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000488",
+      "lbl" : "obsolete branched",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000489",
+      "lbl" : "obsolete coccobacillus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000490",
+      "lbl" : "obsolete crescent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000491",
+      "lbl" : "obsolete curved",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000492",
+      "lbl" : "obsolete curved spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000493",
+      "lbl" : "obsolete diplococcus",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000494",
+      "lbl" : "obsolete ellipsoidal",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000495",
+      "lbl" : "obsolete filament",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000496",
+      "lbl" : "obsolete fusiform",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000497",
+      "lbl" : "obsolete helical",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000498",
+      "lbl" : "obsolete irregular",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000499",
+      "lbl" : "obsolete oval",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000500",
+      "lbl" : "obsolete ovoid",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000501",
+      "lbl" : "obsolete pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000502",
+      "lbl" : "obsolete ring",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000503",
+      "lbl" : "obsolete rod",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000504",
+      "lbl" : "obsolete sphere",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000505",
+      "lbl" : "obsolete spindle",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000506",
+      "lbl" : "obsolete spiral",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000507",
+      "lbl" : "obsolete star - dumbbell - pleomorphic",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000508",
+      "lbl" : "obsolete tailed",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000509",
+      "lbl" : "obsolete temperature adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000510",
+      "lbl" : "obsolete salinity adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000511",
+      "lbl" : "obsolete pH adaptation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000512",
+      "lbl" : "obsolete bacterial spore",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000513",
+      "lbl" : "obsolete pressure adaptation type",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000514",
+      "lbl" : "obsolete pressure tolerance range",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000515",
+      "lbl" : "obsolete sensitivity to oxygen",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000516",
+      "lbl" : "obsolete sensitivity toward",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000517",
+      "lbl" : "obsolete size",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000518",
+      "lbl" : "obsolete 1-D extent",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000519",
+      "lbl" : "obsolete width",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000520",
+      "lbl" : "obsolete length",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000521",
+      "lbl" : "obsolete sensitivity toward pressure",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000522",
+      "lbl" : "obsolete sensitivity toward nacl",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000523",
+      "lbl" : "obsolete sensitivity toward ph",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000524",
+      "lbl" : "obsolete sensitivity toward temperature",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000525",
       "lbl" : "microbe",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation."
+          "val" : "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OHMI_0000460"
+            } ]
+          }
         },
         "comments" : [ "METPO is primarily concerned with unicellular, prokaryotic life forms, i.e. bacteria and archaea, including the cases of giant bacteria like Thiomargarita" ],
         "basicPropertyValues" : [ {
@@ -1307,7 +15118,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A material entity that is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances."
+          "val" : "A material entity that is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/CHEBI_24431"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://www.w3.org/2004/02/skos/core#closeMatch",
@@ -1318,6 +15135,32 @@
       "id" : "https://w3id.org/metpo/1000527",
       "lbl" : "enzyme",
       "type" : "CLASS"
+    }, {
+      "id" : "https://w3id.org/metpo/1000528",
+      "lbl" : "obsolete structured susceptibility detail",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000529",
+      "lbl" : "obsolete facultative psychrophile",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1000531",
       "lbl" : "pH phenotype with numerical limits",
@@ -1378,17 +15221,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that is relating to an organism's oxygen requirements or tolerance for growth."
+          "val" : "A phenotype that is relating to an organism's oxygen requirements or tolerance for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/UPHENO_0049673"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/OxygenTolerance"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.oxygen tolerance.oxygen tolerance"
+          "val" : "Physiology and metabolism.oxygen tolerance.oxygen tolerance",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "metabolism"
+          "val" : "metabolism",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxygen preference"
+          "val" : "oxygen preference",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1397,17 +15267,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which growth occurs in the presence of molecular oxygen (O₂), typically using O₂ as the terminal electron acceptor."
+          "val" : "An oxygen preference in which growth occurs in the presence of molecular oxygen (O₂), typically using O₂ as the terminal electron acceptor.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000173"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005253"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Ox_aerobic"
+          "val" : "Ox_aerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobe"
+          "val" : "aerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic"
+          "val" : "aerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1416,17 +15313,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which growth occurs in the absence of molecular oxygen (O₂)."
+          "val" : "An oxygen preference in which growth occurs in the absence of molecular oxygen (O₂).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000495"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Ox_anaerobic"
+          "val" : "Ox_anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobe"
+          "val" : "anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic"
+          "val" : "anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1435,17 +15356,47 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that requires molecular oxygen (O₂) at concentrations lower than atmospheric."
+          "val" : "An oxygen preference that requires molecular oxygen (O₂) at concentrations lower than atmospheric.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000180"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000515"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005254"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Ox_microerophile"
+          "val" : "Ox_microerophile",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "microaerophile"
+          "val" : "microaerophile",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "microaerophilic"
+          "val" : "microaerophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1454,17 +15405,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which growth can occur with or without molecular oxygen (O₂)."
+          "val" : "An oxygen preference in which growth can occur with or without molecular oxygen (O₂).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001520"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000087"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative"
+          "val" : "facultative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative anaerobe"
+          "val" : "facultative anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative anaerobe"
+          "val" : "facultative anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1473,17 +15451,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that requires molecular oxygen (O₂) for growth."
+          "val" : "An oxygen preference that requires molecular oxygen (O₂) for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000516"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate aerobe"
+          "val" : "obligate aerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate aerobic"
+          "val" : "obligate aerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate aerobic"
+          "val" : "obligate aerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1492,14 +15494,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which molecular oxygen (O₂) inhibits or prevents growth."
+          "val" : "An oxygen preference in which molecular oxygen (O₂) inhibits or prevents growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000504"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate anaerobe"
+          "val" : "obligate anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate anaerobic"
+          "val" : "obligate anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1508,14 +15528,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference in which growth can occur without oxygen but is capable of aerobic growth."
+          "val" : "An oxygen preference in which growth can occur without oxygen but is capable of aerobic growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000177"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000087"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative"
+          "val" : "facultative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative aerobe"
+          "val" : "facultative aerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1524,14 +15565,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that does not use O₂ for growth but tolerates its presence."
+          "val" : "An oxygen preference that does not use O₂ for growth but tolerates its presence.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000502"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerotolerant"
+          "val" : "aerotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerotolerant"
+          "val" : "aerotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1540,11 +15599,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that tolerates low levels of molecular oxygen (O₂) without requiring it."
+          "val" : "An oxygen preference that tolerates low levels of molecular oxygen (O₂) without requiring it.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000180"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000181"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000087"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000105"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "microaerotolerant"
+          "val" : "microaerotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1553,14 +15633,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An obligately anaerobic where a microorganism does not grow in the presence of oxygen gas (O2)."
+          "val" : "An obligately anaerobic where a microorganism does not grow in the presence of oxygen gas (O2).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000184"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "obligate anaerobic"
+          "val" : "obligate anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "strictly anaerobic"
+          "val" : "strictly anaerobic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1569,11 +15667,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oxygen preference that describes a microorganism that can grow with or without molecular oxygen."
+          "val" : "An oxygen preference that describes a microorganism that can grow with or without molecular oxygen.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000087"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Ox_facultative_aerobe_anaerobe"
+          "val" : "Ox_facultative_aerobe_anaerobe",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1582,17 +15692,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that describes characteristic growth with respect to environmental temperature."
+          "val" : "A phenotype that describes characteristic growth with respect to environmental temperature.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005002"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.culture temp.temperature"
+          "val" : "Physiology and metabolism.culture temp.temperature",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "range_tmp"
+          "val" : "range_tmp",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "temperature preference"
+          "val" : "temperature preference",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1601,17 +15735,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth is favored at low temperatures, typically near or below ~15 °C."
+          "val" : "A temperature preference in which growth is favored at low temperatures, typically near or below ~15 °C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001306"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "psychrophilic"
+          "val" : "psychrophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "psychrophilic"
+          "val" : "psychrophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "psychrophilic"
+          "val" : "psychrophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1620,14 +15778,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth is favored at intermediate temperatures, typically ~20–45 °C."
+          "val" : "A temperature preference in which growth is favored at intermediate temperatures, typically ~20–45 °C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "mesophilic"
+          "val" : "mesophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "mesophilic"
+          "val" : "mesophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1636,17 +15812,47 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth is favored at elevated temperatures, typically ≥45 °C."
+          "val" : "A temperature preference in which growth is favored at elevated temperatures, typically ≥45 °C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000118"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005003"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005004"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "thermophilic"
+          "val" : "thermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "thermophilic"
+          "val" : "thermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "thermophilic"
+          "val" : "thermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1655,14 +15861,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth is favored at very high temperatures, typically ≥80 °C."
+          "val" : "A temperature preference in which growth is favored at very high temperatures, typically ≥80 °C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001538"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "extreme thermophilic"
+          "val" : "extreme thermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "hyperthermophilic"
+          "val" : "hyperthermophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1671,11 +15895,29 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth can occur at low temperatures without an obligate low-temperature preference."
+          "val" : "A temperature preference in which growth can occur at low temperatures without an obligate low-temperature preference.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001310"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005006"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005007"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "psychrotolerant"
+          "val" : "psychrotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1684,11 +15926,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference in which growth can occur at elevated temperatures without an obligate high-temperature preference."
+          "val" : "A temperature preference in which growth can occur at elevated temperatures without an obligate high-temperature preference.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001286"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "thermotolerant"
+          "val" : "thermotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1697,14 +15951,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism requires high concentrations of salt for growth and survival."
+          "val" : "A halophily preference in which an organism requires high concentrations of salt for growth and survival.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0170002"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001314"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001315"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "halophilic"
+          "val" : "halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "halophilic"
+          "val" : "halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1713,11 +15994,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism requires both high salt concentrations and alkaline pH for optimal growth."
+          "val" : "A halophily preference in which an organism requires both high salt concentrations and alkaline pH for optimal growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001314"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001392"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001554"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "haloalkaliphilic"
+          "val" : "haloalkaliphilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1726,14 +16028,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism can tolerate high salt concentrations but does not require them for growth."
+          "val" : "A halophily preference in which an organism can tolerate high salt concentrations but does not require them for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001316"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "halotolerant"
+          "val" : "halotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "halotolerant"
+          "val" : "halotolerant",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1742,14 +16062,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference where growth and proliferation requires high levels of sodium chloride, usually above or about 0.2 M."
+          "val" : "A halophily preference where growth and proliferation requires high levels of sodium chloride, usually above or about 0.2 M.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "moderate-halophilic"
+          "val" : "moderate-halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "moderately halophilic"
+          "val" : "moderately halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1766,10 +16104,22 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "non-halophilic"
+          "val" : "non-halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "non-halophilic"
+          "val" : "non-halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1778,11 +16128,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism requires low to moderate salt concentrations (0.3 to 0.8 M NaCl) for optimal growth."
+          "val" : "A halophily preference in which an organism requires low to moderate salt concentrations (0.3 to 0.8 M NaCl) for optimal growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "slightly halophilic"
+          "val" : "slightly halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1791,11 +16153,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism can only tolerate a narrow range of salinity concentrations and cannot survive significant changes in environmental salt levels."
+          "val" : "A halophily preference in which an organism can only tolerate a narrow range of salinity concentrations and cannot survive significant changes in environmental salt levels.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/SaltTolerance"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "stenohaline"
+          "val" : "stenohaline",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1815,7 +16189,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "euryhaline"
+          "val" : "euryhaline",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1824,14 +16204,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A halophily preference in which an organism requires very high salt concentrations (typically 15-30% NaCl or higher) for optimal growth and cannot grow at salt concentrations below approximately 12%."
+          "val" : "A halophily preference in which an organism requires very high salt concentrations (typically 15-30% NaCl or higher) for optimal growth and cannot grow at salt concentrations below approximately 12%.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001314"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "extreme-halophilic"
+          "val" : "extreme-halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "extremely halophilic"
+          "val" : "extremely halophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1844,17 +16245,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that is relating to an organism's salt concentration requirements or tolerance for growth."
+          "val" : "A phenotype that is relating to an organism's salt concentration requirements or tolerance for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005016"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/SaltTolerance"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.halophily.halophily level"
+          "val" : "Physiology and metabolism.halophily.halophily level",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "range_salinity"
+          "val" : "range_salinity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "salinity preference"
+          "val" : "salinity preference",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1876,13 +16304,25 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.nutrition type.type"
+          "val" : "Physiology and metabolism.nutrition type.type",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
           "val" : "nutritional type"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pathways"
+          "val" : "pathways",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1895,17 +16335,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism produces organic compounds from inorganic carbon sources (primarily carbon dioxide or bicarbonate) using energy from light (photoautotrophy) or from the oxidation of inorganic compounds (chemoautotrophy)."
+          "val" : "A trophic type in which an organism produces organic compounds from inorganic carbon sources (primarily carbon dioxide or bicarbonate) using energy from light (photoautotrophy) or from the oxidation of inorganic compounds (chemoautotrophy).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001456"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_autotroph"
+          "val" : "TT_autotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "autotroph"
+          "val" : "autotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "autotrophy"
+          "val" : "autotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1927,11 +16394,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism uses chemical oxidation of inorganic compounds as the energy source and carbon dioxide as the primary carbon source for biosynthesis."
+          "val" : "A trophic type in which an organism uses chemical oxidation of inorganic compounds as the energy source and carbon dioxide as the primary carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000123"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000124"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000129"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoautolithotroph"
+          "val" : "chemoautolithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1944,11 +16435,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from oxidation of inorganic compounds and carbon from carbon dioxide."
+          "val" : "A trophic type in which an organism obtains energy from oxidation of inorganic compounds and carbon from carbon dioxide.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000123"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000129"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001480"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoautotroph"
+          "val" : "chemoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1957,14 +16472,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains both energy and carbon from organic compounds."
+          "val" : "A trophic type in which an organism obtains both energy and carbon from organic compounds.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000012"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000127"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000132"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic_chemo_heterotrophy"
+          "val" : "aerobic_chemo_heterotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoheterotroph"
+          "val" : "chemoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1973,11 +16518,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from oxidation of inorganic compounds (lithotrophy) and carbon from carbon dioxide."
+          "val" : "A trophic type in which an organism obtains energy from oxidation of inorganic compounds (lithotrophy) and carbon from carbon dioxide.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000511"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemolithoautotroph"
+          "val" : "chemolithoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -1986,11 +16543,26 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of inorganic chemical compounds as electron donors for energy generation while utilizing organic compounds as the primary carbon source."
+          "val" : "A trophic type characterized by the use of inorganic chemical compounds as electron donors for energy generation while utilizing organic compounds as the primary carbon source.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000512"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001478"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemolithoheterotroph"
+          "val" : "chemolithoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2003,11 +16575,26 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of inorganic chemical compounds as electron donors and carbon dioxide as the primary carbon source for energy generation and biosynthesis."
+          "val" : "A trophic type characterized by the use of inorganic chemical compounds as electron donors and carbon dioxide as the primary carbon source for energy generation and biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001499"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemolithotroph"
+          "val" : "chemolithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2020,11 +16607,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains both energy and carbon from organic compounds through oxidation."
+          "val" : "A trophic type in which an organism obtains both energy and carbon from organic compounds through oxidation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000127"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000514"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001479"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001481"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoorganoheterotroph"
+          "val" : "chemoorganoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2033,14 +16644,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from chemical oxidation of either inorganic or organic compounds."
+          "val" : "A trophic type in which an organism obtains energy from chemical oxidation of either inorganic or organic compounds.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001458"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_chemotroph"
+          "val" : "TT_chemotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemotroph"
+          "val" : "chemotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2053,11 +16682,30 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "copiotroph"
+          "val" : "copiotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Jed Dongjin Kim-Ozaeta"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000643",
+      "lbl" : "obsolete denitrifying",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -2066,20 +16714,63 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide."
+          "val" : "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001474"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_heterotroph"
+          "val" : "TT_heterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic_heterotrophy"
+          "val" : "aerobic_heterotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "heterotroph"
+          "val" : "heterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "heterotrophic"
+          "val" : "heterotrophic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000645",
+      "lbl" : "obsolete hydrogen-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -2104,11 +16795,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from inorganic electron donors and carbon from carbon dioxide."
+          "val" : "A trophic type in which an organism obtains energy from inorganic electron donors and carbon from carbon dioxide.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000014"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000122"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001477"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001483"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "lithoautotroph"
+          "val" : "lithoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2117,11 +16832,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from the oxidation of inorganic compounds while using organic compounds as the primary carbon source for biosynthesis."
+          "val" : "A trophic type in which an organism obtains energy from the oxidation of inorganic compounds while using organic compounds as the primary carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000014"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000162"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001459"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001478"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007110"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "lithoheterotroph"
+          "val" : "lithoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2134,14 +16873,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism uses inorganic compounds as electron donors for energy generation."
+          "val" : "A trophic type in which an organism uses inorganic compounds as electron donors for energy generation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001459"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_lithotroph"
+          "val" : "TT_lithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "lithotroph"
+          "val" : "lithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2158,7 +16915,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "methanotroph"
+          "val" : "methanotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2175,13 +16938,31 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_methylotroph"
+          "val" : "TT_methylotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "methylotroph"
+          "val" : "methylotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "methylotrophy"
+          "val" : "methylotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2190,11 +16971,36 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism can use both organic and inorganic carbon sources for growth."
+          "val" : "A trophic type in which an organism can use both organic and inorganic carbon sources for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001475"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "mixotroph"
+          "val" : "mixotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000653",
+      "lbl" : "obsolete nitrogen-fixing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -2203,14 +17009,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A nutrient adaptation characterized by the ability to thrive in environments with very low nutrient concentrations, typically possessing efficient nutrient uptake and utilization systems."
+          "val" : "A nutrient adaptation characterized by the ability to thrive in environments with very low nutrient concentrations, typically possessing efficient nutrient uptake and utilization systems.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_00002223"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_01000774"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_oligotroph"
+          "val" : "TT_oligotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "oligotroph"
+          "val" : "oligotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2226,14 +17053,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from the oxidation of organic compounds."
+          "val" : "A trophic type in which an organism obtains energy from the oxidation of organic compounds.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000162"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_organotroph"
+          "val" : "TT_organotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "organotroph"
+          "val" : "organotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2242,26 +17090,80 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of light as the energy source and carbon dioxide as the primary carbon source for biosynthesis."
+          "val" : "A trophic type characterized by the use of light as the energy source and carbon dioxide as the primary carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000017"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000121"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001457"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001483"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0006008"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anoxygenic_photoautotrophy"
+          "val" : "anoxygenic_photoautotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anoxygenic_photoautotrophy_hydrogen_oxidation"
+          "val" : "anoxygenic_photoautotrophy_hydrogen_oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anoxygenic_photoautotrophy_iron_oxidation"
+          "val" : "anoxygenic_photoautotrophy_iron_oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "anoxygenic_photoautotrophy_sulfur_oxidation"
+          "val" : "anoxygenic_photoautotrophy_sulfur_oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoautotroph"
+          "val" : "photoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoautotrophy"
+          "val" : "photoautotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2274,14 +17176,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism uses light as the energy source and organic compounds as the primary carbon source for biosynthesis."
+          "val" : "A trophic type in which an organism uses light as the energy source and organic compounds as the primary carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000131"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoheterotroph"
+          "val" : "photoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoheterotrophy"
+          "val" : "photoheterotrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2294,11 +17214,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism uses light as the energy source and inorganic compounds as electron donors, typically with carbon dioxide as the primary carbon source."
+          "val" : "A trophic type in which an organism uses light as the energy source and inorganic compounds as electron donors, typically with carbon dioxide as the primary carbon source.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001482"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "photolithotroph"
+          "val" : "photolithotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2314,11 +17246,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from light and carbon from organic compounds."
+          "val" : "A trophic type in which an organism obtains energy from light and carbon from organic compounds.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000510"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "photoorganoheterotroph"
+          "val" : "photoorganoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2327,21 +17271,74 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of light as the primary energy source for metabolic processes, regardless of carbon source."
+          "val" : "A trophic type characterized by the use of light as the primary energy source for metabolic processes, regardless of carbon source.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001457"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007064"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "TT_phototroph"
+          "val" : "TT_phototroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic_anoxygenic_phototrophy"
+          "val" : "aerobic_anoxygenic_phototrophy",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "phototroph"
+          "val" : "phototroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Anthea Guo"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000661",
+      "lbl" : "obsolete sulfate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000662",
+      "lbl" : "obsolete sulfur-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -2350,11 +17347,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy through chemical oxidation of organic compounds that also serve as the carbon source for biosynthesis."
+          "val" : "A trophic type in which an organism obtains energy through chemical oxidation of organic compounds that also serve as the carbon source for biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007111"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "chemoorganotroph"
+          "val" : "chemoorganotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2367,11 +17376,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type characterized by the use of organic compounds as both electron donors and primary carbon sources for energy generation and biosynthesis."
+          "val" : "A trophic type characterized by the use of organic compounds as both electron donors and primary carbon sources for energy generation and biosynthesis.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000121"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000125"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000126"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000127"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ECOCORE_00000162"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "organoheterotroph"
+          "val" : "organoheterotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2384,11 +17417,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type in which an organism obtains energy from light and carbon from carbon dioxide using inorganic electron donors."
+          "val" : "A trophic type in which an organism obtains energy from light and carbon from carbon dioxide using inorganic electron donors.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000500"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "photolithoautotroph"
+          "val" : "photolithoautotroph",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2397,17 +17442,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that describes the characteristic three-dimensional morphological form of a microbial cell, determined by cell wall structure, cytoskeletal elements, and environmental factors."
+          "val" : "A phenotype that describes the characteristic three-dimensional morphological form of a microbial cell, determined by cell wall structure, cytoskeletal elements, and environmental factors.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000073"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Morphology.cell morphology.cell shape"
+          "val" : "Morphology.cell morphology.cell shape",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell shape"
+          "val" : "cell shape",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell_shape"
+          "val" : "cell_shape",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2423,11 +17492,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape characterized by an elongated, rod cylindrical morphology with relatively parallel sides and rounded ends."
+          "val" : "A cell shape characterized by an elongated, rod cylindrical morphology with relatively parallel sides and rounded ends.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000076"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "bacillus"
+          "val" : "bacillus",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2440,14 +17521,38 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has a spherical or nearly spherical morphology, with roughly equal dimensions in all directions."
+          "val" : "A cell shape in which an organism has a spherical or nearly spherical morphology, with roughly equal dimensions in all directions.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000402"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000075"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000123"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "coccus"
+          "val" : "coccus",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "coccus-shaped"
+          "val" : "coccus-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2461,7 +17566,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "crescent-shaped"
+          "val" : "crescent-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2475,10 +17586,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_curved_spiral"
+          "val" : "S_curved_spiral",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "curved-shaped"
+          "val" : "curved-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2491,11 +17614,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which spherical cells remain attached in pairs following cell division, forming characteristic doublets."
+          "val" : "A cell shape in which spherical cells remain attached in pairs following cell division, forming characteristic doublets.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000117"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "diplococcus-shaped"
+          "val" : "diplococcus-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2509,10 +17644,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_star_dumbbell_pleomorphic"
+          "val" : "S_star_dumbbell_pleomorphic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "dumbbell-shaped"
+          "val" : "dumbbell-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2521,11 +17668,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has an oval or ellipse morphology, elongated along one axis with rounded ends, intermediate between spherical and rod-shaped."
+          "val" : "A cell shape in which an organism has an oval or ellipse morphology, elongated along one axis with rounded ends, intermediate between spherical and rod-shaped.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0000947"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "ellipsoidal"
+          "val" : "ellipsoidal",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2542,13 +17701,31 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_filament"
+          "val" : "S_filament",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "filament"
+          "val" : "filament",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "filament-shaped"
+          "val" : "filament-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2562,10 +17739,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "flask"
+          "val" : "flask",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "flask-shaped"
+          "val" : "flask-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2575,7 +17764,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "helical-shaped"
+          "val" : "helical-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2591,14 +17786,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has an oval morphology, rounded at both ends with one end often slightly broader than the other."
+          "val" : "A cell shape in which an organism has an oval morphology, rounded at both ends with one end often slightly broader than the other.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0001891"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_ovoid"
+          "val" : "S_ovoid",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "ovoid-shaped"
+          "val" : "ovoid-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2611,11 +17824,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape characterized by an ellipsoidal morphology with rounded ends, resembling an elongated sphere."
+          "val" : "A cell shape characterized by an ellipsoidal morphology with rounded ends, resembling an elongated sphere.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007100"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oval-shaped"
+          "val" : "oval-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2628,17 +17853,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape characterized by variable and irregular morphology, where individual cells within a population exhibit multiple distinct shapes."
+          "val" : "A cell shape characterized by variable and irregular morphology, where individual cells within a population exhibit multiple distinct shapes.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000132"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_star_dumbbell_pleomorphic"
+          "val" : "S_star_dumbbell_pleomorphic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pleomorphic"
+          "val" : "pleomorphic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "pleomorphic-shaped"
+          "val" : "pleomorphic-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2654,14 +17903,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism forms circular or toroidal structures."
+          "val" : "A cell shape in which an organism forms circular or toroidal structures.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0002539"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "ring"
+          "val" : "ring",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "ring-shaped"
+          "val" : "ring-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2670,14 +17937,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has an elongated, cylindrical morphology with relatively straight sides and rounded or flat ends."
+          "val" : "A cell shape in which an organism has an elongated, cylindrical morphology with relatively straight sides and rounded or flat ends.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000076"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_rod"
+          "val" : "S_rod",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "rod-shaped"
+          "val" : "rod-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2691,7 +17976,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "spore-shaped"
+          "val" : "spore-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2705,10 +17996,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_sphere"
+          "val" : "S_sphere",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "sphere-shaped"
+          "val" : "sphere-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2722,13 +18025,31 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_curved_spiral"
+          "val" : "S_curved_spiral",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "spiral"
+          "val" : "spiral",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "spiral-shaped"
+          "val" : "spiral-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2741,17 +18062,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has multiple radiating projections from a central body."
+          "val" : "A cell shape in which an organism has multiple radiating projections from a central body.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000130"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0002065"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "S_star_dumbbell_pleomorphic"
+          "val" : "S_star_dumbbell_pleomorphic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "star"
+          "val" : "star",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "star-shaped"
+          "val" : "star-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2760,14 +18108,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has a curved rod or comma morphology, characterized by a short curved cylindrical form with a single arc."
+          "val" : "A cell shape in which an organism has a curved rod or comma morphology, characterized by a short curved cylindrical form with a single arc.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000077"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000086"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "vibrio"
+          "val" : "vibrio",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "vibrio-shaped"
+          "val" : "vibrio-shaped",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2781,7 +18150,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "branced"
+          "val" : "branced",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2791,7 +18166,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "coccobacillus"
+          "val" : "coccobacillus",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2804,7 +18185,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "disc"
+          "val" : "disc",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2813,11 +18200,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape that is wide in the middle and tapers at both ends."
+          "val" : "A cell shape that is wide in the middle and tapers at both ends.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0002400"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "fusiform"
+          "val" : "fusiform",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2827,7 +18226,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "irregular"
+          "val" : "irregular",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2837,7 +18242,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "spindle"
+          "val" : "spindle",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2850,11 +18261,29 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cell shape in which an organism has an elongated, tightly coiled helical morphology with periplasmic flagella (endoflagella) located between the cell wall and outer membrane."
+          "val" : "A cell shape in which an organism has an elongated, tightly coiled helical morphology with periplasmic flagella (endoflagella) located between the cell wall and outer membrane.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000086"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000124"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000125"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "spirochete"
+          "val" : "spirochete",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2868,7 +18297,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "square"
+          "val" : "square",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2878,7 +18313,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "tailed"
+          "val" : "tailed",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2888,7 +18329,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "triangular"
+          "val" : "triangular",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2897,14 +18344,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype where microorganisms are grouped based on their ability to retain crystal violet dye in the Gram staining procedure."
+          "val" : "A phenotype where microorganisms are grouped based on their ability to retain crystal violet dye in the Gram staining procedure.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000191"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Morphology.cell morphology.gram stain"
+          "val" : "Morphology.cell morphology.gram stain",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "gram_stain"
+          "val" : "gram_stain",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2920,20 +18385,53 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A gram stain in which an organism retains crystal violet dye and appears purple under microscopy due to a thick peptidoglycan cell wall."
+          "val" : "A gram stain in which an organism retains crystal violet dye and appears purple under microscopy due to a thick peptidoglycan cell wall.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000188"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/GramPositiveBacteria"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "G_positive"
+          "val" : "G_positive",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "gram positive"
+          "val" : "gram positive",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "positive"
+          "val" : "positive",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "positive"
+          "val" : "positive",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -2946,16 +18444,40 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "G_negative"
+          "val" : "G_negative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "gram negative"
+          "val" : "gram negative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "negative"
+          "val" : "negative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "negative"
+          "val" : "negative",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2968,11 +18490,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A gram stain in which bacteria from the same culture show both gram-positive and gram-negative staining characteristics, often due to age of culture or cell wall degradation."
+          "val" : "A gram stain in which bacteria from the same culture show both gram-positive and gram-negative staining characteristics, often due to age of culture or cell wall degradation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000190"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "variable"
+          "val" : "variable",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -2985,17 +18519,41 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype in which an organism has the capability to move independently through its environment, typically by means of flagella, pili, gliding mechanisms, or other locomotory structures."
+          "val" : "A phenotype in which an organism has the capability to move independently through its environment, typically by means of flagella, pili, gliding mechanisms, or other locomotory structures.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000001"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Morphology.cell morphology.motility"
+          "val" : "Morphology.cell morphology.motility",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "motility"
+          "val" : "motility",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "presence of motility"
+          "val" : "presence of motility",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3008,17 +18566,44 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motility in which an organism has the ability to move independently using metabolic energy."
+          "val" : "A motility in which an organism has the ability to move independently using metabolic energy.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/CL_0000219"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000005"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "motile"
+          "val" : "motile",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yes"
+          "val" : "yes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yes"
+          "val" : "yes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3027,17 +18612,53 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motility in which an organism lacks the ability to move independently under its own power."
+          "val" : "A motility in which an organism lacks the ability to move independently under its own power.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000133"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007488"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007489"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007490"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/UPHENO_0034076"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "no"
+          "val" : "no",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "no"
+          "val" : "no",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "non-motile"
+          "val" : "non-motile",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3046,11 +18667,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motile in which an organism possesses flagella for locomotion."
+          "val" : "A motile in which an organism possesses flagella for locomotion.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/CL_0011016"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0030317"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000272"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000029"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "flagella"
+          "val" : "flagella",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3059,11 +18701,26 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motility where the flagellum filament of an organism is located in the periplasm and does not extend past the cell envelope."
+          "val" : "A motility where the flagellum filament of an organism is located in the periplasm and does not extend past the cell envelope.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0055040"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000023"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "axial filament"
+          "val" : "axial filament",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3076,11 +18733,29 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motile in which an organism moves smoothly along solid surfaces without flagella or pili."
+          "val" : "A motile in which an organism moves smoothly along solid surfaces without flagella or pili.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0071976"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000437"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000112"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "gliding"
+          "val" : "gliding",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3089,14 +18764,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference characterized by the ability to grow at low temperatures (typically below 20°C) while maintaining optimal growth at moderate temperatures."
+          "val" : "A temperature preference characterized by the ability to grow at low temperatures (typically below 20°C) while maintaining optimal growth at moderate temperatures.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001306"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001417"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005007"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
           "val" : "facultative psychrophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "facultative psychrophilic"
+          "val" : "facultative psychrophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3109,7 +18802,22 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A temperature preference that grows optimally at temperatures above 90°C."
+          "val" : "A temperature preference that grows optimally at temperatures above 90°C.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_00002027"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001294"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001538"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005003"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
@@ -3125,7 +18833,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trophic type that involves an organism's physiological and metabolic adaptations to specific nutrient availability."
+          "val" : "A trophic type that involves an organism's physiological and metabolic adaptations to specific nutrient availability.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PHIPO_0001216"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3138,14 +18852,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A metabolism that is characterized by the method of performing cellular respiration, distinguished primarily by the specific terminal electron acceptor utilized for producing cellular energy."
+          "val" : "A metabolism that is characterized by the method of performing cellular respiration, distinguished primarily by the specific terminal electron acceptor utilized for producing cellular energy.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009060"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0045333"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pathways"
+          "val" : "pathways",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "respiration"
+          "val" : "respiration",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3158,7 +18893,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A respiration in which molecular oxygen serves as the terminal electron acceptor in the electron transport chain, generating ATP through oxidative phosphorylation with water as the final product."
+          "val" : "A respiration in which molecular oxygen serves as the terminal electron acceptor in the electron transport chain, generating ATP through oxidative phosphorylation with water as the final product.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009060"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
@@ -3178,7 +18919,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A respiration in which an organism uses electron acceptors other than oxygen for energy production."
+          "val" : "A respiration in which an organism uses electron acceptors other than oxygen for energy production.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009061"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
@@ -3194,7 +18941,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A metabolism that generates ATP through the transfer of electrons from electron donors to electron acceptors via redox reactions, coupled to the pumping of protons across a membrane to create an electrochemical gradient."
+          "val" : "A metabolism that generates ATP through the transfer of electrons from electron donors to electron acceptors via redox reactions, coupled to the pumping of protons across a membrane to create an electrochemical gradient.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0006119"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3216,7 +18969,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A metabolism in which electrons are transferred from an electron donor to an electron acceptor."
+          "val" : "A metabolism in which electrons are transferred from an electron donor to an electron acceptor.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009055"
+            } ]
+          }
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3237,12 +18996,499 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000807",
+      "lbl" : "obsolete Nitrogen compound respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000808",
+      "lbl" : "obsolete Nitrate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000809",
+      "lbl" : "obsolete Denitrification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000810",
+      "lbl" : "obsolete Dissimilatory nitrate reduction to ammonium",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000811",
+      "lbl" : "obsolete Nitrite reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000812",
+      "lbl" : "obsolete Anaerobic ammonium oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000813",
+      "lbl" : "obsolete Nitric oxide reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000814",
+      "lbl" : "obsolete Nitrous oxide reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000815",
+      "lbl" : "obsolete Sulfur and sulfoxide compound respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000816",
+      "lbl" : "obsolete Sulfate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000817",
+      "lbl" : "obsolete Sulfur reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000818",
+      "lbl" : "obsolete Sulfite reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000819",
+      "lbl" : "obsolete Thiosulfate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000820",
+      "lbl" : "obsolete Sulfoxide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000821",
+      "lbl" : "obsolete Dimethyl sulfoxide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000822",
+      "lbl" : "obsolete Methionine sulfoxide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000823",
+      "lbl" : "obsolete Sulfide oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000824",
+      "lbl" : "obsolete Thiosulfate oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000825",
+      "lbl" : "obsolete Sulfite oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000826",
+      "lbl" : "obsolete Tetrathionate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000827",
+      "lbl" : "obsolete Polysulfide reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000828",
+      "lbl" : "obsolete Metal and metalloid respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000829",
+      "lbl" : "obsolete Iron reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000830",
+      "lbl" : "obsolete Iron oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000831",
+      "lbl" : "obsolete Nitrate-dependent Fe(II) oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000832",
+      "lbl" : "obsolete Manganese reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000833",
+      "lbl" : "obsolete Manganese oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000834",
+      "lbl" : "obsolete Uranium reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000835",
+      "lbl" : "obsolete Vanadium reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000836",
+      "lbl" : "obsolete Chromium reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000837",
+      "lbl" : "obsolete Technetium reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000838",
+      "lbl" : "obsolete Cobalt reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000839",
+      "lbl" : "obsolete Arsenate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000840",
+      "lbl" : "obsolete Arsenite oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000841",
+      "lbl" : "obsolete Selenate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000842",
+      "lbl" : "obsolete Selenite reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000843",
+      "lbl" : "obsolete Carbon and organic compound respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000844",
       "lbl" : "Methanogenesis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions."
+          "val" : "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0015948"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
@@ -3255,7 +19501,13 @@
           "val" : "Carbonate respiration"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "methanogenesis"
+          "val" : "methanogenesis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3278,7 +19530,13 @@
           "val" : "Acetate fermentation"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "acetogenesis"
+          "val" : "acetogenesis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3305,25 +19563,354 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1000847",
+      "lbl" : "obsolete Fumarate respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000848",
+      "lbl" : "obsolete Trimethylamine N-oxide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000849",
+      "lbl" : "obsolete Humus respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000850",
+      "lbl" : "obsolete Halogenated compound respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000851",
+      "lbl" : "obsolete Organohalide respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000852",
+      "lbl" : "obsolete (Per)chlorate respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000853",
+      "lbl" : "obsolete Perchlorate respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000854",
+      "lbl" : "obsolete Chlorate respiration",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000855",
+      "lbl" : "obsolete Bromate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000856",
+      "lbl" : "obsolete Iodate reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000857",
+      "lbl" : "obsolete Nitrite-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000858",
+      "lbl" : "obsolete Nitrate-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000859",
+      "lbl" : "obsolete Hydrogen oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000860",
+      "lbl" : "obsolete Sulfur oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000861",
+      "lbl" : "obsolete Nitrification",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000862",
+      "lbl" : "obsolete Complete ammonia oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000863",
+      "lbl" : "obsolete Carbon monoxide oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000864",
+      "lbl" : "obsolete Hydrogenotrophic methanogenesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000865",
+      "lbl" : "obsolete Acetoclastic methanogenesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000866",
+      "lbl" : "obsolete Methylotrophic methanogenesis",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000867",
+      "lbl" : "obsolete Anaerobic methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000868",
+      "lbl" : "obsolete Lanthanide reduction",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1000869",
+      "lbl" : "obsolete Lanthanide oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1000870",
       "lbl" : "sporulation",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that is relating to an organism's ability to form dormant, stress-resistant endospores."
+          "val" : "A phenotype that is relating to an organism's ability to form dormant, stress-resistant endospores.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0043934"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "General.keywords"
+          "val" : "General.keywords",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.spore formation.spore formation"
+          "val" : "Physiology and metabolism.spore formation.spore formation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "sporulation"
+          "val" : "sporulation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "sporulation"
+          "val" : "sporulation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3332,17 +19919,47 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A sporulation in which an organism has the ability to produce endospores."
+          "val" : "A sporulation in which an organism has the ability to produce endospores.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0034301"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000017"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://purl.dsmz.de/schema/SporeFormation"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "spore"
+          "val" : "spore",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yes"
+          "val" : "yes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yes"
+          "val" : "yes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3351,17 +19968,53 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A sporulation in which an organism lacks the ability to produce endospores."
+          "val" : "A sporulation in which an organism lacks the ability to produce endospores.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000018"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007232"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007236"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007434"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/UPHENO_0083394"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "no"
+          "val" : "no",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "no"
+          "val" : "no",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "no_spore"
+          "val" : "no_spore",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3370,11 +20023,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that inheres in a cell by virtue of its longer dimension when viewed on a plane."
+          "val" : "A phenotype that inheres in a cell by virtue of its longer dimension when viewed on a plane.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OBA_2040145"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell length"
+          "val" : "cell length",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3383,11 +20048,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that inheres in a cell by virtue of its shorter dimension when viewed on a plane."
+          "val" : "A phenotype that inheres in a cell by virtue of its shorter dimension when viewed on a plane.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OBA_2040146"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell width"
+          "val" : "cell width",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3397,7 +20074,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "L_<=1.3"
+          "val" : "L_<=1.3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3414,7 +20097,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "L_1.3_2"
+          "val" : "L_1.3_2",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3434,7 +20123,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "L_2_3"
+          "val" : "L_2_3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3454,7 +20149,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "L_>3"
+          "val" : "L_>3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3471,7 +20172,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "W_<=0.5"
+          "val" : "W_<=0.5",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3488,7 +20195,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "W_0.5_0.65"
+          "val" : "W_0.5_0.65",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3508,7 +20221,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "W_0.65_0.9"
+          "val" : "W_0.65_0.9",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3528,7 +20247,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "W_>0.9"
+          "val" : "W_>0.9",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://qudt.org/schema/qudt/ucumCode",
@@ -3540,97 +20265,316 @@
       }
     }, {
       "id" : "https://w3id.org/metpo/1001000",
-      "lbl" : "observation",
-      "type" : "CLASS"
-    }, {
-      "id" : "https://w3id.org/metpo/1001001",
-      "lbl" : "optimum temperature observation",
+      "lbl" : "obsolete observation",
       "type" : "CLASS",
       "meta" : {
-        "definition" : {
-          "val" : "An observation that identifies the temperature at which a microorganism exhibits maximum growth rate or metabolic activity."
-        },
         "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Luke Wang"
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1001001",
+      "lbl" : "obsolete optimum temperature observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/1001002",
-      "lbl" : "growth temperature observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete growth temperature observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001003",
-      "lbl" : "temperature range observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete temperature range observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001004",
-      "lbl" : "temperature delta observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete temperature delta observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1001005",
+      "lbl" : "obsolete culture temperature observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1001006",
+      "lbl" : "obsolete culture NaCl observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001007",
-      "lbl" : "growth NaCl observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete growth NaCl observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001008",
-      "lbl" : "NaCl delta observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete NaCl delta observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001009",
-      "lbl" : "NaCl range observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete NaCl range observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001010",
-      "lbl" : "optimum NaCl observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete optimum NaCl observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1001011",
+      "lbl" : "obsolete culture pH observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001012",
-      "lbl" : "growth pH observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete growth pH observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001013",
-      "lbl" : "optimum pH observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete optimum pH observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001014",
-      "lbl" : "pH delta observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete pH delta observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001015",
-      "lbl" : "pH range observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete pH range observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001016",
-      "lbl" : "optimum oxygen observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete optimum oxygen observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001017",
-      "lbl" : "growth oxygen observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete growth oxygen observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001018",
-      "lbl" : "oxygen range observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete oxygen range observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001019",
-      "lbl" : "oxygen delta observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete oxygen delta observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001020",
-      "lbl" : "oxygen observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete oxygen observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001021",
-      "lbl" : "temperature observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete temperature observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001022",
-      "lbl" : "NaCl observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete NaCl observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001023",
-      "lbl" : "pH observation",
-      "type" : "CLASS"
+      "lbl" : "obsolete pH observation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/1001101",
       "lbl" : "biosafety level",
@@ -3641,10 +20585,22 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Safety information.risk assessment.biosafety level"
+          "val" : "Safety information.risk assessment.biosafety level",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "biosafety level"
+          "val" : "biosafety level",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3657,7 +20613,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "1"
+          "val" : "1",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3674,7 +20636,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "2"
+          "val" : "2",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3687,10 +20655,22 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "3"
+          "val" : "3",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "3**"
+          "val" : "3**",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3707,7 +20687,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "4"
+          "val" : "4",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3720,7 +20706,52 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "5"
+          "val" : "5",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002000",
+      "lbl" : "obsolete Sulfate-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002001",
+      "lbl" : "obsolete Fe(III)-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002002",
+      "lbl" : "obsolete Mn(IV)-dependent methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -3738,14 +20769,32 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A respiration that generates energy through the oxidation of organic compounds without using an external electron acceptor, using organic molecules as both electron donors and final electron acceptors."
+          "val" : "A respiration that generates energy through the oxidation of organic compounds without using an external electron acceptor, using organic molecules as both electron donors and final electron acceptors.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0006113"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "fermentation"
+          "val" : "fermentation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://github.com/jmadin/bacteria_archaea_traits"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "fermentation"
+          "val" : "fermentation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -3766,16 +20815,470 @@
         } ]
       }
     }, {
+      "id" : "https://w3id.org/metpo/1002007",
+      "lbl" : "obsolete Sulfur disproportionation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002008",
+      "lbl" : "obsolete Nitrogen fixation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002009",
+      "lbl" : "obsolete Nitrate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002010",
+      "lbl" : "obsolete Anaerobic ammonium-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002011",
+      "lbl" : "obsolete Nitrous oxide-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002012",
+      "lbl" : "obsolete Sulfate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002013",
+      "lbl" : "obsolete Sulfur-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002014",
+      "lbl" : "obsolete Sulfite-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002015",
+      "lbl" : "obsolete Thiosulfate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002016",
+      "lbl" : "obsolete Sulfur-disproportionating",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002017",
+      "lbl" : "obsolete Sulfide-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002018",
+      "lbl" : "obsolete Thiosulfate-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002019",
+      "lbl" : "obsolete Sulfite-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002020",
+      "lbl" : "obsolete Iron-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002021",
+      "lbl" : "obsolete Iron-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002022",
+      "lbl" : "obsolete Nitrate-dependent Fe(II)-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002023",
+      "lbl" : "obsolete Manganese-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002024",
+      "lbl" : "obsolete Manganese-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002025",
+      "lbl" : "obsolete Uranium-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002026",
+      "lbl" : "obsolete Arsenate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002027",
+      "lbl" : "obsolete Selenate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002028",
+      "lbl" : "obsolete Selenite-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002029",
+      "lbl" : "obsolete Perchlorate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002030",
+      "lbl" : "obsolete Chlorate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002031",
+      "lbl" : "obsolete Bromate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002032",
+      "lbl" : "obsolete Iodate-reducing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002033",
+      "lbl" : "obsolete Hydrogen-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002034",
+      "lbl" : "obsolete Sulfur-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002035",
+      "lbl" : "obsolete Ammonia oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002036",
+      "lbl" : "obsolete Nitrite oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002037",
+      "lbl" : "obsolete Complete ammonia-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002038",
+      "lbl" : "obsolete Methane oxidation",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002039",
+      "lbl" : "obsolete Carbon monoxide-oxidizing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/1002040",
+      "lbl" : "obsolete Nitrogen-fixing",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/1003000",
       "lbl" : "pH growth preference",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype that describes how the rate and extent of population growth are affected by environmental pH."
+          "val" : "A phenotype that describes how the rate and extent of population growth are affected by environmental pH.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005008"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pH growth"
+          "val" : "pH growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3784,7 +21287,16 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference characterized by optimal growth at near-neutral pH values, typically between pH 6.5 and 7.5."
+          "val" : "A pH growth preference characterized by optimal growth at near-neutral pH values, typically between pH 6.5 and 7.5.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005010"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/PATO_0070046"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3807,7 +21319,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism grows optimally at pH values above 9."
+          "val" : "A pH growth preference in which an organism grows optimally at pH values above 9.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_00002022"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001549"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005010"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3829,7 +21359,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism grows optimally at pH values below 5."
+          "val" : "A pH growth preference in which an organism grows optimally at pH values below 5.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001549"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005010"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007945"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3839,7 +21387,13 @@
           "val" : "acidophile"
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "acidophilic"
+          "val" : "acidophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3848,7 +21402,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism requires alkaline conditions (typically pH above 8.5) for growth and cannot grow at neutral or acidic pH."
+          "val" : "A pH growth preference in which an organism requires alkaline conditions (typically pH above 8.5) for growth and cannot grow at neutral or acidic pH.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/ENVO_00002022"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001565"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007771"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007947"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3871,7 +21443,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism can grow at alkaline pH but does not require it."
+          "val" : "A pH growth preference in which an organism can grow at alkaline pH but does not require it.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001558"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007771"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007947"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3890,7 +21480,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference characterized by the requirement for acidic environments (pH below 5.5) for growth, with inability to grow at neutral or alkaline pH values."
+          "val" : "A pH growth preference characterized by the requirement for acidic environments (pH below 5.5) for growth, with inability to grow at neutral or alkaline pH values.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001566"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3913,7 +21509,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference characterized by optimal growth in acidic environments (pH below 5.5) with the capacity to also grow at near-neutral pH values."
+          "val" : "A pH growth preference characterized by optimal growth in acidic environments (pH below 5.5) with the capacity to also grow at near-neutral pH values.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001557"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005010"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007945"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3936,7 +21550,13 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference characterized by the ability to tolerate acidic environments (typically pH below 5.5) while maintaining optimal growth near neutral pH."
+          "val" : "A pH growth preference characterized by the ability to tolerate acidic environments (typically pH below 5.5) while maintaining optimal growth near neutral pH.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0001555"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3956,7 +21576,25 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pH growth preference in which an organism can tolerate alkaline pH but grows optimally at neutral pH."
+          "val" : "A pH growth preference in which an organism can tolerate alkaline pH but grows optimally at neutral pH.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005009"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007011"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007771"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007947"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3969,11 +21607,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype characterized by the color of pigments produced by a microorganism."
+          "val" : "A phenotype characterized by the color of pigments produced by a microorganism.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0043473"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell color"
+          "val" : "cell color",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3983,7 +21633,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_black"
+          "val" : "Pigment_black",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -3993,7 +21649,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_brown"
+          "val" : "Pigment_brown",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4003,7 +21665,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_cream"
+          "val" : "Pigment_cream",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4013,7 +21681,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_green"
+          "val" : "Pigment_green",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4023,7 +21697,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_orange"
+          "val" : "Pigment_orange",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4033,7 +21713,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_pink"
+          "val" : "Pigment_pink",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4043,7 +21729,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_red"
+          "val" : "Pigment_red",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4053,7 +21745,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_white"
+          "val" : "Pigment_white",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4063,10 +21761,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_yellow"
+          "val" : "Pigment_yellow",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "yellow pigment"
+          "val" : "yellow pigment",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4076,7 +21786,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Pigment_carotenoid"
+          "val" : "Pigment_carotenoid",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4085,14 +21801,35 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype where a microbe is a pathogen of of some host organism."
+          "val" : "A phenotype where a microbe is a pathogen of of some host organism.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000068"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0007284"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "General.keywords"
+          "val" : "General.keywords",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "Safety information.risk assessment"
+          "val" : "Safety information.risk assessment",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4105,7 +21842,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "animal pathogen"
+          "val" : "animal pathogen",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4118,7 +21861,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "plant pathogen"
+          "val" : "plant pathogen",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4127,11 +21876,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A pathogen that infects organisms of the species Homo sapiens."
+          "val" : "A pathogen that infects organisms of the species Homo sapiens.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/IDO_0000639"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "human pathogen"
+          "val" : "human pathogen",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4140,12 +21901,18 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A processed material that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms."
+          "val" : "A processed material that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OBI_0000079"
+            } ]
+          }
         },
         "comments" : [ "This class is equivalent to OBI:0000079 'culture medium'. It is included in METPO to serve as the range for growth-related object properties." ],
         "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2004/02/skos/core#closeMatch",
-          "val" : "https://biolink.github.io/biolink-model/ChemicalEntity"
+          "pred" : "http://www.w3.org/2004/02/skos/core#broadMatch",
+          "val" : "https://biolink.github.io/biolink-model/ProcessedMaterial"
         } ]
       }
     }, {
@@ -4154,12 +21921,27 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A two-step biological process in which ammonia is oxidized to nitrite (ammonia oxidation) and nitrite is oxidized to nitrate (nitrite oxidation)."
+          "val" : "A two-step biological process in which ammonia is oxidized to nitrite (ammonia oxidation) and nitrite is oxidized to nitrate (nitrite oxidation).",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0019329"
+            }, {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0019332"
+            } ]
+          }
         },
         "comments" : [ "MetaTraits maps to OMIT:0027217 (wrong ontology). Correct GO terms are GO:0019329 (ammonia oxidation) and GO:0019332 (nitrite oxidation)." ],
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "nitrification"
+          "val" : "nitrification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4168,11 +21950,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An assay that tests the ability of an organism to produce indole from tryptophan."
+          "val" : "An assay that tests the ability of an organism to produce indole from tryptophan.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/MICRO_0000430"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "indole test"
+          "val" : "indole test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4185,7 +21979,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "indole test"
+          "val" : "indole test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4203,11 +22003,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An assay that tests the ability of an organism to produce and maintain stable acid end products from glucose fermentation."
+          "val" : "An assay that tests the ability of an organism to produce and maintain stable acid end products from glucose fermentation.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "SNOMED:5894006"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "methyl red test"
+          "val" : "methyl red test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4220,7 +22032,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "methyl red test"
+          "val" : "methyl red test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4238,11 +22056,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An assay that tests the ability of an organism to produce acetoin from glucose via the butanediol fermentation pathway."
+          "val" : "An assay that tests the ability of an organism to produce acetoin from glucose via the butanediol fermentation pathway.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "SNOMED:66592006"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "voges-proskauer test"
+          "val" : "voges-proskauer test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4255,7 +22085,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "voges-proskauer test"
+          "val" : "voges-proskauer test",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4273,11 +22109,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype describing an organism that requires elevated concentrations of carbon dioxide for growth."
+          "val" : "A phenotype describing an organism that requires elevated concentrations of carbon dioxide for growth.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "SNOMED:413748004"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "capnophilic"
+          "val" : "capnophilic",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4286,11 +22134,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype describing the ability of an organism to lyse red blood cells."
+          "val" : "A phenotype describing the ability of an organism to lyse red blood cells.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0005117"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "presence of hemolysis"
+          "val" : "presence of hemolysis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4317,11 +22177,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A motility phenotype in which flagella are distributed over the entire cell surface."
+          "val" : "A motility phenotype in which flagella are distributed over the entire cell surface.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/OMP_0000078"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "flagellum arrangement"
+          "val" : "flagellum arrangement",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4334,7 +22206,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "flagellum arrangement"
+          "val" : "flagellum arrangement",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4388,11 +22266,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A biological process in which nitrate or nitrite is reduced to gaseous nitrogen compounds (NO, N2O, or N2) under anaerobic or microaerobic conditions."
+          "val" : "A biological process in which nitrate or nitrite is reduced to gaseous nitrogen compounds (NO, N2O, or N2) under anaerobic or microaerobic conditions.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0019333"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "denitrification pathway"
+          "val" : "denitrification pathway",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4401,11 +22291,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A biological process in which atmospheric dinitrogen is reduced to ammonia, catalyzed by nitrogenase."
+          "val" : "A biological process in which atmospheric dinitrogen is reduced to ammonia, catalyzed by nitrogenase.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "http://purl.obolibrary.org/obo/GO_0009399"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "nitrogen fixation"
+          "val" : "nitrogen fixation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4414,11 +22316,50 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources."
+          "val" : "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "inbio:000022"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "generalist"
+          "val" : "generalist",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/9999999",
+      "lbl" : "obsolete obsolete",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000000",
+      "lbl" : "obsolete has susceptibility profile",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -4434,7 +22375,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "assimilation"
+          "val" : "assimilation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4445,7 +22392,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds acid from"
+          "val" : "builds acid from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4456,7 +22409,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds base from"
+          "val" : "builds base from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4467,7 +22426,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds gas from"
+          "val" : "builds gas from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4478,7 +22443,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "carbon source"
+          "val" : "carbon source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4489,7 +22460,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "degradation"
+          "val" : "degradation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4500,7 +22477,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "electron acceptor"
+          "val" : "electron acceptor",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4511,7 +22494,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "electron donor"
+          "val" : "electron donor",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4522,7 +22511,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "energy source"
+          "val" : "energy source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4533,7 +22528,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "fermentation"
+          "val" : "fermentation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4544,7 +22545,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "growth"
+          "val" : "growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4555,7 +22562,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "hydrolysis"
+          "val" : "hydrolysis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4566,7 +22579,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "nitrogen source"
+          "val" : "nitrogen source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4577,10 +22596,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "other"
+          "val" : "other",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "utilizes"
+          "val" : "utilizes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4591,7 +22622,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxidation"
+          "val" : "oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4602,7 +22639,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "reduction"
+          "val" : "reduction",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4613,7 +22656,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "required for growth"
+          "val" : "required for growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4624,7 +22673,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "respiration"
+          "val" : "respiration",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4635,7 +22690,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "sulfur source"
+          "val" : "sulfur source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4646,7 +22707,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic catabolization"
+          "val" : "aerobic catabolization",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4657,7 +22724,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic growth"
+          "val" : "aerobic growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4668,7 +22741,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic catabolization"
+          "val" : "anaerobic catabolization",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4679,7 +22758,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth"
+          "val" : "anaerobic growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4690,7 +22775,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth in the dark"
+          "val" : "anaerobic growth in the dark",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4701,7 +22792,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth with light"
+          "val" : "anaerobic growth with light",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4712,7 +22809,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "assimilation"
+          "val" : "assimilation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4723,7 +22826,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds acid from"
+          "val" : "builds acid from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4734,7 +22843,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds base from"
+          "val" : "builds base from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4745,7 +22860,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "builds gas from"
+          "val" : "builds gas from",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4756,7 +22877,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "carbon source"
+          "val" : "carbon source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4767,7 +22894,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic catabolization"
+          "val" : "aerobic catabolization",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4778,7 +22911,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "degradation"
+          "val" : "degradation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4789,7 +22928,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "electron acceptor"
+          "val" : "electron acceptor",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4800,7 +22945,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "electron donor"
+          "val" : "electron donor",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4811,7 +22962,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "energy source"
+          "val" : "energy source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4822,7 +22979,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "fermentation"
+          "val" : "fermentation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4833,7 +22996,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "growth"
+          "val" : "growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4844,7 +23013,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "hydrolysis"
+          "val" : "hydrolysis",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4855,7 +23030,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "nitrogen source"
+          "val" : "nitrogen source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4866,10 +23047,22 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "other"
+          "val" : "other",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         }, {
           "pred" : "hasRelatedSynonym",
-          "val" : "utilizes"
+          "val" : "utilizes",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4880,7 +23073,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxidation"
+          "val" : "oxidation",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4891,7 +23090,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "aerobic growth"
+          "val" : "aerobic growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4902,7 +23107,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "reduction"
+          "val" : "reduction",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4913,7 +23124,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "required for growth"
+          "val" : "required for growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4924,7 +23141,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "respiration"
+          "val" : "respiration",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4935,7 +23158,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "sulfur source"
+          "val" : "sulfur source",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4946,7 +23175,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic catabolization"
+          "val" : "anaerobic catabolization",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4957,7 +23192,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth"
+          "val" : "anaerobic growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4968,7 +23209,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth in the dark"
+          "val" : "anaerobic growth in the dark",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -4979,58 +23226,98 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "anaerobic growth with light"
+          "val" : "anaerobic growth with light",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000052",
-      "lbl" : "has temperature observation",
+      "lbl" : "obsolete has temperature observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a temperature observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000053",
-      "lbl" : "has optimum temperature observation",
+      "lbl" : "obsolete has optimum temperature observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an optimum temperature observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000054",
-      "lbl" : "has growth temperature observation",
+      "lbl" : "obsolete has growth temperature observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth temperature observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000055",
-      "lbl" : "has range temperature observation",
+      "lbl" : "obsolete has range temperature observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth temperature range observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000056",
-      "lbl" : "has temperature delta observation",
+      "lbl" : "obsolete has temperature delta observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a temperature tolerance breadth (delta) observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000057",
+      "lbl" : "obsolete has culture temperature observation",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000101",
@@ -5067,7 +23354,27 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "dismutates"
+          "val" : "dismutates",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000201",
+      "lbl" : "obsolete lyses",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -5078,7 +23385,69 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "produces"
+          "val" : "produces",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000203",
+      "lbl" : "obsolete fixes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000204",
+      "lbl" : "obsolete catabolizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000205",
+      "lbl" : "obsolete mineralizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000206",
+      "lbl" : "obsolete conjugates",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -5112,6 +23481,104 @@
       "type" : "PROPERTY",
       "propertyType" : "OBJECT"
     }, {
+      "id" : "https://w3id.org/metpo/2000213",
+      "lbl" : "obsolete binds",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000214",
+      "lbl" : "obsolete chelates",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000215",
+      "lbl" : "obsolete precipitates",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000216",
+      "lbl" : "obsolete solubilizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000217",
+      "lbl" : "obsolete volatilizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000218",
+      "lbl" : "obsolete crystallizes",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000219",
+      "lbl" : "obsolete adsorbs",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
       "id" : "https://w3id.org/metpo/2000220",
       "lbl" : "does not disproportionate",
       "type" : "PROPERTY",
@@ -5119,7 +23586,27 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "dismutates"
+          "val" : "dismutates",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000221",
+      "lbl" : "obsolete does not lyse",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -5130,7 +23617,69 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "produces"
+          "val" : "produces",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000223",
+      "lbl" : "obsolete does not fix",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000224",
+      "lbl" : "obsolete does not catabolize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000225",
+      "lbl" : "obsolete does not mineralize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000226",
+      "lbl" : "obsolete does not conjugate",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
         } ]
       }
     }, {
@@ -5164,14 +23713,102 @@
       "type" : "PROPERTY",
       "propertyType" : "OBJECT"
     }, {
-      "id" : "https://w3id.org/metpo/2000239",
-      "lbl" : "has pH observation",
+      "id" : "https://w3id.org/metpo/2000233",
+      "lbl" : "obsolete does not bind",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a pH observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000234",
+      "lbl" : "obsolete does not chelate",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000235",
+      "lbl" : "obsolete does not precipitate",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000236",
+      "lbl" : "obsolete does not solubilize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000237",
+      "lbl" : "obsolete does not volatilize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000238",
+      "lbl" : "obsolete does not crystallize",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000239",
+      "lbl" : "obsolete has pH observation",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000301",
@@ -5181,7 +23818,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.enzymes.[].activity"
+          "val" : "Physiology and metabolism.enzymes.[].activity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5192,7 +23835,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.enzymes.[].activity"
+          "val" : "Physiology and metabolism.enzymes.[].activity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5203,153 +23852,238 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "Physiology and metabolism.enzymes.[].activity"
+          "val" : "Physiology and metabolism.enzymes.[].activity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://bacdive.dsmz.de/"
+            } ]
+          }
         } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000501",
-      "lbl" : "has optimum pH observation",
+      "lbl" : "obsolete has optimum pH observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an optimum pH observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000502",
-      "lbl" : "has growth pH observation",
+      "lbl" : "obsolete has growth pH observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth pH observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000503",
-      "lbl" : "has range pH observation",
+      "lbl" : "obsolete has range pH observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth pH range observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000504",
-      "lbl" : "has pH delta observation",
+      "lbl" : "obsolete has pH delta observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a pH tolerance breadth (delta) observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000505",
+      "lbl" : "obsolete has culture pH observation",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000506",
-      "lbl" : "has NaCl observation",
+      "lbl" : "obsolete has NaCl observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a NaCl observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000507",
-      "lbl" : "has optimum NaCl observation",
+      "lbl" : "obsolete has optimum NaCl observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an optimum NaCl observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000508",
-      "lbl" : "has growth NaCl observation",
+      "lbl" : "obsolete has growth NaCl observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth NaCl observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000509",
-      "lbl" : "has range NaCl observation",
+      "lbl" : "obsolete has range NaCl observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth NaCl range observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000510",
-      "lbl" : "has NaCl delta observation",
+      "lbl" : "obsolete has NaCl delta observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a NaCl tolerance breadth (delta) observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000511",
-      "lbl" : "has observation",
-      "type" : "PROPERTY",
-      "propertyType" : "OBJECT"
-    }, {
-      "id" : "https://w3id.org/metpo/2000512",
-      "lbl" : "has oxygen observation",
+      "lbl" : "obsolete has observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an oxygen observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
+    }, {
+      "id" : "https://w3id.org/metpo/2000512",
+      "lbl" : "obsolete has oxygen observation",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000513",
-      "lbl" : "has optimum oxygen observation",
+      "lbl" : "obsolete has optimum oxygen observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to an optimum oxygen observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000514",
-      "lbl" : "has growth oxygen observation",
+      "lbl" : "obsolete has growth oxygen observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth oxygen observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000515",
-      "lbl" : "has range oxygen observation",
+      "lbl" : "obsolete has range oxygen observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a growth oxygen range observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000516",
-      "lbl" : "has oxygen delta observation",
+      "lbl" : "obsolete has oxygen delta observation",
       "type" : "PROPERTY",
       "propertyType" : "OBJECT",
       "meta" : {
-        "definition" : {
-          "val" : "Relates a microbe to a oxygen tolerance breadth (delta) observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000517",
@@ -5379,7 +24113,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "denitrification"
+          "val" : "denitrification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5390,7 +24130,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "denitrification"
+          "val" : "denitrification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5401,7 +24147,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "ammonification"
+          "val" : "ammonification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5412,7 +24164,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "ammonification"
+          "val" : "ammonification",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5423,7 +24181,13 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxidation in darkness"
+          "val" : "oxidation in darkness",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5434,64 +24198,99 @@
       "meta" : {
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "oxidation in darkness"
+          "val" : "oxidation in darkness",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000058",
-      "lbl" : "has observed spot value",
+      "lbl" : "obsolete has observed spot value",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "A reported temperature value (°C) for this observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000059",
-      "lbl" : "has minimum observed value",
+      "lbl" : "obsolete has minimum observed value",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "The minimum temperature (°C) associated with this observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000060",
-      "lbl" : "has maximum observed value",
+      "lbl" : "obsolete has maximum observed value",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "The maximum temperature (°C) associated with this observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000061",
-      "lbl" : "has value comments",
+      "lbl" : "obsolete has value comments",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "Free-text comments associated with this observation."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000062",
-      "lbl" : "is negative data",
+      "lbl" : "obsolete is negative data",
       "type" : "PROPERTY",
       "propertyType" : "DATA",
       "meta" : {
-        "definition" : {
-          "val" : "True if this observation indicates no growth at the reported temperature (negative result)."
-        }
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
       }
     }, {
       "id" : "https://w3id.org/metpo/2000063",
-      "lbl" : "observation data property",
+      "lbl" : "obsolete observation data property",
       "type" : "PROPERTY",
-      "propertyType" : "DATA"
+      "propertyType" : "DATA",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      }
     }, {
       "id" : "https://w3id.org/metpo/2000071",
       "lbl" : "has value",
@@ -5513,7 +24312,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "temperature growth"
+          "val" : "temperature growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5527,7 +24332,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "temperature minimum"
+          "val" : "temperature minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5541,7 +24352,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "temperature maximum"
+          "val" : "temperature maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5555,7 +24372,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pH growth"
+          "val" : "pH growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5569,7 +24392,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pH minimum"
+          "val" : "pH minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5583,7 +24412,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pH maximum"
+          "val" : "pH maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5597,7 +24432,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "salinity growth"
+          "val" : "salinity growth",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5611,7 +24452,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "salinity minimum"
+          "val" : "salinity minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5625,7 +24472,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "salinity maximum"
+          "val" : "salinity maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5639,7 +24492,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "genome size"
+          "val" : "genome size",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5653,7 +24512,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "estimated genome size"
+          "val" : "estimated genome size",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5667,7 +24532,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "gene count"
+          "val" : "gene count",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5681,7 +24552,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "estimated gene count"
+          "val" : "estimated gene count",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5695,7 +24572,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "GC percentage"
+          "val" : "GC percentage",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5709,7 +24592,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "coding density"
+          "val" : "coding density",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5723,7 +24612,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell length"
+          "val" : "cell length",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5737,7 +24632,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell width"
+          "val" : "cell width",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5751,7 +24652,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell length minimum"
+          "val" : "cell length minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5765,7 +24672,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell length maximum"
+          "val" : "cell length maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5779,7 +24692,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell width minimum"
+          "val" : "cell width minimum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5793,7 +24712,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "cell width maximum"
+          "val" : "cell width maximum",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5817,7 +24742,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "generalism_score"
+          "val" : "generalism_score",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5831,7 +24762,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "habitat_count"
+          "val" : "habitat_count",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5845,7 +24782,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "pangenome_openness"
+          "val" : "pangenome_openness",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5859,7 +24802,13 @@
         },
         "synonyms" : [ {
           "pred" : "hasRelatedSynonym",
-          "val" : "intra_species_nucleotide_diversity"
+          "val" : "intra_species_nucleotide_diversity",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "https://metatraits.embl.de/"
+            } ]
+          }
         } ]
       }
     }, {
@@ -5875,6 +24824,14 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000119",
       "lbl" : "definition source",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000231",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.org/dc/terms/contributor",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -5918,6 +24875,10 @@
       "propertyType" : "ANNOTATION"
     }, {
       "id" : "http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://www.w3.org/2004/02/skos/core#broadMatch",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -6762,86 +25723,6 @@
       "pred" : "is_a",
       "obj" : "https://w3id.org/metpo/1000882"
     }, {
-      "sub" : "https://w3id.org/metpo/1001001",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001002",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001003",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001004",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001007",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001008",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001009",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001010",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001012",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001013",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001014",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001015",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001016",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001017",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001018",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001019",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001020",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001021",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001022",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
-      "sub" : "https://w3id.org/metpo/1001023",
-      "pred" : "is_a",
-      "obj" : "https://w3id.org/metpo/1001000"
-    }, {
       "sub" : "https://w3id.org/metpo/1001101",
       "pred" : "is_a",
       "obj" : "https://w3id.org/metpo/1000188"
@@ -7278,26 +26159,6 @@
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000001"
     }, {
-      "sub" : "https://w3id.org/metpo/2000052",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000511"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000053",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000052"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000054",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000052"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000055",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000052"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000056",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000052"
-    }, {
       "sub" : "https://w3id.org/metpo/2000102",
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000101"
@@ -7366,10 +26227,6 @@
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000230"
     }, {
-      "sub" : "https://w3id.org/metpo/2000239",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000511"
-    }, {
       "sub" : "https://w3id.org/metpo/2000302",
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000301"
@@ -7377,62 +26234,6 @@
       "sub" : "https://w3id.org/metpo/2000303",
       "pred" : "subPropertyOf",
       "obj" : "https://w3id.org/metpo/2000301"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000501",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000239"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000502",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000239"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000503",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000239"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000504",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000239"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000506",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000511"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000507",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000506"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000508",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000506"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000509",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000506"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000510",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000506"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000512",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000511"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000513",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000512"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000514",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000512"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000515",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000512"
-    }, {
-      "sub" : "https://w3id.org/metpo/2000516",
-      "pred" : "subPropertyOf",
-      "obj" : "https://w3id.org/metpo/2000512"
     }, {
       "sub" : "https://w3id.org/metpo/2000601",
       "pred" : "subPropertyOf",
@@ -7462,26 +26263,6 @@
       "predicateId" : "https://w3id.org/metpo/2000001",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
       "rangeClassIds" : [ "https://w3id.org/metpo/1000526" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000052",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001021" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000053",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001001" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000054",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001002" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000055",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001003" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000056",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001004" ]
     }, {
       "predicateId" : "https://w3id.org/metpo/2000101",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
@@ -7527,10 +26308,6 @@
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
       "rangeClassIds" : [ "https://w3id.org/metpo/1000526" ]
     }, {
-      "predicateId" : "https://w3id.org/metpo/2000239",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001023" ]
-    }, {
       "predicateId" : "https://w3id.org/metpo/2000301",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
       "rangeClassIds" : [ "https://w3id.org/metpo/1000527" ]
@@ -7542,66 +26319,6 @@
       "predicateId" : "https://w3id.org/metpo/2000303",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
       "rangeClassIds" : [ "https://w3id.org/metpo/1000527" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000501",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001013" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000502",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001012" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000503",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001015" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000504",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001014" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000506",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001022" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000507",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001010" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000508",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001007" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000509",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001009" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000510",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001008" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000511",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001000" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000512",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001020" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000513",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001016" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000514",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001017" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000515",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001018" ]
-    }, {
-      "predicateId" : "https://w3id.org/metpo/2000516",
-      "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],
-      "rangeClassIds" : [ "https://w3id.org/metpo/1001019" ]
     }, {
       "predicateId" : "https://w3id.org/metpo/2000517",
       "domainClassIds" : [ "https://w3id.org/metpo/1000525" ],

--- a/metpo.obo
+++ b/metpo.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: https://w3id.org/metpo/metpo/releases/2026-03-24/metpo.owl
+data-version: https://w3id.org/metpo/metpo/releases/2026-05-19/metpo.owl
 idspace: dce http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
 idspace: metpo https://w3id.org/metpo/ 
@@ -7,13 +7,3815 @@ idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl#
 idspace: qudt http://qudt.org/schema/qudt/ 
 idspace: skos http://www.w3.org/2004/02/skos/core# 
 ontology: https://w3id.org/metpo/metpo.owl
+property_value: dcterms:contributor https://orcid.org/0000-0001-9076-6066
 property_value: dcterms:creator "METPO Development Team" xsd:string
-property_value: dcterms:description "Microbial ecophysiological trait and phenotype ontology" xsd:string
+property_value: dcterms:description "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible." xsd:string
 property_value: dcterms:issued "2024-01-01" xsd:string
 property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
-property_value: dcterms:modified "2025-09-29" xsd:string
-property_value: dcterms:title "METPO" xsd:string
-property_value: owl:versionInfo "2026-03-24" xsd:string
+property_value: dcterms:modified "2026-05-18" xsd:string
+property_value: dcterms:title "METPO: Microbial Ecophysiological Trait and Phenotype Ontology" xsd:string
+property_value: owl:versionInfo "2026-05-19" xsd:string
+property_value: seeAlso https://bioportal.bioontology.org/ontologies/METPO
+property_value: seeAlso https://bioregistry.io/registry/metpo
+property_value: seeAlso https://github.com/berkeleybop/metpo
+
+[Term]
+id: metpo:0000001
+name: obsolete Temperature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000002
+name: obsolete Salinity
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000003
+name: obsolete pH
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000004
+name: obsolete Oxygen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000005
+name: obsolete Trophic type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000006
+name: obsolete Motility
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000007
+name: obsolete Sporulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000008
+name: obsolete Pressure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000009
+name: obsolete GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000001
+name: obsolete Temperature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000010
+name: obsolete Cell Width
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000011
+name: obsolete Cell Length
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000012
+name: obsolete Temperature Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000013
+name: obsolete Temperature Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000014
+name: obsolete pH Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000015
+name: obsolete pH Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000016
+name: obsolete NaCl Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000017
+name: obsolete NaCl Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000018
+name: obsolete pH delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000019
+name: obsolete NaCl delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000002
+name: obsolete Salinity
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000020
+name: obsolete Temperature Delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000021
+name: obsolete METPO Morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000022
+name: obsolete Psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000023
+name: obsolete Psychrotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000024
+name: obsolete Mesophilie
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000025
+name: obsolete Thermotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000026
+name: obsolete Thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000027
+name: obsolete Extreme thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000028
+name: obsolete Hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000029
+name: obsolete Extreme hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000003
+name: obsolete pH
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000030
+name: obsolete Halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000031
+name: obsolete Non-halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000032
+name: obsolete Slight halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000033
+name: obsolete Moderate halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000034
+name: obsolete Extreme halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000035
+name: obsolete Halotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000036
+name: obsolete Haloalkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000037
+name: obsolete Extreme Acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000038
+name: obsolete Acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000039
+name: obsolete Neutrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000004
+name: obsolete Oxygen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000040
+name: obsolete Alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000041
+name: obsolete Acid Tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000042
+name: obsolete Alkali Tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000043
+name: obsolete Extreme Alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000044
+name: obsolete Facultative acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000045
+name: obsolete Obligative acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000046
+name: obsolete Aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000047
+name: obsolete Anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000048
+name: obsolete Facultative anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000049
+name: obsolete Facultative aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000005
+name: obsolete Trophic type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000050
+name: obsolete Microaerophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000051
+name: obsolete Aerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000052
+name: obsolete Microaerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000053
+name: obsolete Aerotolerant anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000054
+name: obsolete Obligate aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000055
+name: obsolete Obligate anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000056
+name: obsolete Oxygenic phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000057
+name: obsolete Anoxygenic phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000058
+name: obsolete Autotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000059
+name: obsolete Photoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000006
+name: obsolete Motility
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000060
+name: obsolete Chemoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000061
+name: obsolete Heterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000062
+name: obsolete Photoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000063
+name: obsolete Chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000064
+name: obsolete Lithotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000065
+name: obsolete Organotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000066
+name: obsolete Phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000067
+name: obsolete Chemotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000068
+name: obsolete Oligotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000069
+name: obsolete Copiotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000007
+name: obsolete Sporulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000070
+name: obsolete Lithoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000071
+name: obsolete Mixotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000072
+name: obsolete Lithoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000073
+name: obsolete Chemoorganoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000074
+name: obsolete Chemolithoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000075
+name: obsolete Methylotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000076
+name: obsolete Methanotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000077
+name: obsolete Carboxydotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000078
+name: obsolete Hydrogenotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000079
+name: obsolete Hydrogen oxidizer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000008
+name: obsolete Pressure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000080
+name: obsolete Hydrogen producer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000081
+name: obsolete Nitrogen fixer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000082
+name: obsolete Methanogen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000083
+name: obsolete Sulfate reducer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000084
+name: obsolete Sulfur oxidizer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000085
+name: obsolete Denitrifier
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000086
+name: obsolete Capnophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000087
+name: obsolete Motile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000088
+name: obsolete Non-motile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000089
+name: obsolete Flagellated
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000009
+name: obsolete GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000090
+name: obsolete Peritrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000091
+name: obsolete Lophotrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000092
+name: obsolete Monotrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000093
+name: obsolete Ciliated
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000094
+name: obsolete Gliding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000095
+name: obsolete Twitching
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000096
+name: obsolete Sliding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000097
+name: obsolete Swarming
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000098
+name: obsolete Endospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000099
+name: obsolete Exospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000010
+name: obsolete Cell Width
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000100
+name: obsolete Myxospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000101
+name: obsolete Arthrospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000102
+name: obsolete Conidia
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000103
+name: obsolete Sporangiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000104
+name: obsolete Zygospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000105
+name: obsolete Akinetes
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000106
+name: obsolete Chlamydospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000107
+name: obsolete Sporocysts
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000108
+name: obsolete Hypnospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000109
+name: obsolete Gemmae
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000011
+name: obsolete Cell Length
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000110
+name: obsolete Oospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000111
+name: obsolete Azygospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000112
+name: obsolete Cysts
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000113
+name: obsolete Ascospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000114
+name: obsolete Basidiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000115
+name: obsolete Aleuriospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000116
+name: obsolete Stylospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000117
+name: obsolete Sclerotia
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000118
+name: obsolete Zoospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000119
+name: obsolete Teliospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000012
+name: obsolete Temperature Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000120
+name: obsolete Urediniospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000121
+name: obsolete Pycnidiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000122
+name: obsolete Acriospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000123
+name: obsolete Aplanospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000124
+name: obsolete Statismospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000125
+name: obsolete Barotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000126
+name: obsolete Piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000127
+name: obsolete Piezotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000128
+name: obsolete Piezosensitive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000129
+name: obsolete Obligate barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000013
+name: obsolete Temperature Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000130
+name: obsolete Facultative barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000131
+name: obsolete Hyperbarophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000132
+name: obsolete Hypobarophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000133
+name: obsolete Atmospheric pressure-adapted
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000134
+name: obsolete Moderate piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000135
+name: obsolete Extreme piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000136
+name: obsolete Stenopiezic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000137
+name: obsolete Eurypiezic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000138
+name: obsolete Pressure-sensitive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000139
+name: obsolete Pressure-resistant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000014
+name: obsolete pH Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000140
+name: obsolete Pressure-adapted
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000141
+name: obsolete Piezo-acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000142
+name: obsolete Piezo-alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000143
+name: obsolete Piezo-halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000144
+name: obsolete Piezo-psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000145
+name: obsolete Piezo-thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000146
+name: obsolete Piezo-lithoautotrophe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000147
+name: obsolete Piezo-chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000148
+name: obsolete Piezo-oligotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000149
+name: obsolete Piezo-endolithic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000015
+name: obsolete pH Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000150
+name: obsolete Piezo-tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000151
+name: obsolete GC low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000152
+name: obsolete GC mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000153
+name: obsolete GC mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000154
+name: obsolete GC high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000155
+name: obsolete Cell width very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000156
+name: obsolete Cell width low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000157
+name: obsolete Cell width mid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000158
+name: obsolete Cell width high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000159
+name: obsolete Cell length very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000016
+name: obsolete NaCl Optimum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000160
+name: obsolete Cell length low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000161
+name: obsolete Cell length mid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000162
+name: obsolete Cell length high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000163
+name: obsolete Temperature Optimum very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000164
+name: obsolete Temperature Optimum low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000165
+name: obsolete Temperature Optimum mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000166
+name: obsolete Temperature Optimum mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000167
+name: obsolete Temperature Optimum mid3
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000168
+name: obsolete Temperature Optimum mid4
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000169
+name: obsolete Temperature Optimum high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000017
+name: obsolete NaCl Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000170
+name: obsolete Temperature Range very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000171
+name: obsolete Temperature Range low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000172
+name: obsolete Temperature Range mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000173
+name: obsolete Temperature Range mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000174
+name: obsolete Temperature Range mid3
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000175
+name: obsolete Temperature Range mid4
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000176
+name: obsolete Temperature Range high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000177
+name: obsolete pH Optimum low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000178
+name: obsolete pH Optimum mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000179
+name: obsolete pH Optimum mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000018
+name: obsolete pH delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000180
+name: obsolete pH Optimum high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000181
+name: obsolete pH Range very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000182
+name: obsolete pH Range low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000183
+name: obsolete pH Range mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000184
+name: obsolete pH Range mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000185
+name: obsolete pH Range mid3
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000186
+name: obsolete pH Range high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000187
+name: obsolete NaCl Optimum low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000188
+name: obsolete NaCl Optimum mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000189
+name: obsolete NaCl Optimum mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000019
+name: obsolete NaCl delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000190
+name: obsolete NaCl Optimum high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000191
+name: obsolete NaCl Range low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000192
+name: obsolete NaCl Range mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000193
+name: obsolete NaCl Range mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000194
+name: obsolete NaCl Range high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000195
+name: obsolete pH Delta very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000196
+name: obsolete pH Delta low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000197
+name: obsolete pH Delta mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000198
+name: obsolete pH Delta mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000199
+name: obsolete pH Delta mid3
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000020
+name: obsolete Temperature Delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000200
+name: obsolete pH Delta high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000201
+name: obsolete NaCl Delta low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000202
+name: obsolete NaCl Delta mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000203
+name: obsolete NaCl Delta mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000204
+name: obsolete NaCl Delta high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000205
+name: obsolete Temperature Delta very low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000206
+name: obsolete Temperature Delta low
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000207
+name: obsolete Temperature Delta mid1
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000208
+name: obsolete Temperature Delta mid2
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000209
+name: obsolete Temperature Delta high
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000021
+name: obsolete Morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000210
+name: obsolete Bacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000211
+name: obsolete Branced
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000212
+name: obsolete Coccobacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000213
+name: obsolete Coccus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000214
+name: obsolete Crescent
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000215
+name: obsolete Curved
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000216
+name: obsolete Curved Spiral
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000217
+name: obsolete Diplococcus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000218
+name: obsolete Disc
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000219
+name: obsolete Dumbbell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000022
+name: obsolete Other
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000220
+name: obsolete Ellipsoidal
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000221
+name: obsolete Filament
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000222
+name: obsolete Flask
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000223
+name: obsolete Fusiform
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000224
+name: obsolete Helical
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000225
+name: obsolete Irregular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000226
+name: obsolete Oval
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000227
+name: obsolete Ovoid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000228
+name: obsolete Pleomorphic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000229
+name: obsolete Ring
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000023
+name: obsolete Psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000230
+name: obsolete Rod
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000231
+name: obsolete Sphere
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000232
+name: obsolete Spindle
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000233
+name: obsolete Spiral
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000234
+name: obsolete Spirochete
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000235
+name: obsolete Spore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000236
+name: obsolete Square
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000237
+name: obsolete Star
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000238
+name: obsolete Star - Dumbbell - Pleomorphic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000239
+name: obsolete Tailed
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000024
+name: obsolete Psychrotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000240
+name: obsolete Triangular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000241
+name: obsolete Vibrio
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000242
+name: obsolete Environmental Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000243
+name: obsolete Growth Condition
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000244
+name: obsolete Physiological Trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000245
+name: obsolete Metabolic Classification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000246
+name: obsolete Cellular Characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000247
+name: obsolete Taxonomic Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000248
+name: obsolete Microbial Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000249
+name: obsolete Growth Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000025
+name: obsolete Mesophilie
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000250
+name: obsolete Structural Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000251
+name: obsolete Temperature Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000252
+name: obsolete Salinity Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000253
+name: obsolete pH Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000254
+name: obsolete Oxygen Requirement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000255
+name: obsolete Carbon Source Utilization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000256
+name: obsolete Energy Acquisition Mode
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000257
+name: obsolete Electron Donor Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000258
+name: obsolete Motility Mechanism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000259
+name: obsolete Motility Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000026
+name: obsolete Thermotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000260
+name: obsolete Bacterial Spore Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000261
+name: obsolete Fungal Spore Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000262
+name: obsolete Reproductive Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000263
+name: obsolete Dormancy Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000264
+name: obsolete Pressure Adaptation Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000265
+name: obsolete Pressure Tolerance Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000266
+name: obsolete Genomic Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000267
+name: obsolete Cell Dimension
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000268
+name: obsolete Optimal Growth Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000269
+name: obsolete Growth Range Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000027
+name: obsolete Thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000270
+name: obsolete Growth Tolerance Metric
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000271
+name: obsolete Cell Shape
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000272
+name: obsolete Cell Arrangement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000273
+name: obsolete Colony Morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000274
+name: obsolete Physical Property
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000275
+name: obsolete Environmental Context
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000276
+name: obsolete Biological Property
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000277
+name: obsolete Functional Classification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000278
+name: obsolete Classification Property
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000279
+name: obsolete METPO Biological Process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000028
+name: obsolete Extreme thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000280
+name: obsolete Measurable Property
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000281
+name: obsolete Gram-stain negative
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0000282
+name: obsolete Gram-stain positive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000029
+name: obsolete Hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000030
+name: obsolete Extreme hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000031
+name: obsolete Halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000032
+name: obsolete Non-halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000033
+name: obsolete Slight halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000034
+name: obsolete Moderate halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000035
+name: obsolete Extreme halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000036
+name: obsolete Halotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000037
+name: obsolete Haloalkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000038
+name: obsolete Extreme Acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000039
+name: obsolete Acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000040
+name: obsolete Neutrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000041
+name: obsolete Alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000042
+name: obsolete Acid Tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000043
+name: obsolete Alkali Tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000044
+name: obsolete Extreme Alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000045
+name: obsolete Facultative acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000046
+name: obsolete Obligative acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000047
+name: obsolete Aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000048
+name: obsolete Anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000049
+name: obsolete Facultative anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000050
+name: obsolete Facultative aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000051
+name: obsolete Microaerophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000052
+name: obsolete Aerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000053
+name: obsolete Microaerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000054
+name: obsolete Aerotolerant anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000055
+name: obsolete Obligate aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000056
+name: obsolete Obligate anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000057
+name: obsolete Oxygenic phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000058
+name: obsolete Anoxygenic phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000059
+name: obsolete Autotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000060
+name: obsolete Photoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000061
+name: obsolete Chemoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000062
+name: obsolete Heterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000063
+name: obsolete Photoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000064
+name: obsolete Chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000065
+name: obsolete Lithotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000066
+name: obsolete Organotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000067
+name: obsolete Phototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000068
+name: obsolete Chemotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000069
+name: obsolete Oligotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000070
+name: obsolete Copiotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000071
+name: obsolete Lithoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000072
+name: obsolete Mixotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000073
+name: obsolete Lithoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000074
+name: obsolete Chemoorganoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000075
+name: obsolete Chemolithoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000076
+name: obsolete Methylotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000077
+name: obsolete Methanotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000078
+name: obsolete Carboxydotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000079
+name: obsolete Hydrogenotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000080
+name: obsolete Hydrogen oxidizer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000081
+name: obsolete Hydrogen producer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000082
+name: obsolete Nitrogen fixer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000083
+name: obsolete Methanogen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000084
+name: obsolete Sulfate reducer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000085
+name: obsolete Sulfur oxidizer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000086
+name: obsolete Denitrifier
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000087
+name: obsolete Capnophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000088
+name: obsolete Motile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000089
+name: obsolete Non-motile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000090
+name: obsolete Flagellated
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000091
+name: obsolete Peritrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000092
+name: obsolete Lophotrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000093
+name: obsolete Monotrichous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000094
+name: obsolete Ciliated
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000095
+name: obsolete Gliding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000096
+name: obsolete Twitching
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000097
+name: obsolete Sliding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000098
+name: obsolete Swarming
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000099
+name: obsolete Endospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000100
+name: obsolete Exospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001000
+name: obsolete sensitivity to oxygen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001001
+name: obsolete sensitivity toward
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001002
+name: obsolete 'organismal quality'
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001003
+name: obsolete 'physicial object quality'
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001004
+name: obsolete 'quality'
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001006
+name: obsolete size
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001007
+name: obsolete 1-D extent
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001008
+name: obsolete width
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001009
+name: obsolete length
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000101
+name: obsolete Myxospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001010
+name: obsolete 'prokaryotic metabolically differentiated cell'
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001012
+name: obsolete heterotrophy
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001013
+name: obsolete structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001014
+name: obsolete spore type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001016
+name: obsolete sensitivity toward pressure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001017
+name: obsolete sensitivity toward NaCl
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001018
+name: obsolete sensitivity toward pH
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001019
+name: obsolete sensitivity toward temperature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000102
+name: obsolete Arthrospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001020
+name: obsolete metabolic constraints
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:0001021
+name: obsolete cell by chemical produced
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000103
+name: obsolete Conidia
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000104
+name: obsolete Sporangiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000105
+name: obsolete Zygospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000106
+name: obsolete Akinetes
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000107
+name: obsolete Chlamydospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000108
+name: obsolete Sporocysts
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000109
+name: obsolete Hypnospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000110
+name: obsolete Gemmae
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000111
+name: obsolete Oospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000112
+name: obsolete Azygospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000113
+name: obsolete Cysts
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000114
+name: obsolete Ascospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000115
+name: obsolete Basidiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000116
+name: obsolete Aleuriospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000117
+name: obsolete Stylospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000118
+name: obsolete Sclerotia
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000119
+name: obsolete Zoospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000120
+name: obsolete Teliospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000121
+name: obsolete Urediniospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000122
+name: obsolete Pycnidiospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000123
+name: obsolete Acriospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000124
+name: obsolete Aplanospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000125
+name: obsolete Statismospores
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000126
+name: obsolete Barotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000127
+name: obsolete Piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000128
+name: obsolete Piezotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000129
+name: obsolete Piezosensitive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000130
+name: obsolete Obligate barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000131
+name: obsolete Facultative barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000132
+name: obsolete Hyperbarophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000133
+name: obsolete Hypobarophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000134
+name: obsolete Atmospheric pressure-adapted
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000135
+name: obsolete Moderate piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000136
+name: obsolete Extreme piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000137
+name: obsolete Stenopiezic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000138
+name: obsolete Eurypiezic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000139
+name: obsolete Pressure-sensitive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000140
+name: obsolete Pressure-resistant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000141
+name: obsolete Pressure-adapted
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000142
+name: obsolete Piezo-acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000143
+name: obsolete Piezo-alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000144
+name: obsolete Piezo-halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000145
+name: obsolete Piezo-psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000146
+name: obsolete Piezo-thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000147
+name: obsolete Piezo-lithoautotrophe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000148
+name: obsolete Piezo-chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000149
+name: obsolete Piezo-oligotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000150
+name: obsolete Piezo-endolithic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000151
+name: obsolete Piezo-tolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000152
+name: obsolete GC% low ( < 42.65)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000153
+name: obsolete GC% mid1 (42.65 - 57)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000154
+name: obsolete GC% mid2 (57 - 66.3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000155
+name: obsolete GC% high ( > 66.3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000156
+name: obsolete Cell width uM very low (< 0.5)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000157
+name: obsolete Cell width uM low (0.5 - 0.65)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000158
+name: obsolete Cell width uM mid (0.65 - 0.9)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000159
+name: obsolete Cell width uM high (> 0.9)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000160
+name: obsolete Cell length uM very low (<= 1.3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000161
+name: obsolete Cell length uM low (1.3 - 2)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000162
+name: obsolete Cell length uM mid (2 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000163
+name: obsolete Cell length uM high (> 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000164
+name: obsolete Temperature Optimum C very low (<= 10)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000165
+name: obsolete Temperature Optimum C low (10 - 22)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000166
+name: obsolete Temperature Optimum C mid1 (22 - 27)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000167
+name: obsolete Temperature Optimum C mid2 (27 - 30)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000168
+name: obsolete Temperature Optimum C mid3 (30 - 34)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000169
+name: obsolete Temperature Optimum C mid4 (34 - 40)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000170
+name: obsolete Temperature Optimum C high (> 40)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000171
+name: obsolete Temperature Range C very low (<= 10)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000172
+name: obsolete Temperature Range C low (10 - 22)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000173
+name: obsolete Temperature Range C mid1 (22 - 27)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000174
+name: obsolete Temperature Range C mid2 (27 - 30)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000175
+name: obsolete Temperature Range C mid3 (30 - 34)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000176
+name: obsolete Temperature Range C mid4 (34 - 40)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000177
+name: obsolete Temperature Range C high (> 40)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000178
+name: obsolete pH Optimum low (0 - 6)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000179
+name: obsolete pH Optimum mid1 (6 - 7)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000180
+name: obsolete pH Optimum mid2 (7 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000181
+name: obsolete pH Optimum high (8 - 14)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000182
+name: obsolete pH Range very low (0 - 4)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000183
+name: obsolete pH Range low (4 - 6)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000184
+name: obsolete pH Range mid1 (6 - 7)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000185
+name: obsolete pH Range mid2 (7 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000186
+name: obsolete pH Range mid3 (8 - 10)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000187
+name: obsolete pH Range high (10 - 14)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000188
+name: obsolete % NaCl Optimum low (<= 1)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000189
+name: obsolete % NaCl Optimum mid1 (1 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000190
+name: obsolete % NaCl Optimum mid2 (3 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000191
+name: obsolete % NaCl Optimum high (> 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000192
+name: obsolete % NaCl Range low (<= 1)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000193
+name: obsolete % NaCl Range mid1 (1 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000194
+name: obsolete % NaCl Range mid2 (3 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000195
+name: obsolete % NaCl Range high (> 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000196
+name: obsolete pH delta very low (<= 1)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000197
+name: obsolete pH delta low (1 - 2)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000198
+name: obsolete pH delta mid1 (2 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000199
+name: obsolete pH delta mid2 (3 - 4)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000200
+name: obsolete pH delta mid3 (4 - 5)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000201
+name: obsolete pH delta high (5 - 9)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000202
+name: obsolete % NaCl delta low (<= 1)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000203
+name: obsolete % NaCl delta mid2 (1 - 3)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000204
+name: obsolete % NaCl delta mid2 (3 - 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000205
+name: obsolete % NaCl delta high (>= 8)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000206
+name: obsolete Temperature C delta very low (1 - 5)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000207
+name: obsolete Temperature C delta low (5 - 10)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000208
+name: obsolete Temperature C delta mid1 (10 - 20)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000209
+name: obsolete Temperature C delta mid2 (20 - 30)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000210
+name: obsolete Temperature C delta high (>= 30)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000211
+name: obsolete bacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000212
+name: obsolete branced
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000213
+name: obsolete coccobacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000214
+name: obsolete coccus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000215
+name: obsolete crescent
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000216
+name: obsolete curved
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000217
+name: obsolete curved spiral
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000218
+name: obsolete diplococcus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000219
+name: obsolete disc
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000220
+name: obsolete dumbbell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000221
+name: obsolete ellipsoidal
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000222
+name: obsolete filament
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000223
+name: obsolete flask
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000224
+name: obsolete fusiform
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000225
+name: obsolete helical
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000226
+name: obsolete irregular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000227
+name: obsolete oval
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000228
+name: obsolete ovoid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000229
+name: obsolete pleomorphic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000230
+name: obsolete ring
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000231
+name: obsolete rod
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000232
+name: obsolete sphere
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000233
+name: obsolete spindle
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000234
+name: obsolete spiral
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000235
+name: obsolete spirochete
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000236
+name: obsolete spore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000237
+name: obsolete square
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000238
+name: obsolete star
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000239
+name: obsolete star - dumbbell - pleomorphic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000240
+name: obsolete tailed
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000241
+name: obsolete triangular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000242
+name: obsolete vibrio
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000243
+name: obsolete Environmental Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000244
+name: obsolete Growth Condition
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000245
+name: obsolete Physiological Trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000246
+name: obsolete Metabolic Classification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000247
+name: obsolete Cellular Characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000248
+name: obsolete Taxonomic Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000249
+name: obsolete Microbial Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000250
+name: obsolete Growth Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000251
+name: obsolete Structural Feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000252
+name: obsolete Temperature Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000253
+name: obsolete Salinity Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000254
+name: obsolete pH Adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000255
+name: obsolete Oxygen Requirement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000256
+name: obsolete Carbon Source Utilization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000257
+name: obsolete Energy Acquisition Mode
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000258
+name: obsolete Electron Donor Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000259
+name: obsolete Motility Mechanism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000260
+name: obsolete Motility Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000261
+name: obsolete Bacterial Spore Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000262
+name: obsolete Fungal Spore Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000263
+name: obsolete Reproductive Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000264
+name: obsolete Dormancy Structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000265
+name: obsolete Pressure Adaptation Type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000266
+name: obsolete Pressure Tolerance Range
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000267
+name: obsolete GenomicFeature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000268
+name: obsolete Cell Dimension
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000269
+name: obsolete Optimal Growth Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000270
+name: obsolete Growth Range Parameter
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000271
+name: obsolete Growth Tolerance Metric
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000272
+name: obsolete Cell Shape
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000273
+name: obsolete Cell Arrangement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:000274
+name: obsolete Colony Morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000001
+name: obsolete acid-fast
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000002
+name: obsolete acidophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000003
+name: obsolete active transport
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000004
+name: obsolete adaptation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000005
+name: obsolete adaptive trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000006
+name: obsolete adhesin
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000007
+name: obsolete adhesion structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000008
+name: obsolete aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000009
+name: obsolete aerobic respiration
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000010
+name: obsolete aerotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000011
+name: obsolete aggregate
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000012
+name: obsolete akinete
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000013
+name: obsolete alkaliphile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000014
+name: obsolete ammonification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000015
+name: obsolete amylolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000016
+name: obsolete anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000017
+name: obsolete anaerobic respiration
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000018
+name: obsolete anoxygenic photosynthesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000019
+name: obsolete antibiotic production
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000020
+name: obsolete antibiotic resistance
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000021
+name: obsolete antimicrobial resistance
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000022
+name: obsolete appendage
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000023
+name: obsolete arthrospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000024
+name: obsolete ascospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000025
+name: obsolete autotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000026
+name: obsolete autotrophic process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000027
+name: obsolete auxotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000028
+name: obsolete axial filament
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000029
+name: obsolete bacillus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000030
+name: obsolete barophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000031
+name: obsolete barotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000032
+name: obsolete basidiospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000033
+name: obsolete binary fission
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000034
+name: obsolete biofilm
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000035
+name: obsolete biofilm component
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000036
+name: obsolete biofilm formation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000037
+name: obsolete biogeochemical cycling
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000038
+name: obsolete bioluminescence
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000039
+name: obsolete budding
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000040
+name: obsolete buoyancy structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000041
+name: obsolete capnophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000042
+name: obsolete capsule
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000043
+name: obsolete carbon fixation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000044
+name: obsolete carbon source
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000045
+name: obsolete carboxydotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000046
+name: obsolete cell arrangement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000047
+name: obsolete cell envelope
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000048
+name: obsolete cell length category
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000049
+name: obsolete cell shape
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000050
+name: obsolete cell size
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000051
+name: obsolete cell wall characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000052
+name: obsolete cell wall component
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000053
+name: obsolete cell width category
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000054
+name: obsolete cellular characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000055
+name: obsolete cellular component
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000056
+name: obsolete cellular process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000057
+name: obsolete cellular product
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000058
+name: obsolete cellulolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
 
 [Term]
 id: metpo:1000059
@@ -32,6 +3834,402 @@ is_a: metpo:1000630 ! biological process
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
+id: metpo:1000061
+name: obsolete chemoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000062
+name: obsolete chemotaxis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000063
+name: obsolete chlamydospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000064
+name: obsolete class
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000065
+name: obsolete clinically relevant feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000066
+name: obsolete coccus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000067
+name: obsolete cold shock protein
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000068
+name: obsolete cold shock response
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000069
+name: obsolete colonization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000070
+name: obsolete colony elevation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000071
+name: obsolete colony margin
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000072
+name: obsolete colony morphology
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000073
+name: obsolete colony texture
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000074
+name: obsolete commensalism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000075
+name: obsolete community behavior
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000076
+name: obsolete community structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000077
+name: obsolete compatible solute
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000078
+name: obsolete competence
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000079
+name: obsolete component
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000080
+name: obsolete conidium
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000081
+name: obsolete conjugation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000082
+name: obsolete CRISPR
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000083
+name: obsolete culturability
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000084
+name: obsolete cyst
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000085
+name: obsolete death phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000086
+name: obsolete denitrification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000087
+name: obsolete developmental process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000088
+name: obsolete diagnostic enzyme
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000089
+name: obsolete diagnostic feature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000090
+name: obsolete diazotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000091
+name: obsolete differentiation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000092
+name: obsolete dimorphism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000093
+name: obsolete disc-shaped cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000094
+name: obsolete domain
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000095
+name: obsolete dormancy
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000096
+name: obsolete dormancy structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000097
+name: obsolete dumbbell-shaped cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000098
+name: obsolete ecological niche
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000099
+name: obsolete ecological process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000100
+name: obsolete ecological trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000101
+name: obsolete ectosymbiosis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000102
+name: obsolete electron acceptor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000103
+name: obsolete electron donor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000104
+name: obsolete endospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000105
+name: obsolete endosymbiosis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000106
+name: obsolete energy metabolism process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000107
+name: obsolete enzyme activity
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000108
+name: obsolete epigenetic modification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000109
+name: obsolete evolutionary process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000110
+name: obsolete exospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000111
+name: obsolete exponential phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000112
+name: obsolete extracellular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000113
+name: obsolete extracellular polysaccharide
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000114
+name: obsolete extreme halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000115
+name: obsolete extremophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000116
+name: obsolete facultative
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000117
+name: obsolete facultative anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000118
+name: obsolete family
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000119
+name: obsolete fastidious
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000120
+name: obsolete fermentation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000121
+name: obsolete filamentous
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000122
+name: obsolete fimbriae
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000123
+name: obsolete flagellum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000124
+name: obsolete flask-shaped cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000125
+name: obsolete fungal spore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000126
+name: obsolete gas vesicle
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
 id: metpo:1000127
 name: GC content
 def: "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs." [] {IAO:0000119="https://purl.dsmz.de/schema/GCContent"}
@@ -40,10 +4238,364 @@ is_a: metpo:1000188 ! quality
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
+id: metpo:1000128
+name: obsolete high GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000129
+name: obsolete low GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000130
+name: obsolete lower-mid GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000131
+name: obsolete upper-mid GC content
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000132
+name: obsolete generation time
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000133
+name: obsolete genetic element
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000134
+name: obsolete genetic exchange
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000135
+name: obsolete genetic process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000136
+name: obsolete genome size
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000137
+name: obsolete genomic element
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000138
+name: obsolete genomic island
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000139
+name: obsolete genomic trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000140
+name: obsolete genus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000141
+name: obsolete gliding motility
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000142
+name: obsolete global regulator
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000143
+name: obsolete Gram-negative
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000144
+name: obsolete Gram-positive
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000145
+name: obsolete Gram stain
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000146
+name: obsolete growth characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000147
+name: obsolete growth conditions constraints
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000148
+name: obsolete growth pattern
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000149
+name: obsolete growth rate
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000150
+name: obsolete habitat
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000151
+name: obsolete halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000152
+name: obsolete halotolerant
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000153
+name: obsolete heat shock protein
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000154
+name: obsolete heat shock response
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000155
+name: obsolete hemolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000156
+name: obsolete heterocyst
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000157
+name: obsolete heterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000158
+name: obsolete holdfast
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000159
+name: obsolete horizontal gene transfer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000160
+name: obsolete hydrolase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000161
+name: obsolete hyperthermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000162
+name: obsolete inclusion body
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000163
+name: obsolete infection
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000164
+name: obsolete interaction
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000165
+name: obsolete interaction with a phage
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000166
+name: obsolete interaction with an environment
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000167
+name: obsolete interaction with host
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000168
+name: obsolete interaction within a community
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000169
+name: obsolete intracellular
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000170
+name: obsolete invasion
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000171
+name: obsolete laboratory characteristic
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000172
+name: obsolete lag phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000173
+name: obsolete life cycle
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000174
+name: obsolete life cycle phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000175
+name: obsolete lipolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000176
+name: obsolete lipopolysaccharide
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000177
+name: obsolete localization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000178
+name: obsolete lysogeny
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000179
+name: obsolete macroscopic trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000180
+name: obsolete magnetotaxis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000181
+name: obsolete mesophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000182
+name: obsolete metabolic partner
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000183
+name: obsolete metabolic trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000184
+name: obsolete methanogenesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000185
+name: obsolete methylation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
 id: metpo:1000186
 name: material entity
 def: "An object or portion of a substance or mixture of substances that consists of matter" [] {IAO:0000119="BFO:0000040"}
 property_value: IAO:0000117 "Anthea Guo" xsd:string
+
+[Term]
+id: metpo:1000187
+name: obsolete process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
 
 [Term]
 id: metpo:1000188
@@ -51,10 +4603,688 @@ name: quality
 def: "A characteristic of an entity that depends on the entity's existence, size, color, and physiological traits." []
 
 [Term]
+id: metpo:1000189
+name: obsolete system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000190
+name: obsolete microaerophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000191
+name: obsolete mobile genetic element
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000192
+name: obsolete moderate halophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000193
+name: obsolete morphological trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000194
+name: obsolete motility process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000195
+name: obsolete motility structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000196
+name: obsolete mutualism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000197
+name: obsolete mycolic acid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000198
+name: obsolete mycorrhization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000199
+name: obsolete neutrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000200
+name: obsolete nitrification
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000201
+name: obsolete nitrogen fixation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000202
+name: obsolete nodulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000203
+name: obsolete nucleoid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000204
+name: obsolete nutrient utilization
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000205
+name: obsolete obligate
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000206
+name: obsolete obligate aerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000207
+name: obsolete obligate anaerobe
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000208
+name: obsolete oospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000209
+name: obsolete order
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000210
+name: obsolete microbe characterized by growth conditions
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000211
+name: obsolete microbe characterized by nutritional requirement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000212
+name: obsolete microbe characterized by product produced
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000213
+name: obsolete microbe characterized by relation to oxygen
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000214
+name: obsolete microbe characterized by relation to ph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000215
+name: obsolete microbe characterized by relation to pressure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000216
+name: obsolete microbe characterized by relation to salt concentration
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000217
+name: obsolete microbe characterized by relation to temperature
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000218
+name: obsolete microbe characterized by shape
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000219
+name: obsolete microbe characterized by trophic type
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000220
+name: obsolete osmophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000221
+name: obsolete osmoregulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000222
+name: obsolete oxidative stress response
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000223
+name: obsolete oxidoreductase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000224
+name: obsolete oxygen requirement
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000225
+name: obsolete oxygenic photosynthesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000226
+name: obsolete pan-genome
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000227
+name: obsolete parasitism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000228
+name: obsolete passive transport
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000229
+name: obsolete pathogenicity
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000230
+name: obsolete pathogenicity island
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000231
+name: obsolete peptidoglycan
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
 id: metpo:1000232
 name: pH delta
 is_a: metpo:1000531 ! pH phenotype with numerical limits
 is_a: metpo:1000534 ! delta phenotype with numerical limits
+
+[Term]
+id: metpo:1000233
+name: obsolete pH optimum (growth range)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000234
+name: obsolete pH preference
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000235
+name: obsolete pH range (growth tolerance)
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000236
+name: obsolete pH tolerance
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000237
+name: obsolete phage defense
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000238
+name: obsolete photoautotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000239
+name: obsolete photoheterotroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000240
+name: obsolete photosynthesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000241
+name: obsolete phototaxis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000242
+name: obsolete phylum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000243
+name: obsolete physiological process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000244
+name: obsolete physiological state
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000245
+name: obsolete physiological trait
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000246
+name: obsolete piezophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000247
+name: obsolete pigment
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000248
+name: obsolete pigmentation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000249
+name: obsolete pilus
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000250
+name: obsolete plant growth promotion
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000251
+name: obsolete plasmid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000252
+name: obsolete pleomorphism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000253
+name: obsolete process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000254
+name: obsolete prophage
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000255
+name: obsolete prostheca
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000256
+name: obsolete protein synthesis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000257
+name: obsolete proteolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000258
+name: obsolete prototroph
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000259
+name: obsolete psychrophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000260
+name: obsolete qualifier
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000261
+name: obsolete quorum sensing
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000262
+name: obsolete regulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000263
+name: obsolete regulatory mechanism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000264
+name: obsolete reproductive process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000265
+name: obsolete reproductive structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000266
+name: obsolete resistance mechanism
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000267
+name: obsolete respiration
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000268
+name: obsolete restriction-modification system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000269
+name: obsolete ribosome
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000270
+name: obsolete S-layer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000271
+name: obsolete salinity delta
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000272
+name: obsolete salinity preference
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000273
+name: obsolete secondary metabolite
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000274
+name: obsolete secretion
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000275
+name: obsolete secretion system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000276
+name: obsolete sheathed
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000277
+name: obsolete siderophore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000278
+name: obsolete sigma factor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000279
+name: obsolete signaling
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000280
+name: obsolete slime layer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000281
+name: obsolete specialized cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000282
+name: obsolete species
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000283
+name: obsolete spirillum
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000284
+name: obsolete spirochete
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000285
+name: obsolete sporangiospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000286
+name: obsolete sporulation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000287
+name: obsolete square cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000288
+name: obsolete stalk
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000289
+name: obsolete star-shaped cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000290
+name: obsolete stationary phase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000291
+name: obsolete storage structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000292
+name: obsolete strain
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000293
+name: obsolete stress response
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000294
+name: obsolete structure
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000295
+name: obsolete sulfate reducer
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000296
+name: obsolete swarming
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000297
+name: obsolete symbiosis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000298
+name: obsolete symbiotic process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000299
+name: obsolete syntrophy
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000300
+name: obsolete taxonomic identifier
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000301
+name: obsolete taxonomic rank
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000302
+name: obsolete teichoic acid
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
 
 [Term]
 id: metpo:1000303
@@ -71,10 +5301,160 @@ is_a: metpo:1000536 ! optimum phenotype with numerical limits
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
+id: metpo:1000305
+name: obsolete temperature preference
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
 id: metpo:1000306
 name: temperature range
 is_a: metpo:1000533 ! temperature phenotype with numerical limits
 is_a: metpo:1000535 ! growth range phenotype with numerical limits
+
+[Term]
+id: metpo:1000307
+name: obsolete thermal tolerance
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000308
+name: obsolete thermophile
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000309
+name: obsolete toxin
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000310
+name: obsolete transcription factor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000311
+name: obsolete transduction
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000312
+name: obsolete transferase
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000313
+name: obsolete transformation
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000314
+name: obsolete transport system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000315
+name: obsolete transposon
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000316
+name: obsolete triangular cell
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000317
+name: obsolete trichome
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000318
+name: obsolete twitching motility
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000319
+name: obsolete two-component system
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000320
+name: obsolete viable but non-culturable
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000321
+name: obsolete vibrio
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000322
+name: obsolete virulence
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000323
+name: obsolete virulence factor
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000324
+name: obsolete virulence process
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000325
+name: obsolete xylanolysis
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000326
+name: obsolete zoospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000327
+name: obsolete zygospore
+property_value: IAO:0000231 OMO:0001000
+is_obsolete: true
+
+[Term]
+id: metpo:1000328
+name: obsolete pressure
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000329
+name: obsolete temperature optimum (metabolic activity)
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000330
+name: obsolete temperature range (metabolic viability)
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000331
@@ -112,6 +5492,564 @@ is_a: metpo:1000532 ! salinity phenotype with numerical limits
 is_a: metpo:1000534 ! delta phenotype with numerical limits
 
 [Term]
+id: metpo:1000336
+name: obsolete psychrotolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000337
+name: obsolete thermotolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000338
+name: obsolete extreme thermophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000339
+name: obsolete extreme hyperthermophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000340
+name: obsolete non-halophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000341
+name: obsolete slight halophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000342
+name: obsolete haloalkaliphile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000343
+name: obsolete extreme acidophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000344
+name: obsolete acid tolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000345
+name: obsolete alkali tolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000346
+name: obsolete extreme alkaliphile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000347
+name: obsolete facultative acidophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000348
+name: obsolete obligative acidophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000349
+name: obsolete facultative aerobe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000350
+name: obsolete microaerophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000351
+name: obsolete microaerotolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000352
+name: obsolete aerotolerant anaerobe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000353
+name: obsolete obligate aerobe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000354
+name: obsolete obligate anaerobe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000355
+name: obsolete oxygenic phototroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000356
+name: obsolete anoxygenic phototroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000357
+name: obsolete chemoautotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000358
+name: obsolete chemoheterotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000359
+name: obsolete lithotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000360
+name: obsolete organotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000361
+name: obsolete phototroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000362
+name: obsolete chemotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000363
+name: obsolete oligotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000364
+name: obsolete copiotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000365
+name: obsolete lithoautotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000366
+name: obsolete mixotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000367
+name: obsolete lithoheterotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000368
+name: obsolete chemoorganoheterotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000369
+name: obsolete chemolithoautotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000370
+name: obsolete methylotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000371
+name: obsolete methanotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000372
+name: obsolete hydrogenotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000373
+name: obsolete hydrogen oxidizer
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000374
+name: obsolete hydrogen producer
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000375
+name: obsolete nitrogen fixer
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000376
+name: obsolete methanogen
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000377
+name: obsolete sulfur oxidizer
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000378
+name: obsolete denitrifier
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000379
+name: obsolete motile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000380
+name: obsolete non-motile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000381
+name: obsolete flagellated
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000382
+name: obsolete peritrichous
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000383
+name: obsolete lophotrichous
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000384
+name: obsolete monotrichous
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000385
+name: obsolete ciliated
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000386
+name: obsolete gliding
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000387
+name: obsolete twitching
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000388
+name: obsolete sliding
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000389
+name: obsolete myxospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000390
+name: obsolete conidia
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000391
+name: obsolete chlamydospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000392
+name: obsolete sporocysts
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000393
+name: obsolete hypnospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000394
+name: obsolete gemmae
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000395
+name: obsolete azygospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000396
+name: obsolete aleuriospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000397
+name: obsolete stylospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000398
+name: obsolete sclerotia
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000399
+name: obsolete teliospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000400
+name: obsolete urediniospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000401
+name: obsolete pycnidiospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000402
+name: obsolete acriospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000403
+name: obsolete aplanospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000404
+name: obsolete statismospores
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000405
+name: obsolete piezotolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000406
+name: obsolete piezosensitive
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000407
+name: obsolete obligate barophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000408
+name: obsolete facultative barophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000409
+name: obsolete hyperbarophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000410
+name: obsolete hypobarophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000411
+name: obsolete atmospheric pressure-adapted
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000412
+name: obsolete moderate piezophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000413
+name: obsolete extreme piezophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000414
+name: obsolete stenopiezic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000415
+name: obsolete eurypiezic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000416
+name: obsolete pressure-sensitive
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000417
+name: obsolete pressure-resistant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000418
+name: obsolete pressure-adapted
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000419
+name: obsolete piezo-acidophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000420
+name: obsolete piezo-alkaliphile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000421
+name: obsolete piezo-halophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000422
+name: obsolete piezo-psychrophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000423
+name: obsolete piezo-thermophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000424
+name: obsolete piezo-lithoautotrophe
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000425
+name: obsolete piezo-chemoheterotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000426
+name: obsolete piezo-oligotroph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000427
+name: obsolete piezo-endolithic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000428
+name: obsolete piezo-tolerant
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000429
 name: GC low
 synonym: "GC_42.65_57.0" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
@@ -142,6 +6080,54 @@ is_a: metpo:1000127 ! GC content
 property_value: metpo:range_min "66.3" xsd:string
 
 [Term]
+id: metpo:1000433
+name: obsolete cell width very low
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000434
+name: obsolete cell width low
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000435
+name: obsolete cell width mid
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000436
+name: obsolete cell width high
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000437
+name: obsolete cell length very low
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000438
+name: obsolete cell length low
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000439
+name: obsolete cell length mid
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000440
+name: obsolete cell length high
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000441
 name: temperature optimum very low
 synonym: "Psychrophile" EXACT []
@@ -164,7 +6150,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000443
 name: temperature optimum mid1
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TO_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000304 ! temperature optimum
 property_value: metpo:range_max "27" xsd:string
@@ -174,7 +6160,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000444
 name: temperature optimum mid2
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TO_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000304 ! temperature optimum
 property_value: metpo:range_max "30" xsd:string
@@ -184,7 +6170,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000445
 name: temperature optimum mid3
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TO_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000304 ! temperature optimum
 property_value: metpo:range_max "34" xsd:string
@@ -194,7 +6180,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000446
 name: temperature optimum mid4
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TO_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000304 ! temperature optimum
 property_value: metpo:range_max "40" xsd:string
@@ -233,7 +6219,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000450
 name: temperature range mid1
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TR_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000306 ! temperature range
 property_value: metpo:range_max "27" xsd:string
@@ -243,7 +6229,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000451
 name: temperature range mid2
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TR_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000306 ! temperature range
 property_value: metpo:range_max "30" xsd:string
@@ -253,7 +6239,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000452
 name: temperature range mid3
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TR_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000306 ! temperature range
 property_value: metpo:range_max "34" xsd:string
@@ -263,7 +6249,7 @@ property_value: qudt:ucumCode "Cel" xsd:string
 [Term]
 id: metpo:1000453
 name: temperature range mid4
-synonym: "Mesophilie" EXACT []
+synonym: "mesophilic" EXACT []
 synonym: "TR_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000306 ! temperature range
 property_value: metpo:range_max "40" xsd:string
@@ -603,6 +6589,228 @@ property_value: metpo:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
+id: metpo:1000488
+name: obsolete branched
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000489
+name: obsolete coccobacillus
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000490
+name: obsolete crescent
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000491
+name: obsolete curved
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000492
+name: obsolete curved spiral
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000493
+name: obsolete diplococcus
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000494
+name: obsolete ellipsoidal
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000495
+name: obsolete filament
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000496
+name: obsolete fusiform
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000497
+name: obsolete helical
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000498
+name: obsolete irregular
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000499
+name: obsolete oval
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000500
+name: obsolete ovoid
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000501
+name: obsolete pleomorphic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000502
+name: obsolete ring
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000503
+name: obsolete rod
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000504
+name: obsolete sphere
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000505
+name: obsolete spindle
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000506
+name: obsolete spiral
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000507
+name: obsolete star - dumbbell - pleomorphic
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000508
+name: obsolete tailed
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000509
+name: obsolete temperature adaptation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000510
+name: obsolete salinity adaptation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000511
+name: obsolete pH adaptation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000512
+name: obsolete bacterial spore
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000513
+name: obsolete pressure adaptation type
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000514
+name: obsolete pressure tolerance range
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000515
+name: obsolete sensitivity to oxygen
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000516
+name: obsolete sensitivity toward
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000517
+name: obsolete size
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000518
+name: obsolete 1-D extent
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000519
+name: obsolete width
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000520
+name: obsolete length
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000521
+name: obsolete sensitivity toward pressure
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000522
+name: obsolete sensitivity toward nacl
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000523
+name: obsolete sensitivity toward ph
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000524
+name: obsolete sensitivity toward temperature
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000525
 name: microbe
 def: "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation." [] {IAO:0000119="OHMI:0000460"}
@@ -622,6 +6830,18 @@ property_value: skos:closeMatch https://biolink.github.io/biolink-model/Chemical
 id: metpo:1000527
 name: enzyme
 is_a: metpo:1000186 ! material entity
+
+[Term]
+id: metpo:1000528
+name: obsolete structured susceptibility detail
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000529
+name: obsolete facultative psychrophile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000531
@@ -998,6 +7218,12 @@ is_a: metpo:1000731 ! nutrient adaptation
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
+id: metpo:1000643
+name: obsolete denitrifying
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000644
 name: heterotrophic
 def: "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide." [] {IAO:0000119="MICRO:0001474"}
@@ -1006,6 +7232,12 @@ synonym: "heterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "heterotrophic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_heterotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000631 ! trophic type
+
+[Term]
+id: metpo:1000645
+name: obsolete hydrogen-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000646
@@ -1062,6 +7294,12 @@ name: mixotrophic
 def: "A trophic type in which an organism can use both organic and inorganic carbon sources for growth." [] {IAO:0000119="MICRO:0001475"}
 synonym: "mixotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:1000631 ! trophic type
+
+[Term]
+id: metpo:1000653
+name: obsolete nitrogen-fixing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000654
@@ -1128,6 +7366,18 @@ synonym: "phototroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_phototroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 is_a: metpo:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
+
+[Term]
+id: metpo:1000661
+name: obsolete sulfate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000662
+name: obsolete sulfur-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000663
@@ -1562,6 +7812,228 @@ is_a: metpo:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
+id: metpo:1000807
+name: obsolete Nitrogen compound respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000808
+name: obsolete Nitrate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000809
+name: obsolete Denitrification
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000810
+name: obsolete Dissimilatory nitrate reduction to ammonium
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000811
+name: obsolete Nitrite reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000812
+name: obsolete Anaerobic ammonium oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000813
+name: obsolete Nitric oxide reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000814
+name: obsolete Nitrous oxide reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000815
+name: obsolete Sulfur and sulfoxide compound respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000816
+name: obsolete Sulfate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000817
+name: obsolete Sulfur reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000818
+name: obsolete Sulfite reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000819
+name: obsolete Thiosulfate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000820
+name: obsolete Sulfoxide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000821
+name: obsolete Dimethyl sulfoxide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000822
+name: obsolete Methionine sulfoxide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000823
+name: obsolete Sulfide oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000824
+name: obsolete Thiosulfate oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000825
+name: obsolete Sulfite oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000826
+name: obsolete Tetrathionate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000827
+name: obsolete Polysulfide reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000828
+name: obsolete Metal and metalloid respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000829
+name: obsolete Iron reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000830
+name: obsolete Iron oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000831
+name: obsolete Nitrate-dependent Fe(II) oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000832
+name: obsolete Manganese reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000833
+name: obsolete Manganese oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000834
+name: obsolete Uranium reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000835
+name: obsolete Vanadium reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000836
+name: obsolete Chromium reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000837
+name: obsolete Technetium reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000838
+name: obsolete Cobalt reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000839
+name: obsolete Arsenate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000840
+name: obsolete Arsenite oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000841
+name: obsolete Selenate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000842
+name: obsolete Selenite reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000843
+name: obsolete Carbon and organic compound respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1000844
 name: Methanogenesis
 def: "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions." [] {IAO:0000119="GO:0015948"}
@@ -1590,6 +8062,144 @@ def: "A metabolism in which acetate is produced as the sole reduced end product 
 synonym: "Reductive acetyl-CoA pathway" RELATED []
 synonym: "Wood-Ljungdahl pathway" RELATED []
 is_a: metpo:1000060 ! metabolism
+
+[Term]
+id: metpo:1000847
+name: obsolete Fumarate respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000848
+name: obsolete Trimethylamine N-oxide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000849
+name: obsolete Humus respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000850
+name: obsolete Halogenated compound respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000851
+name: obsolete Organohalide respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000852
+name: obsolete (Per)chlorate respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000853
+name: obsolete Perchlorate respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000854
+name: obsolete Chlorate respiration
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000855
+name: obsolete Bromate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000856
+name: obsolete Iodate reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000857
+name: obsolete Nitrite-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000858
+name: obsolete Nitrate-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000859
+name: obsolete Hydrogen oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000860
+name: obsolete Sulfur oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000861
+name: obsolete Nitrification
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000862
+name: obsolete Complete ammonia oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000863
+name: obsolete Carbon monoxide oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000864
+name: obsolete Hydrogenotrophic methanogenesis
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000865
+name: obsolete Acetoclastic methanogenesis
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000866
+name: obsolete Methylotrophic methanogenesis
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000867
+name: obsolete Anaerobic methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000868
+name: obsolete Lanthanide reduction
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1000869
+name: obsolete Lanthanide oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1000870
@@ -1703,109 +8313,147 @@ property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
 id: metpo:1001000
-name: observation
+name: obsolete observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001001
-name: optimum temperature observation
-def: "An observation that identifies the temperature at which a microorganism exhibits maximum growth rate or metabolic activity." [] {IAO:0000119="PATO:0000146"}
-is_a: metpo:1001000 ! observation
-property_value: IAO:0000117 "Luke Wang" xsd:string
+name: obsolete optimum temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001002
-name: growth temperature observation
-is_a: metpo:1001000 ! observation
+name: obsolete growth temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001003
-name: temperature range observation
-is_a: metpo:1001000 ! observation
+name: obsolete temperature range observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001004
-name: temperature delta observation
-is_a: metpo:1001000 ! observation
+name: obsolete temperature delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1001005
+name: obsolete culture temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1001006
+name: obsolete culture NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001007
-name: growth NaCl observation
-is_a: metpo:1001000 ! observation
+name: obsolete growth NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001008
-name: NaCl delta observation
-is_a: metpo:1001000 ! observation
+name: obsolete NaCl delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001009
-name: NaCl range observation
-is_a: metpo:1001000 ! observation
+name: obsolete NaCl range observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001010
-name: optimum NaCl observation
-is_a: metpo:1001000 ! observation
+name: obsolete optimum NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1001011
+name: obsolete culture pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001012
-name: growth pH observation
-is_a: metpo:1001000 ! observation
+name: obsolete growth pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001013
-name: optimum pH observation
-is_a: metpo:1001000 ! observation
+name: obsolete optimum pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001014
-name: pH delta observation
-is_a: metpo:1001000 ! observation
+name: obsolete pH delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001015
-name: pH range observation
-is_a: metpo:1001000 ! observation
+name: obsolete pH range observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001016
-name: optimum oxygen observation
-is_a: metpo:1001000 ! observation
+name: obsolete optimum oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001017
-name: growth oxygen observation
-is_a: metpo:1001000 ! observation
+name: obsolete growth oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001018
-name: oxygen range observation
-is_a: metpo:1001000 ! observation
+name: obsolete oxygen range observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001019
-name: oxygen delta observation
-is_a: metpo:1001000 ! observation
+name: obsolete oxygen delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001020
-name: oxygen observation
-is_a: metpo:1001000 ! observation
+name: obsolete oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001021
-name: temperature observation
-is_a: metpo:1001000 ! observation
+name: obsolete temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001022
-name: NaCl observation
-is_a: metpo:1001000 ! observation
+name: obsolete NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001023
-name: pH observation
-is_a: metpo:1001000 ! observation
+name: obsolete pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1001101
@@ -1854,6 +8502,24 @@ synonym: "5" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:1001101 ! biosafety level
 
 [Term]
+id: metpo:1002000
+name: obsolete Sulfate-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002001
+name: obsolete Fe(III)-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002002
+name: obsolete Mn(IV)-dependent methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
 id: metpo:1002003
 name: Cable bacteria metabolism
 def: "A metabolism in which electrons are transferred over centimeter-scale distances through multicellular filaments." []
@@ -1874,6 +8540,210 @@ name: Syntrophy
 def: "A metabolism in which the metabolism of one species is thermodynamically dependent on the removal of its products by another species." []
 is_a: metpo:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
+
+[Term]
+id: metpo:1002007
+name: obsolete Sulfur disproportionation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002008
+name: obsolete Nitrogen fixation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002009
+name: obsolete Nitrate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002010
+name: obsolete Anaerobic ammonium-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002011
+name: obsolete Nitrous oxide-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002012
+name: obsolete Sulfate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002013
+name: obsolete Sulfur-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002014
+name: obsolete Sulfite-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002015
+name: obsolete Thiosulfate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002016
+name: obsolete Sulfur-disproportionating
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002017
+name: obsolete Sulfide-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002018
+name: obsolete Thiosulfate-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002019
+name: obsolete Sulfite-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002020
+name: obsolete Iron-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002021
+name: obsolete Iron-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002022
+name: obsolete Nitrate-dependent Fe(II)-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002023
+name: obsolete Manganese-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002024
+name: obsolete Manganese-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002025
+name: obsolete Uranium-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002026
+name: obsolete Arsenate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002027
+name: obsolete Selenate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002028
+name: obsolete Selenite-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002029
+name: obsolete Perchlorate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002030
+name: obsolete Chlorate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002031
+name: obsolete Bromate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002032
+name: obsolete Iodate-reducing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002033
+name: obsolete Hydrogen-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002034
+name: obsolete Sulfur-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002035
+name: obsolete Ammonia oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002036
+name: obsolete Nitrite oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002037
+name: obsolete Complete ammonia-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002038
+name: obsolete Methane oxidation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002039
+name: obsolete Carbon monoxide-oxidizing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Term]
+id: metpo:1002040
+name: obsolete Nitrogen-fixing
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Term]
 id: metpo:1003000
@@ -2069,7 +8939,7 @@ name: growth medium
 def: "A processed material that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms." [] {IAO:0000119="OBI:0000079"}
 comment: This class is equivalent to OBI:0000079 'culture medium'. It is included in METPO to serve as the range for growth-related object properties.
 is_a: metpo:1000186 ! material entity
-property_value: skos:closeMatch https://biolink.github.io/biolink-model/ChemicalEntity
+property_value: skos:broadMatch https://biolink.github.io/biolink-model/ProcessedMaterial
 
 [Term]
 id: metpo:1005001
@@ -2229,6 +9099,18 @@ name: generalist
 def: "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources." [] {IAO:0000119="inbio:000022"}
 synonym: "generalist" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 is_a: metpo:1000059 ! phenotype
+
+[Term]
+id: metpo:9999999
+name: obsolete obsolete
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000000
+name: obsolete has susceptibility profile
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000001
@@ -2540,43 +9422,39 @@ is_a: metpo:2000001 ! organism interacts with chemical
 
 [Typedef]
 id: metpo:2000052
-name: has temperature observation
-def: "Relates a microbe to a temperature observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001021 ! temperature observation
-is_a: metpo:2000511 ! has observation
+name: obsolete has temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000053
-name: has optimum temperature observation
-def: "Relates a microbe to an optimum temperature observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001001 ! optimum temperature observation
-is_a: metpo:2000052 ! has temperature observation
+name: obsolete has optimum temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000054
-name: has growth temperature observation
-def: "Relates a microbe to a growth temperature observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001002 ! growth temperature observation
-is_a: metpo:2000052 ! has temperature observation
+name: obsolete has growth temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000055
-name: has range temperature observation
-def: "Relates a microbe to a growth temperature range observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001003 ! temperature range observation
-is_a: metpo:2000052 ! has temperature observation
+name: obsolete has range temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000056
-name: has temperature delta observation
-def: "Relates a microbe to a temperature tolerance breadth (delta) observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001004 ! temperature delta observation
-is_a: metpo:2000052 ! has temperature observation
+name: obsolete has temperature delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000057
+name: obsolete has culture temperature observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000101
@@ -2606,10 +9484,40 @@ synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:2000001 ! organism interacts with chemical
 
 [Typedef]
+id: metpo:2000201
+name: obsolete lyses
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
 id: metpo:2000202
 name: produces
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:2000001 ! organism interacts with chemical
+
+[Typedef]
+id: metpo:2000203
+name: obsolete fixes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000204
+name: obsolete catabolizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000205
+name: obsolete mineralizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000206
+name: obsolete conjugates
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000207
@@ -2650,16 +9558,88 @@ range: metpo:1000526 ! chemical entity
 is_a: metpo:2000210 ! accumulates
 
 [Typedef]
+id: metpo:2000213
+name: obsolete binds
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000214
+name: obsolete chelates
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000215
+name: obsolete precipitates
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000216
+name: obsolete solubilizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000217
+name: obsolete volatilizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000218
+name: obsolete crystallizes
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000219
+name: obsolete adsorbs
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
 id: metpo:2000220
 name: does not disproportionate
 synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:2000001 ! organism interacts with chemical
 
 [Typedef]
+id: metpo:2000221
+name: obsolete does not lyse
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
 id: metpo:2000222
 name: does not produce
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 is_a: metpo:2000001 ! organism interacts with chemical
+
+[Typedef]
+id: metpo:2000223
+name: obsolete does not fix
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000224
+name: obsolete does not catabolize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000225
+name: obsolete does not mineralize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000226
+name: obsolete does not conjugate
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000227
@@ -2700,12 +9680,46 @@ range: metpo:1000526 ! chemical entity
 is_a: metpo:2000230 ! does not accumulate
 
 [Typedef]
+id: metpo:2000233
+name: obsolete does not bind
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000234
+name: obsolete does not chelate
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000235
+name: obsolete does not precipitate
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000236
+name: obsolete does not solubilize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000237
+name: obsolete does not volatilize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000238
+name: obsolete does not crystallize
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
 id: metpo:2000239
-name: has pH observation
-def: "Relates a microbe to a pH observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001023 ! pH observation
-is_a: metpo:2000511 ! has observation
+name: obsolete has pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000301
@@ -2732,121 +9746,99 @@ is_a: metpo:2000301 ! enzyme activity analyzed
 
 [Typedef]
 id: metpo:2000501
-name: has optimum pH observation
-def: "Relates a microbe to an optimum pH observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001013 ! optimum pH observation
-is_a: metpo:2000239 ! has pH observation
+name: obsolete has optimum pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000502
-name: has growth pH observation
-def: "Relates a microbe to a growth pH observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001012 ! growth pH observation
-is_a: metpo:2000239 ! has pH observation
+name: obsolete has growth pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000503
-name: has range pH observation
-def: "Relates a microbe to a growth pH range observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001015 ! pH range observation
-is_a: metpo:2000239 ! has pH observation
+name: obsolete has range pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000504
-name: has pH delta observation
-def: "Relates a microbe to a pH tolerance breadth (delta) observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001014 ! pH delta observation
-is_a: metpo:2000239 ! has pH observation
+name: obsolete has pH delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
+
+[Typedef]
+id: metpo:2000505
+name: obsolete has culture pH observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000506
-name: has NaCl observation
-def: "Relates a microbe to a NaCl observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001022 ! NaCl observation
-is_a: metpo:2000511 ! has observation
+name: obsolete has NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000507
-name: has optimum NaCl observation
-def: "Relates a microbe to an optimum NaCl observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001010 ! optimum NaCl observation
-is_a: metpo:2000506 ! has NaCl observation
+name: obsolete has optimum NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000508
-name: has growth NaCl observation
-def: "Relates a microbe to a growth NaCl observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001007 ! growth NaCl observation
-is_a: metpo:2000506 ! has NaCl observation
+name: obsolete has growth NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000509
-name: has range NaCl observation
-def: "Relates a microbe to a growth NaCl range observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001009 ! NaCl range observation
-is_a: metpo:2000506 ! has NaCl observation
+name: obsolete has range NaCl observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000510
-name: has NaCl delta observation
-def: "Relates a microbe to a NaCl tolerance breadth (delta) observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001008 ! NaCl delta observation
-is_a: metpo:2000506 ! has NaCl observation
+name: obsolete has NaCl delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000511
-name: has observation
-domain: metpo:1000525 ! microbe
-range: metpo:1001000 ! observation
+name: obsolete has observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000512
-name: has oxygen observation
-def: "Relates a microbe to an oxygen observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001020 ! oxygen observation
-is_a: metpo:2000511 ! has observation
+name: obsolete has oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000513
-name: has optimum oxygen observation
-def: "Relates a microbe to an optimum oxygen observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001016 ! optimum oxygen observation
-is_a: metpo:2000512 ! has oxygen observation
+name: obsolete has optimum oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000514
-name: has growth oxygen observation
-def: "Relates a microbe to a growth oxygen observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001017 ! growth oxygen observation
-is_a: metpo:2000512 ! has oxygen observation
+name: obsolete has growth oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000515
-name: has range oxygen observation
-def: "Relates a microbe to a growth oxygen range observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001018 ! oxygen range observation
-is_a: metpo:2000512 ! has oxygen observation
+name: obsolete has range oxygen observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000516
-name: has oxygen delta observation
-def: "Relates a microbe to a oxygen tolerance breadth (delta) observation." []
-domain: metpo:1000525 ! microbe
-range: metpo:1001019 ! oxygen delta observation
-is_a: metpo:2000512 ! has oxygen observation
+name: obsolete has oxygen delta observation
+property_value: IAO:0000231 IAO:0000226
+is_obsolete: true
 
 [Typedef]
 id: metpo:2000517

--- a/metpo.owl
+++ b/metpo.owl
@@ -15,14 +15,18 @@
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="https://w3id.org/metpo/metpo.owl">
-        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-03-24/metpo.owl"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-05-19/metpo.owl"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0001-9076-6066"/>
         <dcterms:creator>METPO Development Team</dcterms:creator>
-        <dcterms:description>Microbial ecophysiological trait and phenotype ontology</dcterms:description>
+        <dcterms:description>METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible.</dcterms:description>
         <dcterms:issued>2024-01-01</dcterms:issued>
         <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-        <dcterms:modified>2025-09-29</dcterms:modified>
-        <dcterms:title>METPO</dcterms:title>
-        <owl:versionInfo>2026-03-24</owl:versionInfo>
+        <dcterms:modified>2026-05-18</dcterms:modified>
+        <dcterms:title>METPO: Microbial Ecophysiological Trait and Phenotype Ontology</dcterms:title>
+        <rdfs:seeAlso rdf:resource="https://bioportal.bioontology.org/ontologies/METPO"/>
+        <rdfs:seeAlso rdf:resource="https://bioregistry.io/registry/metpo"/>
+        <rdfs:seeAlso rdf:resource="https://github.com/berkeleybop/metpo"/>
+        <owl:versionInfo>2026-05-19</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -59,6 +63,18 @@
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
         <rdfs:label>definition source</rdfs:label>
     </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000231 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000231"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/contributor -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
     
 
 
@@ -125,6 +141,12 @@
     
 
 
+    <!-- http://www.w3.org/2004/02/skos/core#broadMatch -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#broadMatch"/>
+    
+
+
     <!-- http://www.w3.org/2004/02/skos/core#closeMatch -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#closeMatch"/>
@@ -151,6 +173,16 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- https://w3id.org/metpo/2000000 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000000">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has susceptibility profile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
     
 
 
@@ -981,11 +1013,9 @@
     <!-- https://w3id.org/metpo/2000052 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000052">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000511"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001021"/>
-        <obo:IAO_0000115>Relates a microbe to a temperature observation.</obo:IAO_0000115>
-        <rdfs:label>has temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -993,11 +1023,9 @@
     <!-- https://w3id.org/metpo/2000053 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000053">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000052"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001001"/>
-        <obo:IAO_0000115>Relates a microbe to an optimum temperature observation.</obo:IAO_0000115>
-        <rdfs:label>has optimum temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has optimum temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1005,11 +1033,9 @@
     <!-- https://w3id.org/metpo/2000054 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000054">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000052"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001002"/>
-        <obo:IAO_0000115>Relates a microbe to a growth temperature observation.</obo:IAO_0000115>
-        <rdfs:label>has growth temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has growth temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1017,11 +1043,9 @@
     <!-- https://w3id.org/metpo/2000055 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000055">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000052"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001003"/>
-        <obo:IAO_0000115>Relates a microbe to a growth temperature range observation.</obo:IAO_0000115>
-        <rdfs:label>has range temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has range temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1029,11 +1053,19 @@
     <!-- https://w3id.org/metpo/2000056 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000056">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000052"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001004"/>
-        <obo:IAO_0000115>Relates a microbe to a temperature tolerance breadth (delta) observation.</obo:IAO_0000115>
-        <rdfs:label>has temperature delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has temperature delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000057 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000057">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has culture temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1087,6 +1119,16 @@
     
 
 
+    <!-- https://w3id.org/metpo/2000201 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000201">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lyses</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/metpo/2000202 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000202">
@@ -1100,6 +1142,46 @@
         <owl:annotatedTarget>produces</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/2000203 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000203">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete fixes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000204 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000204">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete catabolizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000205 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000205">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete mineralizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000206 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000206">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete conjugates</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
     
 
 
@@ -1165,6 +1247,76 @@
     
 
 
+    <!-- https://w3id.org/metpo/2000213 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000213">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete binds</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000214 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000214">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chelates</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000215 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000215">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete precipitates</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000216 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000216">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete solubilizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000217 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000217">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete volatilizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000218 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000218">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete crystallizes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000219 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000219">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete adsorbs</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/metpo/2000220 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000220">
@@ -1181,6 +1333,16 @@
     
 
 
+    <!-- https://w3id.org/metpo/2000221 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000221">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not lyse</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/metpo/2000222 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000222">
@@ -1194,6 +1356,46 @@
         <owl:annotatedTarget>produces</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/2000223 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not fix</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000224 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000224">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not catabolize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000225 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000225">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not mineralize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000226 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000226">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not conjugate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
     
 
 
@@ -1259,14 +1461,72 @@
     
 
 
+    <!-- https://w3id.org/metpo/2000233 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000233">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not bind</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000234 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000234">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not chelate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000235 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000235">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not precipitate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000236 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000236">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not solubilize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000237 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000237">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not volatilize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000238 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000238">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete does not crystallize</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/metpo/2000239 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000239">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000511"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001023"/>
-        <obo:IAO_0000115>Relates a microbe to a pH observation.</obo:IAO_0000115>
-        <rdfs:label>has pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1327,11 +1587,9 @@
     <!-- https://w3id.org/metpo/2000501 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000501">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000239"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001013"/>
-        <obo:IAO_0000115>Relates a microbe to an optimum pH observation.</obo:IAO_0000115>
-        <rdfs:label>has optimum pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has optimum pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1339,11 +1597,9 @@
     <!-- https://w3id.org/metpo/2000502 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000502">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000239"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001012"/>
-        <obo:IAO_0000115>Relates a microbe to a growth pH observation.</obo:IAO_0000115>
-        <rdfs:label>has growth pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has growth pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1351,11 +1607,9 @@
     <!-- https://w3id.org/metpo/2000503 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000503">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000239"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001015"/>
-        <obo:IAO_0000115>Relates a microbe to a growth pH range observation.</obo:IAO_0000115>
-        <rdfs:label>has range pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has range pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1363,11 +1617,19 @@
     <!-- https://w3id.org/metpo/2000504 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000504">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000239"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001014"/>
-        <obo:IAO_0000115>Relates a microbe to a pH tolerance breadth (delta) observation.</obo:IAO_0000115>
-        <rdfs:label>has pH delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has pH delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/metpo/2000505 -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000505">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has culture pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1375,11 +1637,9 @@
     <!-- https://w3id.org/metpo/2000506 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000506">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000511"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001022"/>
-        <obo:IAO_0000115>Relates a microbe to a NaCl observation.</obo:IAO_0000115>
-        <rdfs:label>has NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1387,11 +1647,9 @@
     <!-- https://w3id.org/metpo/2000507 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000507">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000506"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001010"/>
-        <obo:IAO_0000115>Relates a microbe to an optimum NaCl observation.</obo:IAO_0000115>
-        <rdfs:label>has optimum NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has optimum NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1399,11 +1657,9 @@
     <!-- https://w3id.org/metpo/2000508 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000508">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000506"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001007"/>
-        <obo:IAO_0000115>Relates a microbe to a growth NaCl observation.</obo:IAO_0000115>
-        <rdfs:label>has growth NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has growth NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1411,11 +1667,9 @@
     <!-- https://w3id.org/metpo/2000509 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000509">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000506"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001009"/>
-        <obo:IAO_0000115>Relates a microbe to a growth NaCl range observation.</obo:IAO_0000115>
-        <rdfs:label>has range NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has range NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1423,11 +1677,9 @@
     <!-- https://w3id.org/metpo/2000510 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000510">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000506"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001008"/>
-        <obo:IAO_0000115>Relates a microbe to a NaCl tolerance breadth (delta) observation.</obo:IAO_0000115>
-        <rdfs:label>has NaCl delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has NaCl delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1435,9 +1687,9 @@
     <!-- https://w3id.org/metpo/2000511 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000511">
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>has observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1445,11 +1697,9 @@
     <!-- https://w3id.org/metpo/2000512 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000512">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000511"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001020"/>
-        <obo:IAO_0000115>Relates a microbe to an oxygen observation.</obo:IAO_0000115>
-        <rdfs:label>has oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1457,11 +1707,9 @@
     <!-- https://w3id.org/metpo/2000513 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000513">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000512"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001016"/>
-        <obo:IAO_0000115>Relates a microbe to an optimum oxygen observation.</obo:IAO_0000115>
-        <rdfs:label>has optimum oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has optimum oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1469,11 +1717,9 @@
     <!-- https://w3id.org/metpo/2000514 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000514">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000512"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001017"/>
-        <obo:IAO_0000115>Relates a microbe to a growth oxygen observation.</obo:IAO_0000115>
-        <rdfs:label>has growth oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has growth oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1481,11 +1727,9 @@
     <!-- https://w3id.org/metpo/2000515 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000515">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000512"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001018"/>
-        <obo:IAO_0000115>Relates a microbe to a growth oxygen range observation.</obo:IAO_0000115>
-        <rdfs:label>has range oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has range oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1493,11 +1737,9 @@
     <!-- https://w3id.org/metpo/2000516 -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000516">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000512"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
-        <rdfs:range rdf:resource="https://w3id.org/metpo/1001019"/>
-        <obo:IAO_0000115>Relates a microbe to a oxygen tolerance breadth (delta) observation.</obo:IAO_0000115>
-        <rdfs:label>has oxygen delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has oxygen delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1634,11 +1876,9 @@
     <!-- https://w3id.org/metpo/2000058 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000058">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
-        <obo:IAO_0000115>A reported temperature value (°C) for this observation.</obo:IAO_0000115>
-        <rdfs:label>has observed spot value</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has observed spot value</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1646,11 +1886,9 @@
     <!-- https://w3id.org/metpo/2000059 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000059">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
-        <obo:IAO_0000115>The minimum temperature (°C) associated with this observation.</obo:IAO_0000115>
-        <rdfs:label>has minimum observed value</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has minimum observed value</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1658,11 +1896,9 @@
     <!-- https://w3id.org/metpo/2000060 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000060">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
-        <obo:IAO_0000115>The maximum temperature (°C) associated with this observation.</obo:IAO_0000115>
-        <rdfs:label>has maximum observed value</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has maximum observed value</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1670,11 +1906,9 @@
     <!-- https://w3id.org/metpo/2000061 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000061">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115>Free-text comments associated with this observation.</obo:IAO_0000115>
-        <rdfs:label>has value comments</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete has value comments</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1682,11 +1916,9 @@
     <!-- https://w3id.org/metpo/2000062 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000062">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
-        <rdfs:domain rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115>True if this observation indicates no growth at the reported temperature (negative result).</obo:IAO_0000115>
-        <rdfs:label>is negative data</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete is negative data</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1694,7 +1926,9 @@
     <!-- https://w3id.org/metpo/2000063 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000063">
-        <rdfs:label>observation data property</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete observation data property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -2090,7 +2324,7 @@
     <!-- https://w3id.org/metpo/2000730 -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000730">
-        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000063"/>
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/metpo/2000071"/>
         <rdfs:domain rdf:resource="https://w3id.org/metpo/1000525"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <obo:IAO_0000115>A derived ecological or genomic metric computed from genome or community data.</obo:IAO_0000115>
@@ -2186,6 +2420,6336 @@
     
 
 
+    <!-- https://w3id.org/metpo/0000001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Salinity</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000003 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000003">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000004 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000004">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000005 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000005">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Trophic type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Width</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Length</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000015 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000015">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Salinity</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete METPO Morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000022 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000022">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000023 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000023">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Psychrotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000024 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Mesophilie</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000025 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000025">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Thermotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000026 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000026">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000027 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000027">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000028 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000028">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000029 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000029">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000003 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000003">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000030 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000030">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000031 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000031">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Non-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000032 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000032">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Slight halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000033 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000033">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Moderate halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000034 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000034">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000035 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000035">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Halotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000036 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000036">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000037 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000037">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000038 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000038">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000039 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000039">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Neutrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000004 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000004">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000040 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000040">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000041 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000041">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acid Tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000042 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000042">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000043 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000043">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000044 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000044">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000045 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000045">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000046 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000046">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000047 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000047">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000048 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000048">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000049 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000049">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000005 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000005">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Trophic type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000050 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000050">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microaerophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000051 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000051">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000052 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000052">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microaerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000053 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000053">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000054 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000054">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000055 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000055">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000056 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000056">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000057 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000057">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000058 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000058">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Autotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000059 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000059">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Photoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000060 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000060">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000061 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000061">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Heterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000062 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000062">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Photoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000063 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000063">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000064 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000064">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000065 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000065">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Organotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000066 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000066">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000067 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000067">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000068 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000068">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000069 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000069">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Copiotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000070 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000070">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000071 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000071">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Mixotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000072 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000072">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000073 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000073">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000074 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000074">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000075 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000075">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methylotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000076 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000076">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methanotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000077 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000077">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Carboxydotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000078 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000078">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000079 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000079">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000080 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000080">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogen producer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000081 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000081">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000082 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000082">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methanogen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000083 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000083">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sulfate reducer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000084 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000084">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000085 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000085">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Denitrifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000086 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000086">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Capnophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000087 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000087">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000088 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000088">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Non-motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000089 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000089">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Flagellated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000090 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000090">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Peritrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000091 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000091">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lophotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000092 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000092">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Monotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000093 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000093">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ciliated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000094 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000094">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000095 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000095">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Twitching</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000096 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000096">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000097 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000097">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Swarming</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000098 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000098">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Endospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000099 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000099">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Exospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Width</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000100 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000100">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Myxospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000101 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000101">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Arthrospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000102 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000102">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Conidia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000103 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000103">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporangiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000104 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000104">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Zygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000105 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000105">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Akinetes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000106 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000106">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chlamydospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000107 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000107">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporocysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000108 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000108">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hypnospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000109 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000109">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gemmae</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Length</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000110 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000110">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000111 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000111">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Azygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000112 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000112">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000113 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000113">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ascospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000114 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000114">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Basidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000115 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000115">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aleuriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000116 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000116">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Stylospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000117 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000117">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sclerotia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000118 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000118">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Zoospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000119 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000119">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Teliospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000120 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000120">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Urediniospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000121 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000121">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pycnidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000122 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000122">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000123 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000123">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aplanospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000124 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000124">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Statismospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000125 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000125">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Barotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000126 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000126">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000127 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000127">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000128 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000128">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezosensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000129 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000129">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000130 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000130">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000131 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000131">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hyperbarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000132 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000132">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hypobarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000133 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000133">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000134 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000134">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Moderate piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000135 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000135">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000136 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000136">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Stenopiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000137 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000137">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Eurypiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000138 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000138">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000139 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000139">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-resistant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000140 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000140">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000141 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000141">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000142 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000142">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000143 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000143">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000144 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000144">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000145 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000145">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000146 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000146">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000147 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000147">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000148 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000148">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000149 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000149">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000015 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000015">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000150 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000150">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000151 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000151">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000152 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000152">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000153 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000153">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000154 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000154">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000155 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000155">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000156 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000156">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000157 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000157">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width mid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000158 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000158">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000159 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000159">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000160 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000160">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000161 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000161">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length mid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000162 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000162">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000163 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000163">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000164 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000164">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000165 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000165">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000166 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000166">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000167 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000167">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum mid3</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000168 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000168">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum mid4</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000169 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000169">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000170 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000170">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000171 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000171">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000172 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000172">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000173 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000173">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000174 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000174">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range mid3</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000175 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000175">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range mid4</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000176 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000176">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000177 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000177">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000178 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000178">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000179 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000179">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000180 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000180">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000181 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000181">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000182 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000182">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000183 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000183">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000184 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000184">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000185 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000185">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid3</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000186 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000186">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000187 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000187">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000188 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000188">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000189 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000189">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000190 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000190">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Optimum high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000191 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000191">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000192 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000192">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000193 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000193">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000194 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000194">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Range high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000195 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000195">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000196 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000196">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000197 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000197">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000198 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000198">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000199 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000199">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta mid3</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000200 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000200">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Delta high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000201 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000201">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Delta low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000202 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000202">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000203 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000203">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000204 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000204">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete NaCl Delta high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000205 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000205">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000206 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000206">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000207 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000207">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta mid1</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000208 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000208">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta mid2</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000209 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000209">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Delta high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000210 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000210">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Bacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000211 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000211">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Branced</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000212 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000212">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Coccobacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000213 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000213">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Coccus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000214 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000214">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Crescent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000215 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000215">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Curved</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000216 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000216">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Curved Spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000217 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000217">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Diplococcus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000218 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000218">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Disc</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000219 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000219">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Dumbbell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000022 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000022">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Other</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000220 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000220">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ellipsoidal</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000221 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000221">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Filament</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000222 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000222">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Flask</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000223 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Fusiform</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000224 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000224">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Helical</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000225 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000225">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Irregular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000226 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000226">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oval</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000227 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000227">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ovoid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000228 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000228">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000229 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000229">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ring</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000023 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000023">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000230 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000230">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Rod</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000231 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000231">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sphere</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000232 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000232">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Spindle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000233 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000233">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000234 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000234">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Spirochete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000235 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000235">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Spore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000236 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000236">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Square</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000237 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000237">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Star</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000238 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000238">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Star - Dumbbell - Pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000239 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000239">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Tailed</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000024 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Psychrotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000240 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000240">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Triangular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000241 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000241">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Vibrio</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000242 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000242">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Environmental Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000243 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000243">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Condition</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000244 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000244">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Physiological Trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000245 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000245">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Metabolic Classification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000246 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000246">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000247 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000247">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000248 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000248">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000249 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000249">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000025 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000025">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Mesophilie</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000250 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000250">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Structural Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000251 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000251">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000252 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000252">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000253 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000253">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000254 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000254">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000255 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000255">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000256 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000256">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000257 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000257">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Electron Donor Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000258 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000258">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility Mechanism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000259 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000259">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000026 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000026">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Thermotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000260 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000260">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000261 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000261">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000262 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000262">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Reproductive Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000263 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000263">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Dormancy Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000264 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000264">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000265 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000265">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000266 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000266">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Genomic Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000267 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000267">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Dimension</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000268 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000268">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000269 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000269">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000027 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000027">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000270 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000270">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000271 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000271">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Shape</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000272 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000272">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Arrangement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000273 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000273">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Colony Morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000274 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000274">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Physical Property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000275 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000275">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Environmental Context</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000276 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000276">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Biological Property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000277 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000277">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Functional Classification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000278 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000278">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Classification Property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000279 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000279">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete METPO Biological Process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000028 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000028">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000280 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000280">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Measurable Property</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000281 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000281">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram-stain negative</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0000282 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0000282">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram-stain positive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000029 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000029">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000030 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000030">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000031 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000031">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000032 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000032">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Non-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000033 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000033">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Slight halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000034 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000034">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Moderate halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000035 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000035">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000036 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000036">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Halotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000037 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000037">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000038 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000038">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000039 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000039">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000040 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000040">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Neutrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000041 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000041">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000042 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000042">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acid Tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000043 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000043">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000044 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000044">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000045 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000045">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000046 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000046">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000047 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000047">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000048 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000048">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000049 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000049">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000050 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000050">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000051 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000051">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microaerophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000052 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000052">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000053 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000053">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microaerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000054 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000054">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000055 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000055">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000056 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000056">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000057 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000057">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000058 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000058">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000059 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000059">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Autotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000060 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000060">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Photoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000061 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000061">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000062 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000062">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Heterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000063 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000063">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Photoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000064 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000064">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000065 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000065">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000066 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000066">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Organotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000067 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000067">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000068 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000068">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000069 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000069">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000070 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000070">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Copiotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000071 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000071">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000072 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000072">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Mixotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000073 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000073">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000074 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000074">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000075 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000075">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000076 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000076">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methylotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000077 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000077">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methanotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000078 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000078">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Carboxydotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000079 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000079">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000080 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000080">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000081 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000081">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hydrogen producer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000082 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000082">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000083 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000083">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Methanogen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000084 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000084">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sulfate reducer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000085 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000085">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000086 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000086">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Denitrifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000087 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000087">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Capnophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000088 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000088">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000089 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000089">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Non-motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000090 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000090">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Flagellated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000091 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000091">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Peritrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000092 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000092">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Lophotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000093 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000093">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Monotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000094 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000094">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ciliated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000095 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000095">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000096 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000096">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Twitching</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000097 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000097">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000098 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000098">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Swarming</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000099 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000099">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Endospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000100 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000100">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Exospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001000 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001000">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete &apos;organismal quality&apos;</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001003 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001003">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete &apos;physicial object quality&apos;</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001004 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001004">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete &apos;quality&apos;</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete size</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete 1-D extent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete width</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete length</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000101 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000101">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Myxospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete &apos;prokaryotic metabolically differentiated cell&apos;</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heterotrophy</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spore type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward NaCl</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward pH</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000102 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000102">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Arthrospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete metabolic constraints</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/0001021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/0001021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell by chemical produced</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000103 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000103">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Conidia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000104 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000104">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporangiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000105 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000105">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Zygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000106 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000106">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Akinetes</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000107 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000107">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Chlamydospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000108 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000108">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sporocysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000109 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000109">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hypnospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000110 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000110">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gemmae</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000111 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000111">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000112 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000112">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Azygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000113 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000113">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000114 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000114">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Ascospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000115 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000115">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Basidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000116 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000116">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aleuriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000117 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000117">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Stylospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000118 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000118">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Sclerotia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000119 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000119">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Zoospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000120 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000120">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Teliospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000121 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000121">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Urediniospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000122 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000122">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pycnidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000123 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000123">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Acriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000124 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000124">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Aplanospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000125 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000125">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Statismospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000126 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000126">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Barotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000127 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000127">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000128 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000128">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000129 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000129">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezosensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000130 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000130">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Obligate barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000131 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000131">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Facultative barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000132 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000132">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hyperbarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000133 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000133">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Hypobarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000134 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000134">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000135 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000135">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Moderate piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000136 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000136">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Extreme piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000137 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000137">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Stenopiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000138 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000138">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Eurypiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000139 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000139">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000140 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000140">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-resistant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000141 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000141">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000142 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000142">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000143 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000143">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000144 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000144">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000145 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000145">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000146 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000146">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000147 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000147">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000148 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000148">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000149 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000149">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000150 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000150">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000151 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000151">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000152 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000152">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC% low ( &lt; 42.65)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000153 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000153">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC% mid1 (42.65 - 57)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000154 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000154">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC% mid2 (57 - 66.3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000155 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000155">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GC% high ( &gt; 66.3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000156 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000156">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width uM very low (&lt; 0.5)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000157 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000157">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width uM low (0.5 - 0.65)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000158 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000158">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width uM mid (0.65 - 0.9)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000159 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000159">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell width uM high (&gt; 0.9)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000160 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000160">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length uM very low (&lt;= 1.3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000161 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000161">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length uM low (1.3 - 2)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000162 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000162">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length uM mid (2 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000163 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000163">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell length uM high (&gt; 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000164 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000164">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C very low (&lt;= 10)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000165 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000165">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C low (10 - 22)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000166 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000166">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C mid1 (22 - 27)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000167 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000167">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C mid2 (27 - 30)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000168 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000168">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C mid3 (30 - 34)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000169 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000169">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C mid4 (34 - 40)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000170 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000170">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Optimum C high (&gt; 40)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000171 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000171">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C very low (&lt;= 10)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000172 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000172">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C low (10 - 22)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000173 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000173">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C mid1 (22 - 27)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000174 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000174">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C mid2 (27 - 30)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000175 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000175">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C mid3 (30 - 34)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000176 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000176">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C mid4 (34 - 40)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000177 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000177">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Range C high (&gt; 40)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000178 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000178">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum low (0 - 6)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000179 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000179">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum mid1 (6 - 7)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000180 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000180">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum mid2 (7 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000181 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000181">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Optimum high (8 - 14)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000182 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000182">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range very low (0 - 4)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000183 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000183">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range low (4 - 6)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000184 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000184">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid1 (6 - 7)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000185 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000185">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid2 (7 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000186 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000186">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range mid3 (8 - 10)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000187 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000187">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Range high (10 - 14)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000188 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000188">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Optimum low (&lt;= 1)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000189 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000189">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Optimum mid1 (1 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000190 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000190">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Optimum mid2 (3 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000191 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000191">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Optimum high (&gt; 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000192 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000192">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Range low (&lt;= 1)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000193 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000193">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Range mid1 (1 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000194 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000194">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Range mid2 (3 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000195 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000195">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl Range high (&gt; 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000196 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000196">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta very low (&lt;= 1)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000197 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000197">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta low (1 - 2)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000198 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000198">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta mid1 (2 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000199 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000199">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta mid2 (3 - 4)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000200 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000200">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta mid3 (4 - 5)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000201 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000201">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH delta high (5 - 9)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000202 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000202">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl delta low (&lt;= 1)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000203 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000203">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl delta mid2 (1 - 3)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000204 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000204">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl delta mid2 (3 - 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000205 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000205">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete % NaCl delta high (&gt;= 8)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000206 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000206">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta very low (1 - 5)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000207 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000207">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta low (5 - 10)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000208 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000208">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta mid1 (10 - 20)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000209 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000209">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta mid2 (20 - 30)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000210 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000210">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature C delta high (&gt;= 30)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000211 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000211">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete bacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000212 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000212">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete branced</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000213 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000213">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete coccobacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000214 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000214">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete coccus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000215 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000215">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete crescent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000216 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000216">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete curved</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000217 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000217">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete curved spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000218 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000218">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete diplococcus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000219 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000219">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete disc</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000220 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000220">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dumbbell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000221 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000221">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ellipsoidal</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000222 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000222">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete filament</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000223 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete flask</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000224 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000224">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fusiform</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000225 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000225">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete helical</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000226 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000226">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete irregular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000227 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000227">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oval</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000228 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000228">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ovoid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000229 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000229">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000230 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000230">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ring</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000231 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000231">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete rod</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000232 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000232">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sphere</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000233 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000233">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spindle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000234 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000234">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000235 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000235">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spirochete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000236 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000236">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000237 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000237">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete square</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000238 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000238">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete star</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000239 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000239">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000240 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000240">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete tailed</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000241 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000241">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete triangular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000242 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000242">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete vibrio</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000243 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000243">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Environmental Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000244 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000244">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Condition</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000245 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000245">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Physiological Trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000246 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000246">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Metabolic Classification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000247 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000247">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000248 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000248">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000249 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000249">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000250 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000250">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000251 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000251">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Structural Feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000252 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000252">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000253 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000253">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000254 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000254">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH Adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000255 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000255">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000256 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000256">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000257 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000257">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000258 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000258">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Electron Donor Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000259 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000259">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility Mechanism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000260 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000260">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Motility Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000261 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000261">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000262 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000262">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000263 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000263">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Reproductive Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000264 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000264">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Dormancy Structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000265 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000265">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000266 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000266">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000267 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000267">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete GenomicFeature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000268 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000268">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Dimension</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000269 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000269">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000270 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000270">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000271 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000271">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000272 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000272">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Shape</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000273 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000273">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Cell Arrangement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/000274 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/000274">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Colony Morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete acid-fast</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000003 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000003">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete active transport</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000004 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000004">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000005 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000005">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete adaptive trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete adhesin</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete adhesion structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete aerobic respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete aerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete aggregate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete akinete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ammonification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000015 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000015">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete amylolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete anaerobic respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete anoxygenic photosynthesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete antibiotic production</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete antibiotic resistance</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete antimicrobial resistance</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000022 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000022">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete appendage</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000023 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000023">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete arthrospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000024 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ascospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000025 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000025">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete autotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000026 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000026">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete autotrophic process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000027 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000027">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete auxotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000028 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000028">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete axial filament</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000029 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000029">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete bacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000030 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000030">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000031 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000031">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete barotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000032 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000032">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete basidiospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000033 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000033">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete binary fission</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000034 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000034">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete biofilm</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000035 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000035">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete biofilm component</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000036 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000036">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete biofilm formation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000037 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000037">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete biogeochemical cycling</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000038 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000038">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete bioluminescence</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000039 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000039">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete budding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000040 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000040">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete buoyancy structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000041 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000041">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete capnophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000042 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000042">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete capsule</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000043 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000043">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete carbon fixation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000044 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000044">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete carbon source</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000045 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000045">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete carboxydotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000046 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000046">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell arrangement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000047 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000047">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell envelope</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000048 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000048">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell length category</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000049 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000049">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell shape</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000050 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000050">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell size</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000051 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000051">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell wall characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000052 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000052">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell wall component</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000053 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000053">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cell width category</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000054 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000054">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellular characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000055 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000055">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellular component</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000056 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000056">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellular process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000057 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000057">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellular product</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000058 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000058">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cellulolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000059 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000059">
@@ -2223,6 +8787,666 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000061 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000061">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000062 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000062">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete chemotaxis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000063 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000063">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete chlamydospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000064 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000064">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete class</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000065 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000065">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete clinically relevant feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000066 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000066">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete coccus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000067 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000067">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cold shock protein</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000068 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000068">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cold shock response</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000069 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000069">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colonization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000070 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000070">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colony elevation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000071 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000071">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colony margin</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000072 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000072">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colony morphology</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000073 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000073">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete colony texture</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000074 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000074">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete commensalism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000075 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000075">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete community behavior</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000076 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000076">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete community structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000077 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000077">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete compatible solute</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000078 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000078">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete competence</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000079 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000079">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete component</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000080 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000080">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete conidium</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000081 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000081">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete conjugation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000082 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000082">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete CRISPR</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000083 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000083">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete culturability</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000084 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000084">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete cyst</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000085 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000085">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete death phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000086 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000086">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete denitrification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000087 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000087">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete developmental process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000088 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000088">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete diagnostic enzyme</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000089 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000089">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete diagnostic feature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000090 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000090">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete diazotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000091 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000091">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete differentiation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000092 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000092">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dimorphism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000093 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000093">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete disc-shaped cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000094 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000094">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete domain</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000095 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000095">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dormancy</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000096 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000096">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dormancy structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000097 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000097">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete dumbbell-shaped cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000098 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000098">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ecological niche</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000099 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000099">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ecological process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000100 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000100">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ecological trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000101 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000101">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ectosymbiosis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000102 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000102">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete electron acceptor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000103 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000103">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete electron donor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000104 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000104">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete endospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000105 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000105">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete endosymbiosis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000106 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000106">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete energy metabolism process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000107 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000107">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete enzyme activity</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000108 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000108">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete epigenetic modification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000109 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000109">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete evolutionary process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000110 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000110">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete exospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000111 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000111">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete exponential phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000112 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000112">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete extracellular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000113 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000113">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete extracellular polysaccharide</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000114 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000114">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete extreme halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000115 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000115">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete extremophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000116 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000116">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete facultative</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000117 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000117">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete facultative anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000118 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000118">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete family</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000119 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000119">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fastidious</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000120 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000120">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fermentation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000121 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000121">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete filamentous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000122 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000122">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fimbriae</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000123 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000123">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete flagellum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000124 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000124">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete flask-shaped cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000125 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000125">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete fungal spore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000126 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000126">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete gas vesicle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000127 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000127">
@@ -2247,6 +9471,586 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000128 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000128">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete high GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000129 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000129">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete low GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000130 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000130">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lower-mid GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000131 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000131">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete upper-mid GC content</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000132 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000132">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete generation time</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000133 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000133">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genetic element</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000134 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000134">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genetic exchange</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000135 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000135">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genetic process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000136 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000136">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genome size</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000137 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000137">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genomic element</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000138 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000138">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genomic island</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000139 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000139">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genomic trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000140 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000140">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete genus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000141 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000141">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete gliding motility</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000142 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000142">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete global regulator</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000143 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000143">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram-negative</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000144 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000144">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram-positive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000145 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000145">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete Gram stain</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000146 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000146">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete growth characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000147 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000147">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete growth conditions constraints</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000148 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000148">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete growth pattern</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000149 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000149">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete growth rate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000150 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000150">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete habitat</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000151 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000151">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000152 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000152">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete halotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000153 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000153">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heat shock protein</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000154 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000154">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heat shock response</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000155 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000155">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete hemolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000156 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000156">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heterocyst</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000157 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000157">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete heterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000158 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000158">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete holdfast</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000159 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000159">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete horizontal gene transfer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000160 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000160">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete hydrolase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000161 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000161">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000162 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000162">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete inclusion body</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000163 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000163">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete infection</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000164 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000164">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000165 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000165">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction with a phage</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000166 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000166">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction with an environment</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000167 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000167">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction with host</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000168 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000168">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete interaction within a community</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000169 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000169">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete intracellular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000170 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000170">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete invasion</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000171 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000171">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete laboratory characteristic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000172 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000172">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lag phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000173 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000173">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete life cycle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000174 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000174">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete life cycle phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000175 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000175">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lipolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000176 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000176">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lipopolysaccharide</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000177 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000177">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete localization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000178 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000178">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete lysogeny</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000179 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000179">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete macroscopic trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000180 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000180">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete magnetotaxis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000181 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000181">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mesophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000182 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000182">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete metabolic partner</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000183 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000183">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete metabolic trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000184 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000184">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete methanogenesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000185 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000185">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete methylation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000186 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000186">
@@ -2263,11 +10067,451 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000187 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000187">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000188 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000188">
         <obo:IAO_0000115>A characteristic of an entity that depends on the entity&apos;s existence, size, color, and physiological traits.</obo:IAO_0000115>
         <rdfs:label>quality</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000189 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000189">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000190 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000190">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microaerophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000191 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000191">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mobile genetic element</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000192 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000192">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete moderate halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000193 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000193">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete morphological trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000194 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000194">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete motility process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000195 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000195">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete motility structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000196 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000196">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mutualism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000197 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000197">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mycolic acid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000198 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000198">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete mycorrhization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000199 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000199">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete neutrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000200 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000200">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nitrification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000201 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000201">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nitrogen fixation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000202 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000202">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nodulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000203 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000203">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nucleoid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000204 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000204">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete nutrient utilization</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000205 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000205">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete obligate</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000206 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000206">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete obligate aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000207 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000207">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete obligate anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000208 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000208">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000209 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000209">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete order</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000210 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000210">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by growth conditions</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000211 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000211">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by nutritional requirement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000212 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000212">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by product produced</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000213 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000213">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000214 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000214">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to ph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000215 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000215">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000216 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000216">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to salt concentration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000217 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000217">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by relation to temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000218 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000218">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by shape</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000219 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000219">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete microbe characterized by trophic type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000220 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000220">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete osmophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000221 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000221">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete osmoregulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000222 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000222">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oxidative stress response</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000223 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oxidoreductase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000224 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000224">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oxygen requirement</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000225 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000225">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete oxygenic photosynthesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000226 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000226">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pan-genome</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000227 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000227">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete parasitism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000228 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000228">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete passive transport</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000229 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000229">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pathogenicity</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000230 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000230">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pathogenicity island</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000231 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000231">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete peptidoglycan</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -2278,6 +10522,706 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000531"/>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000534"/>
         <rdfs:label>pH delta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000233 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000233">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH optimum (growth range)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000234 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000234">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH preference</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000235 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000235">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH range (growth tolerance)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000236 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000236">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pH tolerance</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000237 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000237">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete phage defense</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000238 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000238">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete photoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000239 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000239">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete photoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000240 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000240">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete photosynthesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000241 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000241">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete phototaxis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000242 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000242">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete phylum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000243 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000243">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete physiological process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000244 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000244">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete physiological state</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000245 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000245">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete physiological trait</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000246 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000246">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000247 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000247">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pigment</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000248 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000248">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pigmentation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000249 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000249">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pilus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000250 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000250">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete plant growth promotion</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000251 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000251">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete plasmid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000252 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000252">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete pleomorphism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000253 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000253">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000254 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000254">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete prophage</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000255 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000255">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete prostheca</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000256 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000256">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete protein synthesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000257 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000257">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete proteolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000258 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000258">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete prototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000259 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000259">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000260 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000260">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete qualifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000261 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000261">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete quorum sensing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000262 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000262">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete regulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000263 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000263">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete regulatory mechanism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000264 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000264">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete reproductive process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000265 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000265">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete reproductive structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000266 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000266">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete resistance mechanism</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000267 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000267">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000268 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000268">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete restriction-modification system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000269 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000269">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete ribosome</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000270 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000270">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete S-layer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000271 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000271">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete salinity delta</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000272 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000272">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete salinity preference</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000273 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000273">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete secondary metabolite</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000274 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000274">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete secretion</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000275 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000275">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete secretion system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000276 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000276">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sheathed</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000277 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000277">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete siderophore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000278 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000278">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sigma factor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000279 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000279">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete signaling</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000280 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000280">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete slime layer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000281 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000281">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete specialized cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000282 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000282">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete species</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000283 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000283">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spirillum</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000284 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000284">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete spirochete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000285 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000285">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sporangiospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000286 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000286">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sporulation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000287 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000287">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete square cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000288 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000288">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete stalk</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000289 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000289">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete star-shaped cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000290 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000290">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete stationary phase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000291 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000291">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete storage structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000292 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000292">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete strain</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000293 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000293">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete stress response</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000294 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000294">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete structure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000295 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000295">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete sulfate reducer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000296 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000296">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete swarming</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000297 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000297">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete symbiosis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000298 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000298">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete symbiotic process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000299 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000299">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete syntrophy</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000300 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000300">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete taxonomic identifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000301 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000301">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete taxonomic rank</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000302 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000302">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete teichoic acid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -2310,12 +11254,262 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000305 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000305">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete temperature preference</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000306 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000306">
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000533"/>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000535"/>
         <rdfs:label>temperature range</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000307 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000307">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete thermal tolerance</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000308 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000308">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000309 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000309">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete toxin</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000310 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000310">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transcription factor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000311 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000311">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000312 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000312">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transferase</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000313 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000313">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transformation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000314 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000314">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transport system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000315 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000315">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete transposon</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000316 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000316">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete triangular cell</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000317 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000317">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete trichome</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000318 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000318">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete twitching motility</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000319 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000319">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete two-component system</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000320 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000320">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete viable but non-culturable</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000321 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000321">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete vibrio</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000322 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000322">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete virulence</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000323 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000323">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete virulence factor</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000324 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000324">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete virulence process</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000325 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000325">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete xylanolysis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000326 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000326">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete zoospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000327 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000327">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
+        <rdfs:label>obsolete zygospore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000328 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000328">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000329 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000329">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature optimum (metabolic activity)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000330 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000330">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature range (metabolic viability)</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -2377,6 +11571,936 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000532"/>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000534"/>
         <rdfs:label>NaCl delta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000336 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000336">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete psychrotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000337 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000337">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete thermotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000338 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000338">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000339 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000339">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme hyperthermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000340 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000340">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete non-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000341 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000341">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete slight halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000342 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000342">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete haloalkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000343 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000343">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000344 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000344">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete acid tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000345 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000345">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete alkali tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000346 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000346">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000347 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000347">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete facultative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000348 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000348">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obligative acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000349 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000349">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete facultative aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000350 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000350">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete microaerophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000351 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000351">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete microaerotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000352 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000352">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete aerotolerant anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000353 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000353">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obligate aerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000354 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000354">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obligate anaerobe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000355 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000355">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000356 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000356">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete anoxygenic phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000357 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000357">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000358 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000358">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000359 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000359">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lithotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000360 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000360">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete organotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000361 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000361">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete phototroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000362 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000362">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000363 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000363">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000364 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000364">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete copiotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000365 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000365">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000366 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000366">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete mixotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000367 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000367">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lithoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000368 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000368">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemoorganoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000369 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000369">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chemolithoautotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000370 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000370">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete methylotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000371 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000371">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete methanotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000372 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000372">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hydrogenotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000373 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000373">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hydrogen oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000374 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000374">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hydrogen producer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000375 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000375">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete nitrogen fixer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000376 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000376">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete methanogen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000377 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000377">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sulfur oxidizer</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000378 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000378">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete denitrifier</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000379 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000379">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000380 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000380">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete non-motile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000381 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000381">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete flagellated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000382 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000382">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete peritrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000383 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000383">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete lophotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000384 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000384">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete monotrichous</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000385 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000385">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete ciliated</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000386 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000386">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete gliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000387 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000387">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete twitching</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000388 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000388">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sliding</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000389 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000389">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete myxospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000390 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000390">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete conidia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000391 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000391">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete chlamydospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000392 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000392">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sporocysts</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000393 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000393">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hypnospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000394 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000394">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete gemmae</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000395 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000395">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete azygospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000396 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000396">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete aleuriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000397 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000397">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete stylospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000398 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000398">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sclerotia</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000399 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000399">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete teliospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000400 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000400">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete urediniospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000401 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000401">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pycnidiospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000402 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000402">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete acriospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000403 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000403">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete aplanospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000404 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000404">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete statismospores</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000405 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000405">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezotolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000406 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000406">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezosensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000407 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000407">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obligate barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000408 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000408">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete facultative barophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000409 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000409">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hyperbarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000410 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000410">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hypobarophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000411 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000411">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete atmospheric pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000412 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000412">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete moderate piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000413 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000413">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete extreme piezophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000414 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000414">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete stenopiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000415 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000415">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete eurypiezic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000416 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000416">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure-sensitive</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000417 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000417">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure-resistant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000418 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000418">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure-adapted</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000419 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000419">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-acidophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000420 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000420">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-alkaliphile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000421 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000421">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-halophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000422 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000422">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000423 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000423">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-thermophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000424 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000424">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-lithoautotrophe</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000425 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000425">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-chemoheterotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000426 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000426">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-oligotroph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000427 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000427">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-endolithic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000428 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000428">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete piezo-tolerant</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -2537,6 +12661,86 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000433 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000433">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell width very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000434 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000434">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell width low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000435 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000435">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell width mid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000436 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000436">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell width high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000437 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000437">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell length very low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000438 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000438">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell length low</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000439 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000439">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell length mid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000440 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000440">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete cell length high</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000441 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000441">
@@ -2648,7 +12852,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000304"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid1</rdfs:label>
         <metpo:range_max>27</metpo:range_max>
@@ -2691,7 +12895,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000304"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid2</rdfs:label>
         <metpo:range_max>30</metpo:range_max>
@@ -2734,7 +12938,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000304"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid3</rdfs:label>
         <metpo:range_max>34</metpo:range_max>
@@ -2777,7 +12981,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000304"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid4</rdfs:label>
         <metpo:range_max>40</metpo:range_max>
@@ -2942,7 +13146,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000306"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid1</rdfs:label>
         <metpo:range_max>27</metpo:range_max>
@@ -2985,7 +13189,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000306"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid2</rdfs:label>
         <metpo:range_max>30</metpo:range_max>
@@ -3028,7 +13232,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000306"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid3</rdfs:label>
         <metpo:range_max>34</metpo:range_max>
@@ -3071,7 +13275,7 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000306"/>
         <qudt:ucumCode>Cel</qudt:ucumCode>
-        <oboInOwl:hasExactSynonym>Mesophilie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid4</rdfs:label>
         <metpo:range_max>40</metpo:range_max>
@@ -4513,6 +14717,376 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000488 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000488">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete branched</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000489 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000489">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete coccobacillus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000490 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000490">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete crescent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000491 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000491">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete curved</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000492 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000492">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete curved spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000493 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000493">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete diplococcus</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000494 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000494">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete ellipsoidal</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000495 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000495">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete filament</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000496 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000496">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete fusiform</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000497 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000497">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete helical</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000498 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000498">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete irregular</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000499 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000499">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oval</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000500 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000500">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete ovoid</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000501 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000501">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000502 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000502">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete ring</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000503 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000503">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete rod</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000504 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000504">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sphere</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000505 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000505">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete spindle</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000506 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000506">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete spiral</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000507 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000507">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000508 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000508">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete tailed</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000509 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000509">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000510 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000510">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete salinity adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000511 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000511">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pH adaptation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000512 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000512">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete bacterial spore</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000513 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000513">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure adaptation type</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000514 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000514">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pressure tolerance range</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000515 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000515">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000516 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000516">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000517 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000517">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete size</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000518 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000518">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete 1-D extent</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000519 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000519">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete width</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000520 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000520">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete length</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000521 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000521">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000522 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000522">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward nacl</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000523 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000523">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward ph</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000524 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000524">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000525 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000525">
@@ -4554,6 +15128,26 @@
     <owl:Class rdf:about="https://w3id.org/metpo/1000527">
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000186"/>
         <rdfs:label>enzyme</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000528 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000528">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete structured susceptibility detail</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000529 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000529">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete facultative psychrophile</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -5825,6 +16419,16 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000643 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000643">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete denitrifying</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000644 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000644">
@@ -5866,6 +16470,16 @@
         <owl:annotatedTarget>heterotrophic</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://github.com/jmadin/bacteria_archaea_traits"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/1000645 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000645">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete hydrogen-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
     
 
 
@@ -6036,6 +16650,16 @@
         <owl:annotatedTarget>mixotroph</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/1000653 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000653">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete nitrogen-fixing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
     
 
 
@@ -6281,6 +16905,26 @@
         <owl:annotatedTarget>phototroph</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/1000661 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000661">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sulfate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000662 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000662">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete sulfur-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
     
 
 
@@ -7634,6 +18278,376 @@
     
 
 
+    <!-- https://w3id.org/metpo/1000807 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000807">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrogen compound respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000808 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000808">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000809 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000809">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Denitrification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000810 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000810">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Dissimilatory nitrate reduction to ammonium</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000811 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000811">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrite reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000812 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000812">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Anaerobic ammonium oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000813 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000813">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitric oxide reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000814 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000814">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrous oxide reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000815 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000815">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur and sulfoxide compound respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000816 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000816">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000817 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000817">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000818 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000818">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfite reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000819 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000819">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Thiosulfate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000820 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000820">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfoxide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000821 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000821">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Dimethyl sulfoxide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000822 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000822">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Methionine sulfoxide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000823 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000823">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfide oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000824 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000824">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Thiosulfate oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000825 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000825">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfite oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000826 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000826">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Tetrathionate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000827 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000827">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Polysulfide reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000828 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000828">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Metal and metalloid respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000829 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000829">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iron reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000830 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000830">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iron oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000831 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000831">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate-dependent Fe(II) oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000832 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000832">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Manganese reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000833 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000833">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Manganese oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000834 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000834">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Uranium reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000835 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000835">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Vanadium reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000836 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000836">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Chromium reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000837 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000837">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Technetium reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000838 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000838">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Cobalt reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000839 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000839">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Arsenate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000840 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000840">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Arsenite oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000841 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000841">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Selenate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000842 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000842">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Selenite reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000843 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000843">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Carbon and organic compound respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1000844 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1000844">
@@ -7690,6 +18704,236 @@
         <oboInOwl:hasRelatedSynonym>Reductive acetyl-CoA pathway</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>Wood-Ljungdahl pathway</oboInOwl:hasRelatedSynonym>
         <rdfs:label>Homoacetogenesis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000847 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000847">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Fumarate respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000848 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000848">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Trimethylamine N-oxide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000849 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000849">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Humus respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000850 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000850">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Halogenated compound respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000851 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000851">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Organohalide respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000852 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000852">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete (Per)chlorate respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000853 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000853">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Perchlorate respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000854 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000854">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Chlorate respiration</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000855 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000855">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Bromate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000856 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000856">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iodate reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000857 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000857">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrite-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000858 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000858">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000859 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000859">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Hydrogen oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000860 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000860">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000861 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000861">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrification</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000862 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000862">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Complete ammonia oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000863 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000863">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Carbon monoxide oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000864 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000864">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Hydrogenotrophic methanogenesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000865 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000865">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Acetoclastic methanogenesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000866 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000866">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Methylotrophic methanogenesis</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000867 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000867">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Anaerobic methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000868 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000868">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Lanthanide reduction</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1000869 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1000869">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Lanthanide oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8184,7 +19428,9 @@
     <!-- https://w3id.org/metpo/1001000 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001000">
-        <rdfs:label>observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8192,25 +19438,19 @@
     <!-- https://w3id.org/metpo/1001001 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001001">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <obo:IAO_0000115>An observation that identifies the temperature at which a microorganism exhibits maximum growth rate or metabolic activity.</obo:IAO_0000115>
-        <obo:IAO_0000117>Luke Wang</obo:IAO_0000117>
-        <rdfs:label>optimum temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete optimum temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1001001"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget>An observation that identifies the temperature at which a microorganism exhibits maximum growth rate or metabolic activity.</owl:annotatedTarget>
-        <obo:IAO_0000119 rdf:resource="http://purl.obolibrary.org/obo/PATO_0000146"/>
-    </owl:Axiom>
     
 
 
     <!-- https://w3id.org/metpo/1001002 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001002">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>growth temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete growth temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8218,8 +19458,9 @@
     <!-- https://w3id.org/metpo/1001003 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001003">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>temperature range observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature range observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8227,8 +19468,29 @@
     <!-- https://w3id.org/metpo/1001004 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001004">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>temperature delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1001005 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1001005">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete culture temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1001006 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1001006">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete culture NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8236,8 +19498,9 @@
     <!-- https://w3id.org/metpo/1001007 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001007">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>growth NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete growth NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8245,8 +19508,9 @@
     <!-- https://w3id.org/metpo/1001008 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001008">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>NaCl delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete NaCl delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8254,8 +19518,9 @@
     <!-- https://w3id.org/metpo/1001009 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001009">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>NaCl range observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete NaCl range observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8263,8 +19528,19 @@
     <!-- https://w3id.org/metpo/1001010 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001010">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>optimum NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete optimum NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1001011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1001011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete culture pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8272,8 +19548,9 @@
     <!-- https://w3id.org/metpo/1001012 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001012">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>growth pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete growth pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8281,8 +19558,9 @@
     <!-- https://w3id.org/metpo/1001013 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001013">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>optimum pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete optimum pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8290,8 +19568,9 @@
     <!-- https://w3id.org/metpo/1001014 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001014">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>pH delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pH delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8299,8 +19578,9 @@
     <!-- https://w3id.org/metpo/1001015 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001015">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>pH range observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pH range observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8308,8 +19588,9 @@
     <!-- https://w3id.org/metpo/1001016 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001016">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>optimum oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete optimum oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8317,8 +19598,9 @@
     <!-- https://w3id.org/metpo/1001017 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001017">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>growth oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete growth oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8326,8 +19608,9 @@
     <!-- https://w3id.org/metpo/1001018 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001018">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>oxygen range observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oxygen range observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8335,8 +19618,9 @@
     <!-- https://w3id.org/metpo/1001019 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001019">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>oxygen delta observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oxygen delta observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8344,8 +19628,9 @@
     <!-- https://w3id.org/metpo/1001020 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001020">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>oxygen observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete oxygen observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8353,8 +19638,9 @@
     <!-- https://w3id.org/metpo/1001021 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001021">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>temperature observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete temperature observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8362,8 +19648,9 @@
     <!-- https://w3id.org/metpo/1001022 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001022">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>NaCl observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete NaCl observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8371,8 +19658,9 @@
     <!-- https://w3id.org/metpo/1001023 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1001023">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1001000"/>
-        <rdfs:label>pH observation</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete pH observation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -8495,6 +19783,36 @@
     
 
 
+    <!-- https://w3id.org/metpo/1002000 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002000">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfate-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002001 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002001">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Fe(III)-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002002 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002002">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Mn(IV)-dependent methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/metpo/1002003 -->
 
     <owl:Class rdf:about="https://w3id.org/metpo/1002003">
@@ -8542,6 +19860,346 @@
         <obo:IAO_0000115>A metabolism in which the metabolism of one species is thermodynamically dependent on the removal of its products by another species.</obo:IAO_0000115>
         <obo:IAO_0000117>Jed Dongjin Kim-Ozaeta</obo:IAO_0000117>
         <rdfs:label>Syntrophy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002007 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002007">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur disproportionation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002008 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrogen fixation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002009 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002009">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002010 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002010">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Anaerobic ammonium-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002011 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002011">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrous oxide-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002012 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002013 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002013">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002014 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002014">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfite-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002015 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002015">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Thiosulfate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002016 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002016">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur-disproportionating</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002017 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002017">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfide-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002018 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Thiosulfate-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002019 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfite-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002020 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002020">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iron-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002021 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002021">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iron-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002022 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002022">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrate-dependent Fe(II)-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002023 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002023">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Manganese-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002024 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Manganese-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002025 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002025">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Uranium-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002026 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002026">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Arsenate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002027 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002027">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Selenate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002028 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002028">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Selenite-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002029 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002029">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Perchlorate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002030 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002030">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Chlorate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002031 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002031">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Bromate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002032 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002032">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Iodate-reducing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002033 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002033">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Hydrogen-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002034 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002034">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Sulfur-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002035 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002035">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Ammonia oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002036 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002036">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrite oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002037 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002037">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Complete ammonia-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002038 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002038">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Methane oxidation</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002039 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002039">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Carbon monoxide-oxidizing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/metpo/1002040 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/1002040">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete Nitrogen-fixing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
     </owl:Class>
     
 
@@ -9059,7 +20717,7 @@
         <obo:IAO_0000115>A processed material that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms.</obo:IAO_0000115>
         <rdfs:comment>This class is equivalent to OBI:0000079 &apos;culture medium&apos;. It is included in METPO to serve as the range for growth-related object properties.</rdfs:comment>
         <rdfs:label>growth medium</rdfs:label>
-        <skos:closeMatch rdf:resource="https://biolink.github.io/biolink-model/ChemicalEntity"/>
+        <skos:broadMatch rdf:resource="https://biolink.github.io/biolink-model/ProcessedMaterial"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1004005"/>
@@ -9278,15 +20936,15 @@
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1005025"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
-        <owl:annotatedTarget>presence of hemolysis</owl:annotatedTarget>
-        <obo:IAO_0000119 rdf:resource="https://metatraits.embl.de/"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1005025"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>A phenotype describing the ability of an organism to lyse red blood cells.</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="http://purl.obolibrary.org/obo/OMP_0005117"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1005025"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>presence of hemolysis</owl:annotatedTarget>
+        <obo:IAO_0000119 rdf:resource="https://metatraits.embl.de/"/>
     </owl:Axiom>
     
 
@@ -9467,6 +21125,16 @@
         <owl:annotatedTarget>generalist</owl:annotatedTarget>
         <obo:IAO_0000119 rdf:resource="https://metatraits.embl.de/"/>
     </owl:Axiom>
+    
+
+
+    <!-- https://w3id.org/metpo/9999999 -->
+
+    <owl:Class rdf:about="https://w3id.org/metpo/9999999">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label>obsolete obsolete</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
 </rdf:RDF>
 
 


### PR DESCRIPTION
## Summary

- Release-staging commit from \`make prepare_release\` against today's refreshed templates
- Includes today's fixes: #423 (growth medium → biolink:ProcessedMaterial broadMatch), #358 partial (Mesophilie → mesophilic on 8 temperature bins), header metadata enrichment from #440 (description, contributor ORCID, rdfs:seeAlso, refreshed dcterms:modified)
- Build clean: ROBOT v1.9.10 + ELK reasoner; 5/5 SPARQL validation rules PASS; OBO report no violations; OWL 2 DL profile validation passed; RDF/XML check OK on all three artifacts

Version IRI uses \`2026-05-19\` (container UTC date).

Closes #423.

## Files

The 9 release artifacts at repo root:

- \`metpo.owl\`, \`metpo.obo\`, \`metpo.json\` (canonical release)
- \`metpo-base.owl\`, \`metpo-base.obo\`, \`metpo-base.json\` (base variant)
- \`metpo-full.owl\`, \`metpo-full.obo\`, \`metpo-full.json\` (full variant with inferred axioms)

## After merge

1. Tag \`2026-05-19\` against the squash-merge commit
2. \`gh release create 2026-05-19\` with the OWL/OBO/JSON artifacts attached
3. Re-submit to BioPortal (manual web UI step)

## Known issues NOT addressed by this release

These will be addressed in future releases:

- #356 / #432 — GC bin label/synonym swap (needs policy decision)
- #357 — NaCl delta high formula \`<= 8\` should be \`>= 8\`
- #358 partial — remaining items (Ox_microerophile, 10_to_14) intentionally kept source-verbatim per the Synonym Column Conventions added in CLAUDE.md
- #436 — Version IRI has duplicated \`metpo/\` path segment (visible in this release's IRIs)
- #437 — BioPortal submission misconfigured DC properties (will need separate BioPortal-side fix on next submission)
- #444 — \`mesophilic\` as exact synonym on 9 distinct classes (pre-existing structural issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)