### PR TITLE
Add metpo-proposal-lint: deterministic QC/audit guardrails (#433)

### DIFF
--- a/docs/quantitative_modeling.md
+++ b/docs/quantitative_modeling.md
@@ -1,0 +1,135 @@
+# Modeling quantitative growth traits in METPO
+
+Status: draft for discussion (2026-05-29). Covers how METPO represents
+quantitative, gradient-response traits, why the `optimum` / `minimum` /
+`maximum` / `range` / `delta` variants exist, and the policy for choosing
+between a quantitative data property, a phenotype class, or both.
+
+## The quantitative axes
+
+METPO represents three kinds of quantitative information, and only the first
+kind carries the full variant set:
+
+1. **Growth-response gradients.** Continuous environmental variables that an
+   organism responds to with a growth-rate curve over a permissive interval:
+   - temperature (Celsius)
+   - pH
+   - salinity / NaCl concentration (% w/v)
+
+2. **Genome / sequence metrics.** Fixed scalar properties of the genome, each a
+   single value with no internal optimum: GC percentage, genome size, gene
+   count, coding density.
+
+3. **Cell morphometry.** Cell length and cell width, which have a measured
+   spread (min, max) but no biological "optimum".
+
+A consequence: the variant vocabulary tracks the *shape* of the underlying
+quantity. Growth-response gradients get `optimum`, `range`, and `delta` bin
+families; GC gets only coarse `low` / `mid` / `high` bins; cell dimensions get
+only `minimum` / `maximum` value properties.
+
+## Why the min / max / optimum / range / delta variants
+
+An organism's relationship to a continuous gradient is not a single number. It
+is a growth-response curve: a permissive window with an internal peak. Several
+descriptors are needed to characterize that curve, and each answers a different
+biological question.
+
+| Variant | Meaning | Question it answers |
+|---|---|---|
+| minimum | lower bound of the permissive window | what is the coldest / most acidic / least saline condition that still permits growth |
+| maximum | upper bound of the permissive window | what is the hottest / most alkaline / most saline condition that still permits growth |
+| optimum | value at which growth rate is maximal | where does the organism grow best (this is **not** the midpoint of min and max; it usually sits closer to the maximum) |
+| range | the interval [min, max] | what is the full permissive window |
+| delta | the width of the window, `max - min` | how broad is the organism's tolerance (stenotolerant vs eurytolerant) |
+
+`minimum`, `optimum`, and `maximum` are the three cardinal points that define
+the curve. `range` and `delta` are derived summaries of its breadth. They are
+not redundant: two organisms can share an optimum of 37 C while one grows
+30 to 40 C (narrow) and another 4 to 50 C (wide); `delta` is what distinguishes
+them. Because `delta` is a computed difference, its equivalent-class formula is
+error-prone (see issue #357, an inverted NaCl-delta formula).
+
+Each cardinal or derived variable is then discretized into a named bin family
+(`very low` / `low` / `mid1..4` / `high`). The classic qualitative phenotypes
+(psychrophile / mesophile / thermophile; acidophile / neutrophile / alkaliphile;
+halophile) are bins of the **optimum** variable.
+
+## Property, class, or both
+
+The same quantitative fact can be modeled two ways:
+
+- **Quantitative data property** (number on an edge): e.g.
+  `<organism> 'has minimum temperature value' "4.0"^^xsd:decimal`. Lossless,
+  supports numeric query and aggregation, faithful to numeric source data, no
+  threshold commitments.
+- **Phenotype class** (a quality term): e.g. `'temperature minimum tolerance'`,
+  or a bin such as `'temperature optimum high'`. Mappable to other ontologies,
+  reasonable, browsable, and the only sensible home for traits that have no
+  number (catalase positive, rod-shaped, motile).
+
+### The hazard: silent shadows
+
+Issue #228 records the rule: METPO should not carry the same fact as both an
+independently-asserted class and an independently-asserted property. When a
+single source gives a number and a curator *also* hand-asserts a bin, the two
+can drift, and a query against one representation silently misses facts recorded
+only in the other.
+
+### Why "both" is still sometimes correct
+
+Sources are heterogeneous, and this is the decisive point:
+
+- A numeric source (BacDive, metatraits) reports values ("grows 4 to 42 C,
+  optimum 37"). Here the data property is the lossless primary, and the bin
+  class can be **derived** from the value.
+- A label-only source (BactoTraits) reports just the bin ("mesophilic") with no
+  underlying number. Here only the class can be populated; there is no value to
+  store, and the number cannot be recovered from the bin.
+
+So the class and the property are not always shadows: they can carry
+information from sources that cannot be derived from one another. Both
+representations legitimately exist as ingest targets for the two kinds of
+evidence.
+
+### Policy
+
+1. **Categorical traits** (biochemical tests, colony morphology, flagellation,
+   capsule, biofilm, lifestyle tolerances): **class only**. There is no value to
+   lose.
+2. **Quantitative growth parameters** (temperature / pH / salinity, each of
+   optimum / min / max): keep the quantitative **data property as the source of
+   truth for the value**.
+   - When a class (bin or tolerance term) is also wanted, it must be **derived**
+     from the value, not independently asserted. Encode the derivation in the
+     schema as an equivalent-class axiom over the property
+     (the `'temperature optimum' and ('has value' some xsd:decimal[>= 40])`
+     pattern already in the sheet), so there is one source of truth.
+   - When evidence is label-only, assert the class directly and leave the value
+     empty.
+3. **Documentation requirement.** Wherever both representations coexist, the
+   relationship must be explicit in two places: this document (textual), and the
+   schema (the equivalent-class axiom, plus a machine-actionable companion
+   annotation linking a class to its datatype property rather than only a
+   free-text "Companion to ..." note in the definition).
+4. **QC requirement.** For any organism that has both a value and an asserted
+   bin, a check must confirm the asserted bin matches the bin the value would
+   derive. A mismatch is a data error.
+
+### Tooling caveat
+
+The build reasoner is ELK (`reason_test`). ELK does **not** reason over datatype
+facet restrictions (`xsd:decimal[>= 40]`). A derivation that is meant to be
+*inferred* therefore needs either a non-ELK reasoner (HermiT / Pellet) in CI, or
+a materialization step (SPARQL / Python) that computes bin membership from the
+value. If the derivation lives only in prose, it is the silent shadow that
+policy item 2 forbids.
+
+## References
+
+- #228: we do not need both properties and classes for optimal pH observation
+- #357: NaCl delta high equivalent-class formula is inverted
+- #371: removal of the observation reification layer (the reason values sit
+  directly on the organism edge rather than on a reified measurement node)
+- #424: Marcin's proposed cohort that completes both sides of the dual for the
+  temperature / pH / salinity optimum, min, and max parameters

--- a/metpo/scripts/metpo_proposal_lint.py
+++ b/metpo/scripts/metpo_proposal_lint.py
@@ -117,7 +117,10 @@ def cell(r, i):
 
 
 def fnum(s):
-    return float(s) if re.match(r"^-?[0-9.]+$", (s or "x").strip()) else None
+    try:
+        return float((s or "").strip())
+    except ValueError:
+        return None
 
 
 def load_known(paths):
@@ -148,11 +151,19 @@ def parse_bound(formula):
 
 
 def parse_syn_threshold(v):
-    """(lower, upper) from a threshold-encoded synonym (GC_<=42.65, GC_42.65_57.0, TO_10_to_22)."""
-    m = re.match(r"^[A-Za-z]{1,6}_(.+)$", v.strip())
-    if not m:
+    """(lower, upper) from a threshold-encoded synonym.
+
+    Handles an optional short prefix code and prefix-less forms, e.g.
+    ``GC_<=42.65``, ``GC_42.65_57.0``, ``TO_10_to_22``, and bare ``10_to_14`` /
+    ``8_to_10`` (the pH-range synonyms that drop their ``pHR_`` prefix). Returns
+    ``(None, None)`` unless the whole (prefix-stripped) token is a threshold
+    expression, so ordinary synonyms with stray digits are not misread.
+    """
+    body = re.sub(r"^[A-Za-z]{1,6}_", "", v.strip())
+    if not re.fullmatch(
+        r"(?:<=|>=|<|>)?\s*\d+(?:\.\d+)?(?:\s*(?:_to_|_|-)\s*\d+(?:\.\d+)?)?\+?", body
+    ):
         return (None, None)
-    body = m.group(1)
     nums = [float(x) for x in re.findall(r"[0-9]+\.?[0-9]*", body)]
     if not nums:
         return (None, None)
@@ -361,7 +372,7 @@ def ols_lookup(curie):
     try:
         req = urllib.request.Request(
             url,
-            headers={"Accept": "application/json", "User-Agent": "metpo-lint/1.0 (MAM@lbl.gov)"},
+            headers={"Accept": "application/json", "User-Agent": "metpo-proposal-lint"},
         )
         with urllib.request.urlopen(req, timeout=30) as resp:
             for e in json.load(resp).get("elements", []):

--- a/metpo/scripts/metpo_proposal_lint.py
+++ b/metpo/scripts/metpo_proposal_lint.py
@@ -1,0 +1,339 @@
+"""Deterministic guardrails for METPO term additions and released-content audits.
+
+Lints a ROBOT-template TSV (the canonical METPO sheet export, or a proposal template
+such as kg-microbe's ``metpo_proposal_*_robot.tsv``). It keys off the ROBOT directive
+row (row 2), so it is schema-aware rather than column-position-dependent, and works on
+the classes sheet, the properties sheet, ``stubs.tsv`` and ``deprecated.tsv``.
+
+Two modes:
+
+* **review** a proposed batch before it enters METPO:
+  ``metpo-proposal-lint PROPOSAL.tsv --known src/templates/metpo_sheet.tsv --mode submit``
+* **audit** released content for existing bad practices:
+  ``metpo-proposal-lint src/templates/metpo_sheet.tsv --mode draft``
+
+It is meant to run both as a METPO CI gate and as a pre-flight in the generator repos
+(kg-microbe / TraitMech / metpo-kgm-studio) before a proposal PR is opened, which is
+where the "duplicate-check-is-METPO-only" gap currently lives. It catches things the
+ODK build and ELK reasoner cannot: a logically-consistent-but-wrong bin formula (#357),
+scrambled threshold synonyms (#356/#432), mapping CURIEs parked in definition_source
+(#344), and parents that bypass ROBOT's label-resolution safety net via CURIE form.
+
+NOTE: ID-RANGE encodes the current observed convention (classes METPO:1xxxxxx,
+properties METPO:2xxxxxx). The term-IRI scheme is an open question (#16/#434/#436);
+revisit this check when that settles.
+"""
+import csv
+import json
+import re
+import time
+import urllib.parse
+import urllib.request
+
+import click
+
+# An OBO/ontology *class* CURIE in definition_source means "mapping", not "source".
+ONTOLOGY_PREFIXES = {
+    "GO", "PATO", "OMP", "MICRO", "CHEBI", "UBERON", "CL", "ENVO", "OBI", "SO",
+    "NCBITaxon", "PO", "FOODON", "UO", "APO", "FYPO", "UPHENO", "ECOCORE", "OHMI",
+    "BFO", "PHIPO", "MP", "HP", "MONDO",
+}
+TOL = 0.011  # numeric tolerance for threshold comparison
+
+
+class Finding:
+    __slots__ = ("sev", "code", "rid", "msg")
+
+    def __init__(self, sev, code, rid, msg):
+        self.sev, self.code, self.rid, self.msg = sev, code, rid, msg
+
+
+def read_template(path):
+    """Return (labels, directives, data_rows, roles) keyed off the ROBOT directive row."""
+    rows = list(csv.reader(open(path, encoding="utf-8"), delimiter="\t"))
+    if len(rows) < 2:
+        raise click.ClickException(f"{path}: need a label row + a ROBOT directive row")
+    labels, directives = rows[0], rows[1]
+    data = [r for r in rows[2:] if r and r[0].strip()]
+    roles = {"exact_syn": [], "rel_syn": []}
+    for i, d in enumerate(directives):
+        d = d.strip()
+        if d == "ID":
+            roles["id"] = i
+        elif d == "LABEL":
+            roles["label"] = i
+        elif d == "TYPE":
+            roles["type"] = i
+        elif d.startswith("SC") or d.startswith("SP"):
+            roles["parent"] = i
+        elif d.startswith("EC"):
+            roles["ec"] = i
+        elif "IAO:0000115" in d and "definition" not in roles:
+            roles["definition"] = i
+        elif "IAO:0000119" in d and "def_source" not in roles:
+            roles["def_source"] = i
+        elif "hasExactSynonym" in d:
+            roles["exact_syn"].append(i)
+        elif "hasRelatedSynonym" in d:
+            roles["rel_syn"].append(i)
+        elif "hasDbXref" in d:
+            roles["xref"] = i
+        elif "owl:deprecated" in d:
+            roles["deprecated"] = i
+        elif "range_min" in d:
+            roles["range_min"] = i
+        elif "range_max" in d:
+            roles["range_max"] = i
+        elif d == "DOMAIN":
+            roles["domain"] = i
+        elif d == "RANGE":
+            roles["range"] = i
+    return labels, directives, data, roles
+
+
+def cell(r, i):
+    return r[i].strip() if (i is not None and i < len(r)) else ""
+
+
+def fnum(s):
+    return float(s) if re.match(r"^-?[0-9.]+$", (s or "x").strip()) else None
+
+
+def load_known(paths):
+    labels, ids = set(), set()
+    for p in paths:
+        try:
+            _, _, data, roles = read_template(p)
+        except click.ClickException:
+            continue
+        li = roles.get("label", 1)
+        for r in data:
+            if r[0].startswith("METPO:"):
+                ids.add(r[0].strip())
+                labels.add(cell(r, li))
+    return labels, ids
+
+
+def parse_bound(formula):
+    """(lower, upper) from an EC facet like xsd:decimal[>= 40] / [>= 10, <= 22]."""
+    lo = up = None
+    for op, num in re.findall(r"(<=|>=|<|>)\s*([0-9.]+)", formula or ""):
+        v = float(num)
+        if op in (">=", ">"):
+            lo = v
+        else:
+            up = v
+    return lo, up
+
+
+def parse_syn_threshold(v):
+    """(lower, upper) from a threshold-encoded synonym (GC_<=42.65, GC_42.65_57.0, TO_10_to_22)."""
+    v = v.strip()
+    m = re.match(r"^[A-Za-z]{1,6}_(.+)$", v)  # require a short prefix code (GC_, TO_, ...)
+    if not m:
+        return (None, None)
+    body = m.group(1)
+    nums = [float(x) for x in re.findall(r"[0-9]+\.?[0-9]*", body)]
+    if not nums:
+        return (None, None)
+    if "<=" in body or body.startswith("<"):
+        return (None, nums[-1])
+    if ">=" in body or body.startswith(">") or body.endswith("+"):
+        return (nums[0], None)
+    if len(nums) >= 2:
+        return (min(nums), max(nums))
+    return (None, None)
+
+
+def lint(path, known_labels, known_ids, mode, external_known):
+    labels, directives, data, roles = read_template(path)
+    out = []
+    has_type = "type" in roles
+    batch_ids = {r[0].strip() for r in data if r[0].startswith("METPO:")}
+    batch_labels = {cell(r, roles.get("label")) for r in data}
+    resolve_ids = known_ids | batch_ids
+    resolve_labels = known_labels | batch_labels
+    seen = set()
+    for r in data:
+        rid = r[0].strip()
+        L = cell(r, roles.get("label"))
+        typ = cell(r, roles.get("type")) if has_type else "owl:Class"
+        deprecated = cell(r, roles.get("deprecated")).lower() == "true"
+        # ID-DUP (always, even for deprecated/imported)
+        if rid in seen:
+            out.append(Finding("ERROR", "ID-DUP", rid, "duplicate ID within file"))
+        if external_known and rid in known_ids:
+            out.append(Finding("ERROR", "ID-DUP", rid, "ID already exists in canonical METPO"))
+        seen.add(rid)
+        # Deprecated rows are historical: only ID-DUP applies.
+        if deprecated:
+            continue
+        is_metpo = rid.startswith("METPO:")
+        # ID-RANGE (METPO-namespace ids only; external declarations like IAO: are imports)
+        if is_metpo:
+            m = re.match(r"^METPO:(\d)\d{6}$", rid)
+            isprop = typ in ("owl:ObjectProperty", "owl:DataProperty", "owl:DatatypeProperty")
+            if not m:
+                out.append(Finding("ERROR", "ID-RANGE", rid, "METPO ID is not 7 digits"))
+            elif isprop and m.group(1) != "2":
+                out.append(Finding("ERROR", "ID-RANGE", rid, "property ID must be METPO:2xxxxxx"))
+            elif not isprop and m.group(1) != "1":
+                out.append(Finding("ERROR", "ID-RANGE", rid, "class ID must be METPO:1xxxxxx"))
+        # TYPE-VOCAB
+        if typ == "owl:DatatypeProperty":
+            out.append(Finding("ERROR", "TYPE-VOCAB", rid,
+                               "use 'owl:DataProperty' (METPO house style), not 'owl:DatatypeProperty'"))
+        elif typ not in ("owl:Class", "owl:ObjectProperty", "owl:DataProperty", "owl:AnnotationProperty"):
+            out.append(Finding("ERROR", "TYPE-VOCAB", rid, f"unexpected TYPE '{typ}'"))
+        # PARENT
+        for p in [x.strip() for x in cell(r, roles.get("parent")).split("|") if x.strip()]:
+            if p == "METPO:1000000":
+                out.append(Finding("ERROR", "PARENT", rid, "parent 'METPO:1000000' is the nonexistent/over-general root"))
+            elif re.match(r"^METPO:\d+$", p):
+                out.append(Finding("WARN", "HOUSE-STYLE", rid,
+                                   f"parent given as CURIE '{p}'; sheet convention is parent-by-label "
+                                   "(CURIE parents also bypass ROBOT's label-resolution safety net)"))
+                if p not in resolve_ids:
+                    out.append(Finding("ERROR", "PARENT", rid, f"parent CURIE '{p}' does not resolve"))
+            elif p not in resolve_labels:
+                out.append(Finding("ERROR", "PARENT", rid, f"parent label '{p}' does not resolve to a known class"))
+        # DEFINITION / SOURCE
+        if "definition" in roles and not cell(r, roles["definition"]) and mode == "submit":
+            out.append(Finding("ERROR", "DEF-MISSING", rid, "empty definition"))
+        if "def_source" in roles:
+            src = cell(r, roles["def_source"])
+            toks = [x.strip() for x in src.split("|") if x.strip()]
+            if (not toks) and mode == "submit":
+                out.append(Finding("ERROR", "SRC-MISSING", rid, "empty definition_source"))
+            for tok in toks:
+                pm = re.match(r"^([A-Za-z][A-Za-z0-9]*):", tok)
+                if tok == "TODO:add_citation":
+                    if mode == "submit":
+                        out.append(Finding("ERROR", "SRC-MISSING", rid, "definition_source is TODO:add_citation"))
+                elif pm and pm.group(1) in ONTOLOGY_PREFIXES:
+                    out.append(Finding("ERROR", "SRC-ISMAP", rid,
+                                       f"ontology-class CURIE '{tok}' in definition_source; belongs in a "
+                                       "mapping predicate (skos:* / oboInOwl:hasDbXref)"))
+        # authoritative numeric bounds for this row (EC preferred, then range_min/max)
+        alo, aup = parse_bound(cell(r, roles.get("ec")))
+        if alo is None:
+            alo = fnum(cell(r, roles.get("range_min")))
+        if aup is None:
+            aup = fnum(cell(r, roles.get("range_max")))
+        # FORMULA-DIR
+        ec = cell(r, roles.get("ec"))
+        if ec:
+            flo, fup = parse_bound(ec)
+            if re.search(r"\b(high|maximum|max)\b", L) and flo is None and fup is not None:
+                out.append(Finding("ERROR", "FORMULA-DIR", rid,
+                                   f"label says high/max but formula only bounds <= {fup}; expected a lower bound (>=)"))
+            if re.search(r"\b(low|minimum|min)\b", L) and fup is None and flo is not None:
+                out.append(Finding("ERROR", "FORMULA-DIR", rid,
+                                   f"label says low/min but formula only bounds >= {flo}; expected an upper bound (<=)"))
+        # SYN-THRESHOLD: synonym-encoded thresholds must agree with the row's own bounds
+        if alo is not None or aup is not None:
+            for i in (roles["exact_syn"] + roles["rel_syn"]):
+                slo, sup = parse_syn_threshold(cell(r, i))
+                if slo is None and sup is None:
+                    continue
+                bad = None
+                if slo is not None and alo is not None and abs(slo - alo) > TOL:
+                    bad = f"synonym lower {slo} != bound {alo}"
+                elif sup is not None and aup is not None and abs(sup - aup) > TOL:
+                    bad = f"synonym upper {sup} != bound {aup}"
+                elif sup is not None and alo is not None and sup < alo - TOL:
+                    bad = f"synonym ceiling {sup} below bin floor {alo} (contradiction)"
+                elif slo is not None and aup is not None and slo > aup + TOL:
+                    bad = f"synonym floor {slo} above bin ceiling {aup} (contradiction)"
+                if bad:
+                    out.append(Finding("ERROR", "SYN-THRESHOLD", rid, f"'{cell(r, i)}' vs formula/range: {bad}"))
+                    break
+        # SYN-SCOPE (ontology-native synonym columns only)
+        for i in roles["exact_syn"]:
+            for v in [x.strip() for x in cell(r, i).split("|") if x.strip()]:
+                if "/" in v or re.search(r"[A-Za-z0-9_]+\.[A-Za-z0-9_.]+", v):
+                    out.append(Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' looks like a DB field path"))
+                elif v.lower() in ("yes", "no", "true", "false"):
+                    out.append(Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' is a boolean encoding"))
+                elif re.match(r"^[0-9.]+$", v):
+                    out.append(Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' is a bare number"))
+    return out, len(data)
+
+
+def ols_lookup(curie):
+    url = "https://www.ebi.ac.uk/ols4/api/v2/entities?" + urllib.parse.urlencode({"search": curie, "size": 10})
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/json",
+                                                   "User-Agent": "metpo-lint/1.0 (MAM@lbl.gov)"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            for e in json.load(resp).get("elements", []):
+                if e.get("curie") == curie:
+                    lab = e.get("label")
+                    lab = lab[0] if isinstance(lab, list) else lab
+                    return True, bool(e.get("isObsolete")), lab
+    except Exception:
+        return None, None, None
+    return False, None, None
+
+
+def validate_curies(path):
+    _, _, data, roles = read_template(path)
+    out, cache = [], {}
+    for r in data:
+        rid = r[0].strip()
+        for key in ("def_source", "xref"):
+            if key not in roles:
+                continue
+            for tok in [x.strip() for x in cell(r, roles[key]).split("|") if x.strip()]:
+                if not re.match(r"^[A-Z][A-Za-z]*:\d+$", tok) or tok.startswith("wikidata"):
+                    continue
+                if tok not in cache:
+                    cache[tok] = ols_lookup(tok)
+                    time.sleep(0.15)
+                found, obs, lab = cache[tok]
+                if found is False:
+                    out.append(Finding("ERROR", "CURIE-LIVE", rid, f"{key} CURIE '{tok}' not found in OLS"))
+                elif obs:
+                    out.append(Finding("ERROR", "CURIE-LIVE", rid, f"{key} CURIE '{tok}' is OBSOLETE ('{lab}')"))
+    return out
+
+
+@click.command()
+@click.argument("template", type=click.Path(exists=True, dir_okay=False))
+@click.option("--known", "known", multiple=True, type=click.Path(exists=True),
+              help="Canonical METPO template(s) for referential checks (repeatable).")
+@click.option("--mode", type=click.Choice(["draft", "submit"]), default="submit",
+              help="submit = enforce definitions/citations (proposal review); draft = relaxed (audit).")
+@click.option("--validate-curies", is_flag=True,
+              help="Networked: check xref/def_source CURIEs resolve and are not obsolete in OLS.")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of text.")
+@click.option("--warn-only", is_flag=True, help="Exit 0 even when ERROR findings are present.")
+def main(template, known, mode, validate_curies, as_json, warn_only):
+    """Lint a METPO ROBOT-template TSV (proposal review or released-content audit)."""
+    external = bool(known)
+    kl, ki = load_known(known) if external else (set(), set())
+    findings, n = lint(template, kl, ki, mode, external)
+    if validate_curies:
+        findings += validate_curies_run(template)
+    errs = [f for f in findings if f.sev == "ERROR"]
+    warns = [f for f in findings if f.sev == "WARN"]
+    if as_json:
+        click.echo(json.dumps({
+            "template": template, "rows": n,
+            "errors": [(f.code, f.rid, f.msg) for f in errs],
+            "warnings": [(f.code, f.rid, f.msg) for f in warns],
+        }, indent=1))
+    else:
+        click.echo(f"# metpo-proposal-lint: {template}  ({n} rows, mode={mode}, known={'yes' if external else 'self'})")
+        for f in sorted(findings, key=lambda x: (x.sev != "ERROR", x.code)):
+            click.echo(f"  [{f.sev:5}] {f.code:13} {f.rid:14} {f.msg}")
+        click.echo(f"\n  {len(errs)} error(s), {len(warns)} warning(s)")
+    raise SystemExit(1 if errs and not warn_only else 0)
+
+
+# alias so --validate-curies flag name doesn't shadow the function inside main()
+validate_curies_run = validate_curies
+
+
+if __name__ == "__main__":
+    main()

--- a/metpo/scripts/metpo_proposal_lint.py
+++ b/metpo/scripts/metpo_proposal_lint.py
@@ -13,36 +13,71 @@ Two modes:
   ``metpo-proposal-lint src/templates/metpo_sheet.tsv --mode draft``
 
 It is meant to run both as a METPO CI gate and as a pre-flight in the generator repos
-(kg-microbe / TraitMech / metpo-kgm-studio) before a proposal PR is opened, which is
-where the "duplicate-check-is-METPO-only" gap currently lives. It catches things the
-ODK build and ELK reasoner cannot: a logically-consistent-but-wrong bin formula (#357),
-scrambled threshold synonyms (#356/#432), mapping CURIEs parked in definition_source
-(#344), and parents that bypass ROBOT's label-resolution safety net via CURIE form.
+(kg-microbe / TraitMech / metpo-kgm-studio) before a proposal PR is opened. It catches
+things the ODK build and ELK reasoner cannot: a logically-consistent-but-wrong bin
+formula (#357), scrambled threshold synonyms (#356/#432), mapping CURIEs parked in
+definition_source (#344), and parents that bypass ROBOT's label-resolution safety net
+via CURIE form.
 
 NOTE: ID-RANGE encodes the current observed convention (classes METPO:1xxxxxx,
 properties METPO:2xxxxxx). The term-IRI scheme is an open question (#16/#434/#436);
 revisit this check when that settles.
 """
+
 import csv
 import json
 import re
 import time
 import urllib.parse
 import urllib.request
+from pathlib import Path
 
 import click
 
 # An OBO/ontology *class* CURIE in definition_source means "mapping", not "source".
 ONTOLOGY_PREFIXES = {
-    "GO", "PATO", "OMP", "MICRO", "CHEBI", "UBERON", "CL", "ENVO", "OBI", "SO",
-    "NCBITaxon", "PO", "FOODON", "UO", "APO", "FYPO", "UPHENO", "ECOCORE", "OHMI",
-    "BFO", "PHIPO", "MP", "HP", "MONDO",
+    "GO",
+    "PATO",
+    "OMP",
+    "MICRO",
+    "CHEBI",
+    "UBERON",
+    "CL",
+    "ENVO",
+    "OBI",
+    "SO",
+    "NCBITaxon",
+    "PO",
+    "FOODON",
+    "UO",
+    "APO",
+    "FYPO",
+    "UPHENO",
+    "ECOCORE",
+    "OHMI",
+    "BFO",
+    "PHIPO",
+    "MP",
+    "HP",
+    "MONDO",
 }
+VALID_TYPES = ("owl:Class", "owl:ObjectProperty", "owl:DataProperty", "owl:AnnotationProperty")
+PROPERTY_TYPES = ("owl:ObjectProperty", "owl:DataProperty", "owl:DatatypeProperty")
 TOL = 0.011  # numeric tolerance for threshold comparison
+
+_SIMPLE_ROLES = {"ID": "id", "LABEL": "label", "TYPE": "type", "DOMAIN": "domain", "RANGE": "range"}
+_NEEDLE_ROLES = (
+    ("IAO:0000115", "definition"),
+    ("IAO:0000119", "def_source"),
+    ("hasDbXref", "xref"),
+    ("owl:deprecated", "deprecated"),
+    ("range_min", "range_min"),
+    ("range_max", "range_max"),
+)
 
 
 class Finding:
-    __slots__ = ("sev", "code", "rid", "msg")
+    __slots__ = ("code", "msg", "rid", "sev")
 
     def __init__(self, sev, code, rid, msg):
         self.sev, self.code, self.rid, self.msg = sev, code, rid, msg
@@ -50,44 +85,30 @@ class Finding:
 
 def read_template(path):
     """Return (labels, directives, data_rows, roles) keyed off the ROBOT directive row."""
-    rows = list(csv.reader(open(path, encoding="utf-8"), delimiter="\t"))
+    with Path(path).open(encoding="utf-8") as fh:
+        rows = list(csv.reader(fh, delimiter="\t"))
     if len(rows) < 2:
         raise click.ClickException(f"{path}: need a label row + a ROBOT directive row")
     labels, directives = rows[0], rows[1]
     data = [r for r in rows[2:] if r and r[0].strip()]
     roles = {"exact_syn": [], "rel_syn": []}
-    for i, d in enumerate(directives):
-        d = d.strip()
-        if d == "ID":
-            roles["id"] = i
-        elif d == "LABEL":
-            roles["label"] = i
-        elif d == "TYPE":
-            roles["type"] = i
-        elif d.startswith("SC") or d.startswith("SP"):
+    for i, raw in enumerate(directives):
+        d = raw.strip()
+        if d in _SIMPLE_ROLES:
+            roles[_SIMPLE_ROLES[d]] = i
+        elif d.startswith(("SC", "SP")):
             roles["parent"] = i
         elif d.startswith("EC"):
             roles["ec"] = i
-        elif "IAO:0000115" in d and "definition" not in roles:
-            roles["definition"] = i
-        elif "IAO:0000119" in d and "def_source" not in roles:
-            roles["def_source"] = i
         elif "hasExactSynonym" in d:
             roles["exact_syn"].append(i)
         elif "hasRelatedSynonym" in d:
             roles["rel_syn"].append(i)
-        elif "hasDbXref" in d:
-            roles["xref"] = i
-        elif "owl:deprecated" in d:
-            roles["deprecated"] = i
-        elif "range_min" in d:
-            roles["range_min"] = i
-        elif "range_max" in d:
-            roles["range_max"] = i
-        elif d == "DOMAIN":
-            roles["domain"] = i
-        elif d == "RANGE":
-            roles["range"] = i
+        else:
+            for needle, key in _NEEDLE_ROLES:
+                if needle in d and key not in roles:
+                    roles[key] = i
+                    break
     return labels, directives, data, roles
 
 
@@ -128,8 +149,7 @@ def parse_bound(formula):
 
 def parse_syn_threshold(v):
     """(lower, upper) from a threshold-encoded synonym (GC_<=42.65, GC_42.65_57.0, TO_10_to_22)."""
-    v = v.strip()
-    m = re.match(r"^[A-Za-z]{1,6}_(.+)$", v)  # require a short prefix code (GC_, TO_, ...)
+    m = re.match(r"^[A-Za-z]{1,6}_(.+)$", v.strip())
     if not m:
         return (None, None)
     body = m.group(1)
@@ -145,126 +165,204 @@ def parse_syn_threshold(v):
     return (None, None)
 
 
-def lint(path, known_labels, known_ids, mode, external_known):
-    labels, directives, data, roles = read_template(path)
+def check_id_type(rid, typ, is_metpo):
+    """ID-RANGE + TYPE-VOCAB for a non-deprecated row."""
     out = []
+    if is_metpo:
+        m = re.match(r"^METPO:(\d)\d{6}$", rid)
+        isprop = typ in PROPERTY_TYPES
+        if not m:
+            out.append(Finding("ERROR", "ID-RANGE", rid, "METPO ID is not 7 digits"))
+        elif isprop and m.group(1) != "2":
+            out.append(Finding("ERROR", "ID-RANGE", rid, "property ID must be METPO:2xxxxxx"))
+        elif not isprop and m.group(1) != "1":
+            out.append(Finding("ERROR", "ID-RANGE", rid, "class ID must be METPO:1xxxxxx"))
+    if typ == "owl:DatatypeProperty":
+        out.append(
+            Finding(
+                "ERROR",
+                "TYPE-VOCAB",
+                rid,
+                "use 'owl:DataProperty' (METPO house style), not 'owl:DatatypeProperty'",
+            )
+        )
+    elif typ not in VALID_TYPES:
+        out.append(Finding("ERROR", "TYPE-VOCAB", rid, f"unexpected TYPE '{typ}'"))
+    return out
+
+
+def check_parent(rid, parent_cell, resolve_ids, resolve_labels):
+    out = []
+    for p in [x.strip() for x in parent_cell.split("|") if x.strip()]:
+        if p == "METPO:1000000":
+            out.append(
+                Finding(
+                    "ERROR",
+                    "PARENT",
+                    rid,
+                    "parent 'METPO:1000000' is the nonexistent/over-general root",
+                )
+            )
+        elif re.match(r"^METPO:\d+$", p):
+            out.append(
+                Finding(
+                    "WARN",
+                    "HOUSE-STYLE",
+                    rid,
+                    f"parent given as CURIE '{p}'; sheet convention is parent-by-label "
+                    "(CURIE parents also bypass ROBOT's label-resolution safety net)",
+                )
+            )
+            if p not in resolve_ids:
+                out.append(Finding("ERROR", "PARENT", rid, f"parent CURIE '{p}' does not resolve"))
+        elif p not in resolve_labels:
+            out.append(
+                Finding(
+                    "ERROR", "PARENT", rid, f"parent label '{p}' does not resolve to a known class"
+                )
+            )
+    return out
+
+
+def check_definition(rid, r, roles, mode):
+    out = []
+    if "definition" in roles and not cell(r, roles["definition"]) and mode == "submit":
+        out.append(Finding("ERROR", "DEF-MISSING", rid, "empty definition"))
+    if "def_source" not in roles:
+        return out
+    toks = [x.strip() for x in cell(r, roles["def_source"]).split("|") if x.strip()]
+    if not toks and mode == "submit":
+        out.append(Finding("ERROR", "SRC-MISSING", rid, "empty definition_source"))
+    for tok in toks:
+        pm = re.match(r"^([A-Za-z][A-Za-z0-9]*):", tok)
+        if tok == "TODO:add_citation":
+            if mode == "submit":
+                out.append(
+                    Finding("ERROR", "SRC-MISSING", rid, "definition_source is TODO:add_citation")
+                )
+        elif pm and pm.group(1) in ONTOLOGY_PREFIXES:
+            out.append(
+                Finding(
+                    "ERROR",
+                    "SRC-ISMAP",
+                    rid,
+                    f"ontology-class CURIE '{tok}' in definition_source; belongs in a "
+                    "mapping predicate (skos:* / oboInOwl:hasDbXref)",
+                )
+            )
+    return out
+
+
+def row_bounds(r, roles):
+    """Authoritative numeric bounds for a row: EC formula preferred, then range_min/max."""
+    alo, aup = parse_bound(cell(r, roles.get("ec")))
+    if alo is None:
+        alo = fnum(cell(r, roles.get("range_min")))
+    if aup is None:
+        aup = fnum(cell(r, roles.get("range_max")))
+    return alo, aup
+
+
+def check_formula_synonym(rid, label_text, r, roles, alo, aup):
+    out = []
+    ec = cell(r, roles.get("ec"))
+    if ec:
+        flo, fup = parse_bound(ec)
+        if re.search(r"\b(high|maximum|max)\b", label_text) and flo is None and fup is not None:
+            out.append(
+                Finding(
+                    "ERROR",
+                    "FORMULA-DIR",
+                    rid,
+                    f"label says high/max but formula only bounds <= {fup}; expected a lower bound (>=)",
+                )
+            )
+        if re.search(r"\b(low|minimum|min)\b", label_text) and fup is None and flo is not None:
+            out.append(
+                Finding(
+                    "ERROR",
+                    "FORMULA-DIR",
+                    rid,
+                    f"label says low/min but formula only bounds >= {flo}; expected an upper bound (<=)",
+                )
+            )
+    if alo is None and aup is None:
+        return out
+    for i in roles["exact_syn"] + roles["rel_syn"]:
+        slo, sup = parse_syn_threshold(cell(r, i))
+        if slo is None and sup is None:
+            continue
+        bad = None
+        if slo is not None and alo is not None and abs(slo - alo) > TOL:
+            bad = f"synonym lower {slo} != bound {alo}"
+        elif sup is not None and aup is not None and abs(sup - aup) > TOL:
+            bad = f"synonym upper {sup} != bound {aup}"
+        elif sup is not None and alo is not None and sup < alo - TOL:
+            bad = f"synonym ceiling {sup} below bin floor {alo} (contradiction)"
+        elif slo is not None and aup is not None and slo > aup + TOL:
+            bad = f"synonym floor {slo} above bin ceiling {aup} (contradiction)"
+        if bad:
+            out.append(
+                Finding("ERROR", "SYN-THRESHOLD", rid, f"'{cell(r, i)}' vs formula/range: {bad}")
+            )
+            break
+    return out
+
+
+def check_synonym_scope(rid, r, roles):
+    out = []
+    for i in roles["exact_syn"]:
+        for v in [x.strip() for x in cell(r, i).split("|") if x.strip()]:
+            if "/" in v or re.search(r"[A-Za-z0-9_]+\.[A-Za-z0-9_.]+", v):
+                out.append(
+                    Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' looks like a DB field path")
+                )
+            elif v.lower() in ("yes", "no", "true", "false"):
+                out.append(
+                    Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' is a boolean encoding")
+                )
+            elif re.match(r"^[0-9.]+$", v):
+                out.append(Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' is a bare number"))
+    return out
+
+
+def lint(path, known_labels, known_ids, mode, external_known):
+    _, _, data, roles = read_template(path)
     has_type = "type" in roles
     batch_ids = {r[0].strip() for r in data if r[0].startswith("METPO:")}
     batch_labels = {cell(r, roles.get("label")) for r in data}
     resolve_ids = known_ids | batch_ids
     resolve_labels = known_labels | batch_labels
-    seen = set()
+    out, seen = [], set()
     for r in data:
         rid = r[0].strip()
-        L = cell(r, roles.get("label"))
+        label_text = cell(r, roles.get("label"))
         typ = cell(r, roles.get("type")) if has_type else "owl:Class"
-        deprecated = cell(r, roles.get("deprecated")).lower() == "true"
-        # ID-DUP (always, even for deprecated/imported)
         if rid in seen:
             out.append(Finding("ERROR", "ID-DUP", rid, "duplicate ID within file"))
         if external_known and rid in known_ids:
             out.append(Finding("ERROR", "ID-DUP", rid, "ID already exists in canonical METPO"))
         seen.add(rid)
-        # Deprecated rows are historical: only ID-DUP applies.
-        if deprecated:
-            continue
-        is_metpo = rid.startswith("METPO:")
-        # ID-RANGE (METPO-namespace ids only; external declarations like IAO: are imports)
-        if is_metpo:
-            m = re.match(r"^METPO:(\d)\d{6}$", rid)
-            isprop = typ in ("owl:ObjectProperty", "owl:DataProperty", "owl:DatatypeProperty")
-            if not m:
-                out.append(Finding("ERROR", "ID-RANGE", rid, "METPO ID is not 7 digits"))
-            elif isprop and m.group(1) != "2":
-                out.append(Finding("ERROR", "ID-RANGE", rid, "property ID must be METPO:2xxxxxx"))
-            elif not isprop and m.group(1) != "1":
-                out.append(Finding("ERROR", "ID-RANGE", rid, "class ID must be METPO:1xxxxxx"))
-        # TYPE-VOCAB
-        if typ == "owl:DatatypeProperty":
-            out.append(Finding("ERROR", "TYPE-VOCAB", rid,
-                               "use 'owl:DataProperty' (METPO house style), not 'owl:DatatypeProperty'"))
-        elif typ not in ("owl:Class", "owl:ObjectProperty", "owl:DataProperty", "owl:AnnotationProperty"):
-            out.append(Finding("ERROR", "TYPE-VOCAB", rid, f"unexpected TYPE '{typ}'"))
-        # PARENT
-        for p in [x.strip() for x in cell(r, roles.get("parent")).split("|") if x.strip()]:
-            if p == "METPO:1000000":
-                out.append(Finding("ERROR", "PARENT", rid, "parent 'METPO:1000000' is the nonexistent/over-general root"))
-            elif re.match(r"^METPO:\d+$", p):
-                out.append(Finding("WARN", "HOUSE-STYLE", rid,
-                                   f"parent given as CURIE '{p}'; sheet convention is parent-by-label "
-                                   "(CURIE parents also bypass ROBOT's label-resolution safety net)"))
-                if p not in resolve_ids:
-                    out.append(Finding("ERROR", "PARENT", rid, f"parent CURIE '{p}' does not resolve"))
-            elif p not in resolve_labels:
-                out.append(Finding("ERROR", "PARENT", rid, f"parent label '{p}' does not resolve to a known class"))
-        # DEFINITION / SOURCE
-        if "definition" in roles and not cell(r, roles["definition"]) and mode == "submit":
-            out.append(Finding("ERROR", "DEF-MISSING", rid, "empty definition"))
-        if "def_source" in roles:
-            src = cell(r, roles["def_source"])
-            toks = [x.strip() for x in src.split("|") if x.strip()]
-            if (not toks) and mode == "submit":
-                out.append(Finding("ERROR", "SRC-MISSING", rid, "empty definition_source"))
-            for tok in toks:
-                pm = re.match(r"^([A-Za-z][A-Za-z0-9]*):", tok)
-                if tok == "TODO:add_citation":
-                    if mode == "submit":
-                        out.append(Finding("ERROR", "SRC-MISSING", rid, "definition_source is TODO:add_citation"))
-                elif pm and pm.group(1) in ONTOLOGY_PREFIXES:
-                    out.append(Finding("ERROR", "SRC-ISMAP", rid,
-                                       f"ontology-class CURIE '{tok}' in definition_source; belongs in a "
-                                       "mapping predicate (skos:* / oboInOwl:hasDbXref)"))
-        # authoritative numeric bounds for this row (EC preferred, then range_min/max)
-        alo, aup = parse_bound(cell(r, roles.get("ec")))
-        if alo is None:
-            alo = fnum(cell(r, roles.get("range_min")))
-        if aup is None:
-            aup = fnum(cell(r, roles.get("range_max")))
-        # FORMULA-DIR
-        ec = cell(r, roles.get("ec"))
-        if ec:
-            flo, fup = parse_bound(ec)
-            if re.search(r"\b(high|maximum|max)\b", L) and flo is None and fup is not None:
-                out.append(Finding("ERROR", "FORMULA-DIR", rid,
-                                   f"label says high/max but formula only bounds <= {fup}; expected a lower bound (>=)"))
-            if re.search(r"\b(low|minimum|min)\b", L) and fup is None and flo is not None:
-                out.append(Finding("ERROR", "FORMULA-DIR", rid,
-                                   f"label says low/min but formula only bounds >= {flo}; expected an upper bound (<=)"))
-        # SYN-THRESHOLD: synonym-encoded thresholds must agree with the row's own bounds
-        if alo is not None or aup is not None:
-            for i in (roles["exact_syn"] + roles["rel_syn"]):
-                slo, sup = parse_syn_threshold(cell(r, i))
-                if slo is None and sup is None:
-                    continue
-                bad = None
-                if slo is not None and alo is not None and abs(slo - alo) > TOL:
-                    bad = f"synonym lower {slo} != bound {alo}"
-                elif sup is not None and aup is not None and abs(sup - aup) > TOL:
-                    bad = f"synonym upper {sup} != bound {aup}"
-                elif sup is not None and alo is not None and sup < alo - TOL:
-                    bad = f"synonym ceiling {sup} below bin floor {alo} (contradiction)"
-                elif slo is not None and aup is not None and slo > aup + TOL:
-                    bad = f"synonym floor {slo} above bin ceiling {aup} (contradiction)"
-                if bad:
-                    out.append(Finding("ERROR", "SYN-THRESHOLD", rid, f"'{cell(r, i)}' vs formula/range: {bad}"))
-                    break
-        # SYN-SCOPE (ontology-native synonym columns only)
-        for i in roles["exact_syn"]:
-            for v in [x.strip() for x in cell(r, i).split("|") if x.strip()]:
-                if "/" in v or re.search(r"[A-Za-z0-9_]+\.[A-Za-z0-9_.]+", v):
-                    out.append(Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' looks like a DB field path"))
-                elif v.lower() in ("yes", "no", "true", "false"):
-                    out.append(Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' is a boolean encoding"))
-                elif re.match(r"^[0-9.]+$", v):
-                    out.append(Finding("WARN", "SYN-SCOPE", rid, f"synonym '{v}' is a bare number"))
+        if cell(r, roles.get("deprecated")).lower() == "true":
+            continue  # deprecated rows are historical: only ID-DUP applies
+        out += check_id_type(rid, typ, rid.startswith("METPO:"))
+        out += check_parent(rid, cell(r, roles.get("parent")), resolve_ids, resolve_labels)
+        out += check_definition(rid, r, roles, mode)
+        alo, aup = row_bounds(r, roles)
+        out += check_formula_synonym(rid, label_text, r, roles, alo, aup)
+        out += check_synonym_scope(rid, r, roles)
     return out, len(data)
 
 
 def ols_lookup(curie):
-    url = "https://www.ebi.ac.uk/ols4/api/v2/entities?" + urllib.parse.urlencode({"search": curie, "size": 10})
+    url = "https://www.ebi.ac.uk/ols4/api/v2/entities?" + urllib.parse.urlencode(
+        {"search": curie, "size": 10}
+    )
     try:
-        req = urllib.request.Request(url, headers={"Accept": "application/json",
-                                                   "User-Agent": "metpo-lint/1.0 (MAM@lbl.gov)"})
+        req = urllib.request.Request(
+            url,
+            headers={"Accept": "application/json", "User-Agent": "metpo-lint/1.0 (MAM@lbl.gov)"},
+        )
         with urllib.request.urlopen(req, timeout=30) as resp:
             for e in json.load(resp).get("elements", []):
                 if e.get("curie") == curie:
@@ -292,47 +390,70 @@ def validate_curies(path):
                     time.sleep(0.15)
                 found, obs, lab = cache[tok]
                 if found is False:
-                    out.append(Finding("ERROR", "CURIE-LIVE", rid, f"{key} CURIE '{tok}' not found in OLS"))
+                    out.append(
+                        Finding("ERROR", "CURIE-LIVE", rid, f"{key} CURIE '{tok}' not found in OLS")
+                    )
                 elif obs:
-                    out.append(Finding("ERROR", "CURIE-LIVE", rid, f"{key} CURIE '{tok}' is OBSOLETE ('{lab}')"))
+                    out.append(
+                        Finding(
+                            "ERROR", "CURIE-LIVE", rid, f"{key} CURIE '{tok}' is OBSOLETE ('{lab}')"
+                        )
+                    )
     return out
 
 
 @click.command()
 @click.argument("template", type=click.Path(exists=True, dir_okay=False))
-@click.option("--known", "known", multiple=True, type=click.Path(exists=True),
-              help="Canonical METPO template(s) for referential checks (repeatable).")
-@click.option("--mode", type=click.Choice(["draft", "submit"]), default="submit",
-              help="submit = enforce definitions/citations (proposal review); draft = relaxed (audit).")
-@click.option("--validate-curies", is_flag=True,
-              help="Networked: check xref/def_source CURIEs resolve and are not obsolete in OLS.")
+@click.option(
+    "--known",
+    "known",
+    multiple=True,
+    type=click.Path(exists=True),
+    help="Canonical METPO template(s) for referential checks (repeatable).",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["draft", "submit"]),
+    default="submit",
+    help="submit = enforce definitions/citations (proposal review); draft = relaxed (audit).",
+)
+@click.option(
+    "--validate-curies",
+    "do_validate_curies",
+    is_flag=True,
+    help="Networked: check xref/def_source CURIEs resolve and are not obsolete in OLS.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of text.")
 @click.option("--warn-only", is_flag=True, help="Exit 0 even when ERROR findings are present.")
-def main(template, known, mode, validate_curies, as_json, warn_only):
+def main(template, known, mode, do_validate_curies, as_json, warn_only):
     """Lint a METPO ROBOT-template TSV (proposal review or released-content audit)."""
     external = bool(known)
     kl, ki = load_known(known) if external else (set(), set())
     findings, n = lint(template, kl, ki, mode, external)
-    if validate_curies:
-        findings += validate_curies_run(template)
+    if do_validate_curies:
+        findings += validate_curies(template)
     errs = [f for f in findings if f.sev == "ERROR"]
     warns = [f for f in findings if f.sev == "WARN"]
     if as_json:
-        click.echo(json.dumps({
-            "template": template, "rows": n,
-            "errors": [(f.code, f.rid, f.msg) for f in errs],
-            "warnings": [(f.code, f.rid, f.msg) for f in warns],
-        }, indent=1))
+        click.echo(
+            json.dumps(
+                {
+                    "template": str(template),
+                    "rows": n,
+                    "errors": [(f.code, f.rid, f.msg) for f in errs],
+                    "warnings": [(f.code, f.rid, f.msg) for f in warns],
+                },
+                indent=1,
+            )
+        )
     else:
-        click.echo(f"# metpo-proposal-lint: {template}  ({n} rows, mode={mode}, known={'yes' if external else 'self'})")
+        click.echo(
+            f"# metpo-proposal-lint: {template}  ({n} rows, mode={mode}, known={'yes' if external else 'self'})"
+        )
         for f in sorted(findings, key=lambda x: (x.sev != "ERROR", x.code)):
             click.echo(f"  [{f.sev:5}] {f.code:13} {f.rid:14} {f.msg}")
         click.echo(f"\n  {len(errs)} error(s), {len(warns)} warning(s)")
     raise SystemExit(1 if errs and not warn_only else 0)
-
-
-# alias so --validate-curies flag name doesn't shadow the function inside main()
-validate_curies_run = validate_curies
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ iterative-definition-improvement = "metpo.scripts.iterative_definition_improveme
 
 # Quality Control
 audit-id-allocation = "metpo.scripts.audit_id_allocation:main"
+metpo-proposal-lint = "metpo.scripts.metpo_proposal_lint:main"
 generate-deprecated-template = "metpo.scripts.generate_deprecated_template:main"
 diff-templates = "metpo.scripts.diff_templates:main"
 qc-metpo-sheets = "metpo.scripts.qc_metpo_sheets:main"

--- a/tests/test_metpo_proposal_lint.py
+++ b/tests/test_metpo_proposal_lint.py
@@ -1,0 +1,104 @@
+"""Tests for the metpo-proposal-lint QC tool."""
+
+from click.testing import CliRunner
+
+from metpo.scripts.metpo_proposal_lint import (
+    fnum,
+    lint,
+    main,
+    parse_bound,
+    parse_syn_threshold,
+)
+
+# A minimal classes ROBOT template (row 1 labels, row 2 directives) exercising each check.
+TEMPLATE = (
+    "ID\tlabel\tTYPE\tparent\tdefinition\tdef_source\tformula\trange_min\trange_max\tsyn\n"
+    "ID\tLABEL\tTYPE\tSC %\tA IAO:0000115\t>A IAO:0000119\tEC %\tA METPO:range_min\tA METPO:range_max\tA oboInOwl:hasExactSynonym\n"
+    "METPO:1007001\tgood term\towl:Class\tphenotype\tA phenotype that is good.\tPMID:1\t\t\t\t\n"
+    "METPO:1007002\tbad parent\towl:Class\tMETPO:1000000\tA phenotype.\tPMID:1\t\t\t\t\n"
+    "METPO:1007003\ttemperature high\towl:Class\tphenotype\tA phenotype.\tPMID:1\t'x' and 'METPO:2000071' some xsd:decimal[<= 8]\t\t\t\n"
+    "METPO:1007004\tgc high\towl:Class\tphenotype\tA phenotype.\tPMID:1\t\t66.3\t\tGC_<=42.65\n"
+    "METPO:2000099\tbad type\towl:DatatypeProperty\tphenotype\tA relation.\tPMID:1\t\t\t\t\n"
+    "METPO:1007005\tno cite\towl:Class\tphenotype\t\t\t\t\t\t\n"
+    "METPO:1007006\tmaps in source\towl:Class\tphenotype\tA phenotype.\tGO:0009399\t\t\t\t\n"
+)
+
+
+def _write(tmp_path):
+    p = tmp_path / "proposal.tsv"
+    p.write_text(TEMPLATE, encoding="utf-8")
+    return p
+
+
+def _codes(tmp_path, mode):
+    findings, _ = lint(str(_write(tmp_path)), {"phenotype"}, set(), mode, external_known=False)
+    by_id = {}
+    for f in findings:
+        by_id.setdefault(f.rid, set()).add(f.code)
+    return by_id
+
+
+def test_fnum():
+    assert fnum("37.0") == 37.0
+    assert fnum("1.2.3") is None  # regression: must not raise ValueError
+    assert fnum("") is None
+    assert fnum("abc") is None
+
+
+def test_parse_bound():
+    assert parse_bound("xsd:decimal[>= 40]") == (40.0, None)
+    assert parse_bound("xsd:decimal[>= 10, <= 22]") == (10.0, 22.0)
+    assert parse_bound("xsd:decimal[<= 8]") == (None, 8.0)
+    assert parse_bound("") == (None, None)
+
+
+def test_parse_syn_threshold_prefixed():
+    assert parse_syn_threshold("GC_<=42.65") == (None, 42.65)
+    assert parse_syn_threshold("GC_>66.3") == (66.3, None)
+    assert parse_syn_threshold("GC_42.65_57.0") == (42.65, 57.0)
+    assert parse_syn_threshold("TO_10_to_22") == (10.0, 22.0)
+    assert parse_syn_threshold("TO_>40") == (40.0, None)
+
+
+def test_parse_syn_threshold_prefixless():
+    # pH-range synonyms drop their pHR_ prefix; must still parse (Copilot #452 review)
+    assert parse_syn_threshold("10_to_14") == (10.0, 14.0)
+    assert parse_syn_threshold("8_to_10") == (8.0, 10.0)
+
+
+def test_parse_syn_threshold_rejects_nonthreshold():
+    assert parse_syn_threshold("Ox_microaerophile") == (None, None)
+    assert parse_syn_threshold("rod-shaped") == (None, None)
+    assert parse_syn_threshold("") == (None, None)
+
+
+def test_lint_submit_mode(tmp_path):
+    codes = _codes(tmp_path, "submit")
+    assert "PARENT" in codes["METPO:1007002"]  # parent METPO:1000000
+    assert "FORMULA-DIR" in codes["METPO:1007003"]  # 'high' label, only upper bound
+    assert "SYN-THRESHOLD" in codes["METPO:1007004"]  # GC_<=42.65 contradicts range_min 66.3
+    assert "TYPE-VOCAB" in codes["METPO:2000099"]  # owl:DatatypeProperty
+    assert "SRC-MISSING" in codes["METPO:1007005"]  # empty def_source
+    assert "DEF-MISSING" in codes["METPO:1007005"]  # empty definition
+    assert "SRC-ISMAP" in codes["METPO:1007006"]  # GO CURIE in def_source
+    assert "METPO:1007001" not in codes  # clean row produces nothing
+
+
+def test_lint_draft_relaxes_citations(tmp_path):
+    codes = _codes(tmp_path, "draft")
+    # draft mode must not require definitions/citations...
+    assert "METPO:1007005" not in codes
+    # ...but structural/value defects still fire
+    assert "SYN-THRESHOLD" in codes["METPO:1007004"]
+    assert "PARENT" in codes["METPO:1007002"]
+
+
+def test_cli_exits_nonzero_on_errors(tmp_path):
+    result = CliRunner().invoke(main, [str(_write(tmp_path)), "--mode", "draft"])
+    assert result.exit_code == 1
+    assert "error(s)" in result.output
+
+
+def test_cli_warn_only_exits_zero(tmp_path):
+    result = CliRunner().invoke(main, [str(_write(tmp_path)), "--mode", "draft", "--warn-only"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Why

Implements the deterministic guardrail track of #433. The ODK build and ELK reasoner cannot catch most METPO content defects, because they are logically consistent but factually wrong: an inverted bin formula, scrambled threshold synonyms, and ontology CURIEs parked in `definition_source` all build green. This adds a linter that fails on them, and that can also run as a pre-flight in the upstream proposal generators.

## What it catches (validated against the live sheet)

- **FORMULA-DIR** — #357: `METPO:1000482 'NaCl delta high'` bounds `<= 8`, should be `>= 8`.
- **SYN-THRESHOLD** — #356/#432: GC bins `METPO:1000429/1000430/1000432` have synonyms that disagree with their own formula/range bounds.
- **SRC-ISMAP** — #344: ontology-class CURIEs in `definition_source` (229 rows) that belong in a mapping predicate.
- Plus `TYPE-VOCAB`, `PARENT` (phantom/root), `HOUSE-STYLE` (CURIE parents, which also bypass ROBOT's label-resolution safety net), `SRC-MISSING`, `SYN-SCOPE`, and networked `CURIE-LIVE`.

Schema-aware (keys off the ROBOT directive row), deprecated/import-aware. Two modes: **review** a proposal TSV (`--known canonical.tsv --mode submit`) or **audit** released content (`--mode draft`).

`docs/quantitative_modeling.md` documents the class/property/both policy for quantitative growth traits (#228) that the formula/synonym checks enforce.

## Open items for the reviewer (not blockers)

- **Overlaps `qc-metpo-sheets`** on ID-clash/parent checks (that tool runs against the live downloaded sheet; this one lints arbitrary TSVs incl. proposals). Consolidation (fold the value-level checks into `qc_metpo_sheets.py` vs keep both) is a pending decision; this PR does **not** touch `qc_metpo_sheets.py`.
- **ID-RANGE** encodes the current `1xxxxxx`/`2xxxxxx` convention; revisit per the term-IRI scheme decision (#434/#436).
- **Makefile/CI wiring** is a deliberate follow-up, pending the consolidation decision above.

This PR adds the tool only; the content bugs it surfaces (#356/#357/#432) are fixed in the Google Sheet, not here.

🤖 Generated with Claude Code
