### PR TITLE
Resolve CodeQL code-quality findings + metpo-edit.owl whitespace

### DIFF
--- a/metpo/analysis/analyze_ontology_value.py
+++ b/metpo/analysis/analyze_ontology_value.py
@@ -194,7 +194,6 @@ def main(input):
     removal_candidates = []
     for _, row in only_imported.iterrows():
         ont_file = row["ontology_file"]
-        df[df["object_source"] == ont_file]
 
         # Check if ALL terms are available natively elsewhere
         all_redundant = True

--- a/metpo/database/filter_ols_chromadb.py
+++ b/metpo/database/filter_ols_chromadb.py
@@ -49,6 +49,7 @@ def main(input_path, input_collection, output_path, output_collection, batch_siz
         output_client.delete_collection(name=output_collection)
         print(f"  Deleted existing collection: {output_collection}")
     except Exception:
+        # Collection may not exist yet (e.g. first run); nothing to delete.
         pass
 
     output_coll = output_client.create_collection(

--- a/metpo/literature_mining/analysis/metpo_assessor.py
+++ b/metpo/literature_mining/analysis/metpo_assessor.py
@@ -1023,6 +1023,7 @@ class MetpoAssessor:
                     if isinstance(data, dict) and "content" in data:
                         return data["content"]
                 except yaml.YAMLError:
+                    # Not valid YAML either; fall through and return the raw input text.
                     pass
                 return input_text
         elif isinstance(input_text, dict):

--- a/metpo/presentations/analyze_ontogpt_grounding.py
+++ b/metpo/presentations/analyze_ontogpt_grounding.py
@@ -132,4 +132,4 @@ def main():
 
 
 if __name__ == "__main__":
-    totals, per_file = main()
+    main()

--- a/metpo/scripts/audit_metatraits_substrate_curies.py
+++ b/metpo/scripts/audit_metatraits_substrate_curies.py
@@ -330,18 +330,10 @@ def _report_sections(rows: list[AuditRow]) -> list[str]:
         [
             "## Related Files\n",
             "\n",
-            "- [`docs/casamino_acids_curie_mapping_case_study.md`]"
-            "(../../docs/casamino_acids_curie_mapping_case_study.md) "
-            "-- CHEBI:78020 error case study\n",
-            "- [`docs/linkml_embedding_and_validation_tools.md`]"
-            "(../../docs/linkml_embedding_and_validation_tools.md) "
-            "-- OAK/linkml-store tooling research\n",
-            "- [`data/mappings/metatraits_in_sheet_resolution.tsv`]"
-            "(metatraits_in_sheet_resolution.tsv) "
-            "-- in-sheet resolution table\n",
-            "- [`data/mappings/metatraits_external_curie_coverage.tsv`]"
-            "(metatraits_external_curie_coverage.tsv) "
-            "-- external CURIE coverage\n",
+            "- [`docs/casamino_acids_curie_mapping_case_study.md`](../../docs/casamino_acids_curie_mapping_case_study.md) -- CHEBI:78020 error case study\n",
+            "- [`docs/linkml_embedding_and_validation_tools.md`](../../docs/linkml_embedding_and_validation_tools.md) -- OAK/linkml-store tooling research\n",
+            "- [`data/mappings/metatraits_in_sheet_resolution.tsv`](metatraits_in_sheet_resolution.tsv) -- in-sheet resolution table\n",
+            "- [`data/mappings/metatraits_external_curie_coverage.tsv`](metatraits_external_curie_coverage.tsv) -- external CURIE coverage\n",
         ]
     )
 

--- a/metpo/tools/make_bacdive_utilization_enum.py
+++ b/metpo/tools/make_bacdive_utilization_enum.py
@@ -140,22 +140,6 @@ def convert_tsv_to_linkml_enum(
             "meaning": id_uri
         }
 
-        # # Add description if we have bacdive key info
-        # if pd.notna(row['bacdive key']) and row['bacdive key']:
-        #     bacdive_key = row['bacdive key']
-        #     description_parts = [f"Relationship type: {bacdive_key}"]
-        #
-        #     # Add count if available
-        #     if pd.notna(row['bacdive count']) and str(row['bacdive count']).isdigit():
-        #         count = int(row['bacdive count'])
-        #         description_parts.append(f"BacDive occurrences: {count:,}")
-        #
-        #     # Add notes if available
-        #     if pd.notna(row['notes']) and row['notes']:
-        #         description_parts.append(f"Notes: {row['notes']}")
-        #
-        #     pv_entry['description'] = '; '.join(description_parts)
-
         # Add to permissible values
         linkml_enum["enums"][enum_name]["permissible_values"][key] = pv_entry
 

--- a/src/ontology/metpo-edit.owl
+++ b/src/ontology/metpo-edit.owl
@@ -51,7 +51,7 @@ AnnotationAssertion(rdfs:label dcterms:title "title")
 
 # Annotation Property: IAO:0000117 (term editor)
 
- AnnotationAssertion(rdfs:label IAO:0000117 "term editor")
+AnnotationAssertion(rdfs:label IAO:0000117 "term editor")
 
 
 ############################
@@ -71,8 +71,8 @@ AnnotationAssertion(rdfs:label dcterms:title "title")
 
 # Annotation Property: <http://qudt.org/schema/qudt/ucumCode> (UCUM code)
 
- AnnotationAssertion(rdfs:label <http://qudt.org/schema/qudt/ucumCode> "UCUM code")
- AnnotationAssertion(rdfs:comment <http://qudt.org/schema/qudt/ucumCode> "A UCUM code that identifies a unit of measure.")
+AnnotationAssertion(rdfs:label <http://qudt.org/schema/qudt/ucumCode> "UCUM code")
+AnnotationAssertion(rdfs:comment <http://qudt.org/schema/qudt/ucumCode> "A UCUM code that identifies a unit of measure.")
 
 
 )


### PR DESCRIPTION
## Why

Resolves the open CodeQL "standard findings" and the `metpo-edit.owl` AI findings from the Security & quality scan.

## CodeQL standard findings
- `audit_metatraits_substrate_curies.py`: implicit string concatenation in a list → single-line literals (removes missing-comma ambiguity).
- `filter_ols_chromadb.py`, `metpo_assessor.py`: explanatory comments added to the bare `except` clauses.
- `analyze_ontogpt_grounding.py`: dropped the unused `totals, per_file` unpacking at the `__main__` guard.
- `make_bacdive_utilization_enum.py`: removed a commented-out description block.
- `analyze_ontology_value.py`: removed a dead filter expression that had no effect.

## AI findings
- `src/ontology/metpo-edit.owl`: removed inconsistent leading whitespace before `AnnotationAssertion` declarations.

## Deliberately handled elsewhere
The `metpo_sheet.tsv` content findings are not in this PR: corrections (GC wording, `quality` definition source, the NaCl-delta formula direction) go through the **Google Sheet** (source of truth); and the `branced` upstream value + the cross-ontology correction-note comments are **retained intentionally** (verbatim upstream source / valuable provenance).

Verified locally: `ruff check .`, `ruff format --check`, and `pytest` (26 passed) all green; no new mypy errors.

🤖 Generated with Claude Code
