### PR TITLE
Add CODEOWNERS (closes #417)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS for berkeleybop/metpo
+# Auto-requests review from the owner when a PR touches their area.
+# Start with a single owner; expand as collaborators take on specific areas.
+# See https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything
+*                             @turbomam
+
+# Ontology editing / templates
+/src/ontology/                @turbomam
+/src/templates/               @turbomam
+
+# Python package
+/metpo/                       @turbomam
+
+# Literature mining
+/literature_mining/           @turbomam
+
+# CI / workflows
+/.github/                     @turbomam


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with @turbomam as default owner for all paths (per #417's suggested structure), so PRs auto-request the owner's review. Expand with additional owners as collaborators take on areas; once populated, the 'require code-owner reviews' branch-protection toggle can be enabled.

Closes #417.

🤖 Generated with Claude Code