### PR TITLE
Finalize w3id IRI scheme: collapse version-IRI doubling (#436), declare w3id canonical (#435)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ METPO releases are available from multiple sources:
 
 Editors of this ontology should use the edit version, [src/ontology/metpo-edit.owl](src/ontology/metpo-edit.owl)
 
+## Identifiers and resolution
+
+The canonical IRI for every METPO term is under the `https://w3id.org/metpo/` namespace, with a bare 7-digit local identifier:
+
+- Term IRI: `https://w3id.org/metpo/<id>` (e.g. `https://w3id.org/metpo/1000482`)
+- The ontology prefix `METPO:` expands to `https://w3id.org/metpo/`
+- Ontology document IRI: `https://w3id.org/metpo.owl` (release products and version IRIs live under `https://w3id.org/metpo/`, e.g. `https://w3id.org/metpo/releases/<date>/metpo.owl`)
+
+**Do not use `http://purl.obolibrary.org/obo/METPO_<id>`.** METPO is not registered in the OBO Foundry, so those PURLs do not resolve (HTTP 404) and are not METPO identifiers. `https://w3id.org/` is the only canonical resolution base for METPO. (Term-IRI resolution behavior is still being finalized; see issues #450 and #435.)
+
 ## Contact
 
 Please use this GitHub repository's [Issue tracker](https://github.com/berkeleybop/metpo/issues) to request new terms/classes or report errors or specific concerns related to the ontology.

--- a/metpo-base.json
+++ b/metpo-base.json
@@ -1,6 +1,6 @@
 {
   "graphs" : [ {
-    "id" : "https://w3id.org/metpo/metpo/metpo-base.json",
+    "id" : "https://w3id.org/metpo/metpo-base.json",
     "meta" : {
       "basicPropertyValues" : [ {
         "pred" : "http://purl.org/dc/elements/1.1/type",
@@ -39,7 +39,7 @@
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
         "val" : "2026-06-02"
       } ],
-      "version" : "https://w3id.org/metpo/metpo/releases/2026-06-02/metpo-base.json"
+      "version" : "https://w3id.org/metpo/releases/2026-06-02/metpo-base.json"
     },
     "nodes" : [ {
       "id" : "http://purl.org/dc/elements/1.1/type",

--- a/metpo-base.obo
+++ b/metpo-base.obo
@@ -1,8 +1,8 @@
 format-version: 1.2
-data-version: https://w3id.org/metpo/metpo/releases/2026-06-02/metpo-base.owl
+data-version: https://w3id.org/metpo/releases/2026-06-02/metpo-base.owl
 idspace: dce http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
-ontology: https://w3id.org/metpo/metpo/metpo-base.owl
+ontology: https://w3id.org/metpo/metpo-base.owl
 property_value: dce:type IAO:8000001
 property_value: dcterms:contributor https://orcid.org/0000-0001-9076-6066
 property_value: dcterms:creator "METPO Development Team" xsd:string

--- a/metpo-base.owl
+++ b/metpo-base.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="https://w3id.org/metpo/metpo/metpo-base.owl#"
-     xml:base="https://w3id.org/metpo/metpo/metpo-base.owl"
+<rdf:RDF xmlns="https://w3id.org/metpo/metpo-base.owl#"
+     xml:base="https://w3id.org/metpo/metpo-base.owl"
      xmlns:IAO="http://purl.obolibrary.org/obo/IAO_"
      xmlns:dce="http://purl.org/dc/elements/1.1/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -9,8 +9,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:dcterms="http://purl.org/dc/terms/">
-    <owl:Ontology rdf:about="https://w3id.org/metpo/metpo/metpo-base.owl">
-        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-06-02/metpo-base.owl"/>
+    <owl:Ontology rdf:about="https://w3id.org/metpo/metpo-base.owl">
+        <owl:versionIRI rdf:resource="https://w3id.org/metpo/releases/2026-06-02/metpo-base.owl"/>
         <dce:type rdf:resource="http://purl.obolibrary.org/obo/IAO_8000001"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0001-9076-6066"/>
         <dcterms:creator>METPO Development Team</dcterms:creator>

--- a/metpo-full.json
+++ b/metpo-full.json
@@ -1,6 +1,6 @@
 {
   "graphs" : [ {
-    "id" : "https://w3id.org/metpo/metpo/metpo-full.json",
+    "id" : "https://w3id.org/metpo/metpo-full.json",
     "meta" : {
       "basicPropertyValues" : [ {
         "pred" : "http://purl.org/dc/terms/contributor",
@@ -36,7 +36,7 @@
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
         "val" : "2026-06-02"
       } ],
-      "version" : "https://w3id.org/metpo/metpo/releases/2026-06-02/metpo-full.json"
+      "version" : "https://w3id.org/metpo/releases/2026-06-02/metpo-full.json"
     },
     "nodes" : [ {
       "id" : "http://www.geneontology.org/formats/oboInOwl#ObsoleteClass",

--- a/metpo-full.obo
+++ b/metpo-full.obo
@@ -1,12 +1,12 @@
 format-version: 1.2
-data-version: https://w3id.org/metpo/metpo/releases/2026-06-02/metpo-full.owl
+data-version: https://w3id.org/metpo/releases/2026-06-02/metpo-full.owl
 idspace: dce http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
 idspace: metpo https://w3id.org/metpo/ 
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
 idspace: qudt http://qudt.org/schema/qudt/ 
 idspace: skos http://www.w3.org/2004/02/skos/core# 
-ontology: https://w3id.org/metpo/metpo/metpo-full.owl
+ontology: https://w3id.org/metpo/metpo-full.owl
 property_value: dcterms:contributor https://orcid.org/0000-0001-9076-6066
 property_value: dcterms:creator "METPO Development Team" xsd:string
 property_value: dcterms:description "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible." xsd:string

--- a/metpo-full.owl
+++ b/metpo-full.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="https://w3id.org/metpo/metpo/metpo-full.owl#"
-     xml:base="https://w3id.org/metpo/metpo/metpo-full.owl"
+<rdf:RDF xmlns="https://w3id.org/metpo/metpo-full.owl#"
+     xml:base="https://w3id.org/metpo/metpo-full.owl"
      xmlns:IAO="http://purl.obolibrary.org/obo/IAO_"
      xmlns:dce="http://purl.org/dc/elements/1.1/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
@@ -14,8 +14,8 @@
      xmlns:metpo="https://w3id.org/metpo/"
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="https://w3id.org/metpo/metpo/metpo-full.owl">
-        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-06-02/metpo-full.owl"/>
+    <owl:Ontology rdf:about="https://w3id.org/metpo/metpo-full.owl">
+        <owl:versionIRI rdf:resource="https://w3id.org/metpo/releases/2026-06-02/metpo-full.owl"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0001-9076-6066"/>
         <dcterms:creator>METPO Development Team</dcterms:creator>
         <dcterms:description>METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible.</dcterms:description>

--- a/metpo.json
+++ b/metpo.json
@@ -1,6 +1,6 @@
 {
   "graphs" : [ {
-    "id" : "https://w3id.org/metpo/metpo.json",
+    "id" : "https://w3id.org/metpo.json",
     "meta" : {
       "basicPropertyValues" : [ {
         "pred" : "http://purl.org/dc/terms/contributor",
@@ -36,7 +36,7 @@
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
         "val" : "2026-06-02"
       } ],
-      "version" : "https://w3id.org/metpo/metpo/releases/2026-06-02/metpo.json"
+      "version" : "https://w3id.org/metpo/releases/2026-06-02/metpo.json"
     },
     "nodes" : [ {
       "id" : "http://www.geneontology.org/formats/oboInOwl#ObsoleteClass",

--- a/metpo.obo
+++ b/metpo.obo
@@ -1,12 +1,12 @@
 format-version: 1.2
-data-version: https://w3id.org/metpo/metpo/releases/2026-06-02/metpo.owl
+data-version: https://w3id.org/metpo/releases/2026-06-02/metpo.owl
 idspace: dce http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
 idspace: metpo https://w3id.org/metpo/ 
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
 idspace: qudt http://qudt.org/schema/qudt/ 
 idspace: skos http://www.w3.org/2004/02/skos/core# 
-ontology: https://w3id.org/metpo/metpo.owl
+ontology: https://w3id.org/metpo.owl
 property_value: dcterms:contributor https://orcid.org/0000-0001-9076-6066
 property_value: dcterms:creator "METPO Development Team" xsd:string
 property_value: dcterms:description "METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible." xsd:string

--- a/metpo.owl
+++ b/metpo.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="https://w3id.org/metpo/metpo.owl#"
-     xml:base="https://w3id.org/metpo/metpo.owl"
+<rdf:RDF xmlns="https://w3id.org/metpo.owl#"
+     xml:base="https://w3id.org/metpo.owl"
      xmlns:IAO="http://purl.obolibrary.org/obo/IAO_"
      xmlns:dce="http://purl.org/dc/elements/1.1/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
@@ -14,8 +14,8 @@
      xmlns:metpo="https://w3id.org/metpo/"
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="https://w3id.org/metpo/metpo.owl">
-        <owl:versionIRI rdf:resource="https://w3id.org/metpo/metpo/releases/2026-06-02/metpo.owl"/>
+    <owl:Ontology rdf:about="https://w3id.org/metpo.owl">
+        <owl:versionIRI rdf:resource="https://w3id.org/metpo/releases/2026-06-02/metpo.owl"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0001-9076-6066"/>
         <dcterms:creator>METPO Development Team</dcterms:creator>
         <dcterms:description>METPO provides standardized terms for the phenotypic traits, growth conditions, metabolic capabilities, and morphology of bacteria and archaea. It integrates heterogeneous microbial trait resources (BactoTraits, BacDive, Madin et al.) and supports knowledge-graph and literature-mining workflows in projects such as KG-Microbe. METPO follows OBO Foundry conventions and reuses terms from PATO, GO, CHEBI, NCBITaxon, and related ontologies where possible.</dcterms:description>

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -19,9 +19,9 @@ CONFIG_HASH=                b36e24392153d51eead1fd6d833e68e831bdb46877e7485056d8
 # these can be overwritten on the command line
 
 OBOBASE=                    http://purl.obolibrary.org/obo
-URIBASE=                    https://w3id.org/metpo
+URIBASE=                    https://w3id.org
 ONT=                        metpo
-ONTBASE=                    https://w3id.org/metpo/metpo
+ONTBASE=                    https://w3id.org/metpo
 EDIT_FORMAT=                owl
 SRC =                       $(ONT)-edit.$(EDIT_FORMAT)
 MAKE_FAST=                  $(MAKE) IMP=false PAT=false COMP=false MIR=false

--- a/src/ontology/components/metpo_sheet.owl
+++ b/src/ontology/components/metpo_sheet.owl
@@ -1,4 +1,4 @@
-Prefix(:=<https://w3id.org/metpo/metpo/components/metpo_sheet.owl#>)
+Prefix(:=<https://w3id.org/metpo/components/metpo_sheet.owl#>)
 Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
 Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
 Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
@@ -6,8 +6,8 @@ Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
-Ontology(<https://w3id.org/metpo/metpo/components/metpo_sheet.owl>
-<https://w3id.org/metpo/metpo/releases/2026-06-02/components/metpo_sheet.owl>
+Ontology(<https://w3id.org/metpo/components/metpo_sheet.owl>
+<https://w3id.org/metpo/releases/2026-06-02/components/metpo_sheet.owl>
 Annotation(owl:versionInfo "2026-06-02")
 
 Declaration(Class(<http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>))


### PR DESCRIPTION
Finishes the IRI-scheme work from #458 so the BioPortal release is clean.

**#436 (version-IRI doubling).** `metpo-odk.yaml` already set `uribase: https://w3id.org`, but the committed generated `src/ontology/Makefile` was never refreshed and still carried `URIBASE=https://w3id.org/metpo` plus a hardcoded `ONTBASE=https://w3id.org/metpo/metpo`. That produced `…/metpo/metpo/releases/…` version IRIs. Aligned the Makefile to the odk.yaml value and rebuilt. Now: version IRI `https://w3id.org/metpo/releases/2026-06-02/metpo.owl`, products `https://w3id.org/metpo/metpo-{base,full}.owl`, main ontology IRI `https://w3id.org/metpo.owl` (standard registry-root layout). No `metpo/metpo/` left.

**#435 (obolibrary PURL 404).** Adopts option 2: README now declares `https://w3id.org/metpo/` the only canonical resolution base and explicitly tells users not to use `purl.obolibrary.org/obo/METPO_<id>` (those 404 because METPO isn't OBO-registered). OBO registration (option 1) is out of scope.

Why a direct Makefile edit rather than `make update_repo`: `URIBASE`/`ONTBASE` are the documented "can be overwritten" config values, odk.yaml is already correct, and this keeps the PR a reviewable 2-line config change plus the rebuild instead of a full ODK scaffold regeneration. A future `update_repo` regenerates the same values.

Does not touch #437 (a BioPortal submission-form setting) or #450 (external `w3id.org` .htaccess). Term IRIs unchanged.