### PR TITLE
Type owl:deprecated as xsd:boolean — clears ~4000 ROBOT report findings

### DIFF
--- a/metpo-base.json
+++ b/metpo-base.json
@@ -52,10 +52,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000002",
@@ -65,10 +63,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000003",
@@ -78,10 +74,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000004",
@@ -91,10 +85,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000005",
@@ -104,10 +96,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000006",
@@ -117,10 +107,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000007",
@@ -130,10 +118,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000008",
@@ -143,10 +129,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000009",
@@ -156,10 +140,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000001",
@@ -169,10 +151,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000010",
@@ -182,10 +162,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000011",
@@ -195,10 +173,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000012",
@@ -208,10 +184,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000013",
@@ -221,10 +195,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000014",
@@ -234,10 +206,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000015",
@@ -247,10 +217,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000016",
@@ -260,10 +228,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000017",
@@ -273,10 +239,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000018",
@@ -286,10 +250,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000019",
@@ -299,10 +261,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000002",
@@ -312,10 +272,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000020",
@@ -325,10 +283,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000021",
@@ -338,10 +294,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000022",
@@ -351,10 +305,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000023",
@@ -364,10 +316,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000024",
@@ -377,10 +327,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000025",
@@ -390,10 +338,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000026",
@@ -403,10 +349,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000027",
@@ -416,10 +360,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000028",
@@ -429,10 +371,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000029",
@@ -442,10 +382,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000003",
@@ -455,10 +393,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000030",
@@ -468,10 +404,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000031",
@@ -481,10 +415,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000032",
@@ -494,10 +426,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000033",
@@ -507,10 +437,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000034",
@@ -520,10 +448,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000035",
@@ -533,10 +459,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000036",
@@ -546,10 +470,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000037",
@@ -559,10 +481,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000038",
@@ -572,10 +492,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000039",
@@ -585,10 +503,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000004",
@@ -598,10 +514,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000040",
@@ -611,10 +525,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000041",
@@ -624,10 +536,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000042",
@@ -637,10 +547,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000043",
@@ -650,10 +558,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000044",
@@ -663,10 +569,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000045",
@@ -676,10 +580,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000046",
@@ -689,10 +591,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000047",
@@ -702,10 +602,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000048",
@@ -715,10 +613,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000049",
@@ -728,10 +624,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000005",
@@ -741,10 +635,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000050",
@@ -754,10 +646,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000051",
@@ -767,10 +657,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000052",
@@ -780,10 +668,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000053",
@@ -793,10 +679,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000054",
@@ -806,10 +690,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000055",
@@ -819,10 +701,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000056",
@@ -832,10 +712,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000057",
@@ -845,10 +723,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000058",
@@ -858,10 +734,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000059",
@@ -871,10 +745,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000006",
@@ -884,10 +756,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000060",
@@ -897,10 +767,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000061",
@@ -910,10 +778,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000062",
@@ -923,10 +789,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000063",
@@ -936,10 +800,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000064",
@@ -949,10 +811,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000065",
@@ -962,10 +822,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000066",
@@ -975,10 +833,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000067",
@@ -988,10 +844,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000068",
@@ -1001,10 +855,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000069",
@@ -1014,10 +866,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000007",
@@ -1027,10 +877,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000070",
@@ -1040,10 +888,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000071",
@@ -1053,10 +899,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000072",
@@ -1066,10 +910,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000073",
@@ -1079,10 +921,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000074",
@@ -1092,10 +932,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000075",
@@ -1105,10 +943,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000076",
@@ -1118,10 +954,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000077",
@@ -1131,10 +965,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000078",
@@ -1144,10 +976,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000079",
@@ -1157,10 +987,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000008",
@@ -1170,10 +998,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000080",
@@ -1183,10 +1009,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000081",
@@ -1196,10 +1020,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000082",
@@ -1209,10 +1031,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000083",
@@ -1222,10 +1042,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000084",
@@ -1235,10 +1053,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000085",
@@ -1248,10 +1064,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000086",
@@ -1261,10 +1075,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000087",
@@ -1274,10 +1086,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000088",
@@ -1287,10 +1097,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000089",
@@ -1300,10 +1108,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000009",
@@ -1313,10 +1119,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000090",
@@ -1326,10 +1130,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000091",
@@ -1339,10 +1141,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000092",
@@ -1352,10 +1152,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000093",
@@ -1365,10 +1163,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000094",
@@ -1378,10 +1174,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000095",
@@ -1391,10 +1185,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000096",
@@ -1404,10 +1196,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000097",
@@ -1417,10 +1207,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000098",
@@ -1430,10 +1218,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000099",
@@ -1443,10 +1229,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000010",
@@ -1456,10 +1240,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000100",
@@ -1469,10 +1251,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000101",
@@ -1482,10 +1262,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000102",
@@ -1495,10 +1273,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000103",
@@ -1508,10 +1284,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000104",
@@ -1521,10 +1295,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000105",
@@ -1534,10 +1306,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000106",
@@ -1547,10 +1317,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000107",
@@ -1560,10 +1328,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000108",
@@ -1573,10 +1339,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000109",
@@ -1586,10 +1350,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000011",
@@ -1599,10 +1361,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000110",
@@ -1612,10 +1372,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000111",
@@ -1625,10 +1383,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000112",
@@ -1638,10 +1394,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000113",
@@ -1651,10 +1405,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000114",
@@ -1664,10 +1416,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000115",
@@ -1677,10 +1427,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000116",
@@ -1690,10 +1438,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000117",
@@ -1703,10 +1449,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000118",
@@ -1716,10 +1460,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000119",
@@ -1729,10 +1471,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000012",
@@ -1742,10 +1482,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000120",
@@ -1755,10 +1493,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000121",
@@ -1768,10 +1504,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000122",
@@ -1781,10 +1515,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000123",
@@ -1794,10 +1526,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000124",
@@ -1807,10 +1537,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000125",
@@ -1820,10 +1548,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000126",
@@ -1833,10 +1559,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000127",
@@ -1846,10 +1570,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000128",
@@ -1859,10 +1581,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000129",
@@ -1872,10 +1592,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000013",
@@ -1885,10 +1603,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000130",
@@ -1898,10 +1614,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000131",
@@ -1911,10 +1625,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000132",
@@ -1924,10 +1636,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000133",
@@ -1937,10 +1647,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000134",
@@ -1950,10 +1658,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000135",
@@ -1963,10 +1669,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000136",
@@ -1976,10 +1680,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000137",
@@ -1989,10 +1691,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000138",
@@ -2002,10 +1702,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000139",
@@ -2015,10 +1713,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000014",
@@ -2028,10 +1724,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000140",
@@ -2041,10 +1735,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000141",
@@ -2054,10 +1746,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000142",
@@ -2067,10 +1757,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000143",
@@ -2080,10 +1768,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000144",
@@ -2093,10 +1779,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000145",
@@ -2106,10 +1790,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000146",
@@ -2119,10 +1801,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000147",
@@ -2132,10 +1812,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000148",
@@ -2145,10 +1823,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000149",
@@ -2158,10 +1834,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000015",
@@ -2171,10 +1845,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000150",
@@ -2184,10 +1856,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000151",
@@ -2197,10 +1867,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000152",
@@ -2210,10 +1878,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000153",
@@ -2223,10 +1889,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000154",
@@ -2236,10 +1900,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000155",
@@ -2249,10 +1911,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000156",
@@ -2262,10 +1922,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000157",
@@ -2275,10 +1933,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000158",
@@ -2288,10 +1944,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000159",
@@ -2301,10 +1955,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000016",
@@ -2314,10 +1966,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000160",
@@ -2327,10 +1977,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000161",
@@ -2340,10 +1988,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000162",
@@ -2353,10 +1999,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000163",
@@ -2366,10 +2010,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000164",
@@ -2379,10 +2021,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000165",
@@ -2392,10 +2032,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000166",
@@ -2405,10 +2043,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000167",
@@ -2418,10 +2054,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000168",
@@ -2431,10 +2065,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000169",
@@ -2444,10 +2076,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000017",
@@ -2457,10 +2087,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000170",
@@ -2470,10 +2098,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000171",
@@ -2483,10 +2109,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000172",
@@ -2496,10 +2120,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000173",
@@ -2509,10 +2131,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000174",
@@ -2522,10 +2142,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000175",
@@ -2535,10 +2153,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000176",
@@ -2548,10 +2164,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000177",
@@ -2561,10 +2175,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000178",
@@ -2574,10 +2186,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000179",
@@ -2587,10 +2197,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000018",
@@ -2600,10 +2208,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000180",
@@ -2613,10 +2219,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000181",
@@ -2626,10 +2230,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000182",
@@ -2639,10 +2241,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000183",
@@ -2652,10 +2252,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000184",
@@ -2665,10 +2263,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000185",
@@ -2678,10 +2274,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000186",
@@ -2691,10 +2285,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000187",
@@ -2704,10 +2296,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000188",
@@ -2717,10 +2307,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000189",
@@ -2730,10 +2318,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000019",
@@ -2743,10 +2329,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000190",
@@ -2756,10 +2340,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000191",
@@ -2769,10 +2351,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000192",
@@ -2782,10 +2362,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000193",
@@ -2795,10 +2373,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000194",
@@ -2808,10 +2384,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000195",
@@ -2821,10 +2395,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000196",
@@ -2834,10 +2406,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000197",
@@ -2847,10 +2417,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000198",
@@ -2860,10 +2428,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000199",
@@ -2873,10 +2439,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000020",
@@ -2886,10 +2450,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000200",
@@ -2899,10 +2461,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000201",
@@ -2912,10 +2472,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000202",
@@ -2925,10 +2483,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000203",
@@ -2938,10 +2494,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000204",
@@ -2951,10 +2505,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000205",
@@ -2964,10 +2516,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000206",
@@ -2977,10 +2527,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000207",
@@ -2990,10 +2538,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000208",
@@ -3003,10 +2549,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000209",
@@ -3016,10 +2560,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000021",
@@ -3029,10 +2571,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000210",
@@ -3042,10 +2582,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000211",
@@ -3055,10 +2593,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000212",
@@ -3068,10 +2604,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000213",
@@ -3081,10 +2615,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000214",
@@ -3094,10 +2626,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000215",
@@ -3107,10 +2637,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000216",
@@ -3120,10 +2648,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000217",
@@ -3133,10 +2659,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000218",
@@ -3146,10 +2670,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000219",
@@ -3159,10 +2681,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000022",
@@ -3172,10 +2692,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000220",
@@ -3185,10 +2703,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000221",
@@ -3198,10 +2714,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000222",
@@ -3211,10 +2725,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000223",
@@ -3224,10 +2736,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000224",
@@ -3237,10 +2747,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000225",
@@ -3250,10 +2758,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000226",
@@ -3263,10 +2769,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000227",
@@ -3276,10 +2780,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000228",
@@ -3289,10 +2791,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000229",
@@ -3302,10 +2802,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000023",
@@ -3315,10 +2813,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000230",
@@ -3328,10 +2824,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000231",
@@ -3341,10 +2835,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000232",
@@ -3354,10 +2846,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000233",
@@ -3367,10 +2857,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000234",
@@ -3380,10 +2868,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000235",
@@ -3393,10 +2879,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000236",
@@ -3406,10 +2890,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000237",
@@ -3419,10 +2901,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000238",
@@ -3432,10 +2912,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000239",
@@ -3445,10 +2923,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000024",
@@ -3458,10 +2934,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000240",
@@ -3471,10 +2945,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000241",
@@ -3484,10 +2956,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000242",
@@ -3497,10 +2967,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000243",
@@ -3510,10 +2978,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000244",
@@ -3523,10 +2989,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000245",
@@ -3536,10 +3000,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000246",
@@ -3549,10 +3011,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000247",
@@ -3562,10 +3022,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000248",
@@ -3575,10 +3033,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000249",
@@ -3588,10 +3044,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000025",
@@ -3601,10 +3055,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000250",
@@ -3614,10 +3066,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000251",
@@ -3627,10 +3077,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000252",
@@ -3640,10 +3088,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000253",
@@ -3653,10 +3099,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000254",
@@ -3666,10 +3110,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000255",
@@ -3679,10 +3121,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000256",
@@ -3692,10 +3132,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000257",
@@ -3705,10 +3143,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000258",
@@ -3718,10 +3154,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000259",
@@ -3731,10 +3165,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000026",
@@ -3744,10 +3176,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000260",
@@ -3757,10 +3187,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000261",
@@ -3770,10 +3198,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000262",
@@ -3783,10 +3209,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000263",
@@ -3796,10 +3220,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000264",
@@ -3809,10 +3231,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000265",
@@ -3822,10 +3242,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000266",
@@ -3835,10 +3253,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000267",
@@ -3848,10 +3264,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000268",
@@ -3861,10 +3275,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000269",
@@ -3874,10 +3286,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000027",
@@ -3887,10 +3297,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000270",
@@ -3900,10 +3308,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000271",
@@ -3913,10 +3319,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000272",
@@ -3926,10 +3330,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000273",
@@ -3939,10 +3341,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000274",
@@ -3952,10 +3352,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000275",
@@ -3965,10 +3363,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000276",
@@ -3978,10 +3374,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000277",
@@ -3991,10 +3385,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000278",
@@ -4004,10 +3396,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000279",
@@ -4017,10 +3407,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000028",
@@ -4030,10 +3418,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000280",
@@ -4043,10 +3429,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000281",
@@ -4056,10 +3440,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000282",
@@ -4069,10 +3451,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000029",
@@ -4082,10 +3462,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000030",
@@ -4095,10 +3473,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000031",
@@ -4108,10 +3484,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000032",
@@ -4121,10 +3495,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000033",
@@ -4134,10 +3506,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000034",
@@ -4147,10 +3517,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000035",
@@ -4160,10 +3528,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000036",
@@ -4173,10 +3539,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000037",
@@ -4186,10 +3550,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000038",
@@ -4199,10 +3561,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000039",
@@ -4212,10 +3572,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000040",
@@ -4225,10 +3583,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000041",
@@ -4238,10 +3594,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000042",
@@ -4251,10 +3605,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000043",
@@ -4264,10 +3616,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000044",
@@ -4277,10 +3627,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000045",
@@ -4290,10 +3638,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000046",
@@ -4303,10 +3649,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000047",
@@ -4316,10 +3660,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000048",
@@ -4329,10 +3671,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000049",
@@ -4342,10 +3682,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000050",
@@ -4355,10 +3693,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000051",
@@ -4368,10 +3704,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000052",
@@ -4381,10 +3715,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000053",
@@ -4394,10 +3726,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000054",
@@ -4407,10 +3737,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000055",
@@ -4420,10 +3748,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000056",
@@ -4433,10 +3759,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000057",
@@ -4446,10 +3770,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000058",
@@ -4459,10 +3781,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000059",
@@ -4472,10 +3792,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000060",
@@ -4485,10 +3803,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000061",
@@ -4498,10 +3814,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000062",
@@ -4511,10 +3825,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000063",
@@ -4524,10 +3836,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000064",
@@ -4537,10 +3847,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000065",
@@ -4550,10 +3858,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000066",
@@ -4563,10 +3869,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000067",
@@ -4576,10 +3880,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000068",
@@ -4589,10 +3891,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000069",
@@ -4602,10 +3902,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000070",
@@ -4615,10 +3913,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000071",
@@ -4628,10 +3924,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000072",
@@ -4641,10 +3935,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000073",
@@ -4654,10 +3946,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000074",
@@ -4667,10 +3957,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000075",
@@ -4680,10 +3968,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000076",
@@ -4693,10 +3979,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000077",
@@ -4706,10 +3990,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000078",
@@ -4719,10 +4001,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000079",
@@ -4732,10 +4012,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000080",
@@ -4745,10 +4023,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000081",
@@ -4758,10 +4034,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000082",
@@ -4771,10 +4045,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000083",
@@ -4784,10 +4056,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000084",
@@ -4797,10 +4067,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000085",
@@ -4810,10 +4078,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000086",
@@ -4823,10 +4089,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000087",
@@ -4836,10 +4100,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000088",
@@ -4849,10 +4111,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000089",
@@ -4862,10 +4122,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000090",
@@ -4875,10 +4133,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000091",
@@ -4888,10 +4144,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000092",
@@ -4901,10 +4155,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000093",
@@ -4914,10 +4166,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000094",
@@ -4927,10 +4177,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000095",
@@ -4940,10 +4188,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000096",
@@ -4953,10 +4199,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000097",
@@ -4966,10 +4210,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000098",
@@ -4979,10 +4221,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000099",
@@ -4992,10 +4232,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000100",
@@ -5005,10 +4243,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001000",
@@ -5018,10 +4254,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001001",
@@ -5031,10 +4265,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001002",
@@ -5044,10 +4276,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001003",
@@ -5057,10 +4287,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001004",
@@ -5070,10 +4298,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001006",
@@ -5083,10 +4309,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001007",
@@ -5096,10 +4320,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001008",
@@ -5109,10 +4331,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001009",
@@ -5122,10 +4342,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000101",
@@ -5135,10 +4353,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001010",
@@ -5148,10 +4364,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001012",
@@ -5161,10 +4375,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001013",
@@ -5174,10 +4386,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001014",
@@ -5187,10 +4397,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001016",
@@ -5200,10 +4408,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001017",
@@ -5213,10 +4419,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001018",
@@ -5226,10 +4430,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001019",
@@ -5239,10 +4441,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000102",
@@ -5252,10 +4452,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001020",
@@ -5265,10 +4463,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001021",
@@ -5278,10 +4474,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000103",
@@ -5291,10 +4485,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000104",
@@ -5304,10 +4496,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000105",
@@ -5317,10 +4507,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000106",
@@ -5330,10 +4518,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000107",
@@ -5343,10 +4529,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000108",
@@ -5356,10 +4540,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000109",
@@ -5369,10 +4551,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000110",
@@ -5382,10 +4562,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000111",
@@ -5395,10 +4573,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000112",
@@ -5408,10 +4584,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000113",
@@ -5421,10 +4595,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000114",
@@ -5434,10 +4606,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000115",
@@ -5447,10 +4617,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000116",
@@ -5460,10 +4628,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000117",
@@ -5473,10 +4639,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000118",
@@ -5486,10 +4650,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000119",
@@ -5499,10 +4661,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000120",
@@ -5512,10 +4672,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000121",
@@ -5525,10 +4683,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000122",
@@ -5538,10 +4694,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000123",
@@ -5551,10 +4705,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000124",
@@ -5564,10 +4716,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000125",
@@ -5577,10 +4727,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000126",
@@ -5590,10 +4738,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000127",
@@ -5603,10 +4749,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000128",
@@ -5616,10 +4760,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000129",
@@ -5629,10 +4771,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000130",
@@ -5642,10 +4782,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000131",
@@ -5655,10 +4793,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000132",
@@ -5668,10 +4804,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000133",
@@ -5681,10 +4815,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000134",
@@ -5694,10 +4826,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000135",
@@ -5707,10 +4837,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000136",
@@ -5720,10 +4848,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000137",
@@ -5733,10 +4859,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000138",
@@ -5746,10 +4870,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000139",
@@ -5759,10 +4881,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000140",
@@ -5772,10 +4892,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000141",
@@ -5785,10 +4903,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000142",
@@ -5798,10 +4914,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000143",
@@ -5811,10 +4925,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000144",
@@ -5824,10 +4936,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000145",
@@ -5837,10 +4947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000146",
@@ -5850,10 +4958,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000147",
@@ -5863,10 +4969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000148",
@@ -5876,10 +4980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000149",
@@ -5889,10 +4991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000150",
@@ -5902,10 +5002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000151",
@@ -5915,10 +5013,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000152",
@@ -5928,10 +5024,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000153",
@@ -5941,10 +5035,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000154",
@@ -5954,10 +5046,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000155",
@@ -5967,10 +5057,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000156",
@@ -5980,10 +5068,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000157",
@@ -5993,10 +5079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000158",
@@ -6006,10 +5090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000159",
@@ -6019,10 +5101,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000160",
@@ -6032,10 +5112,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000161",
@@ -6045,10 +5123,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000162",
@@ -6058,10 +5134,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000163",
@@ -6071,10 +5145,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000164",
@@ -6084,10 +5156,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000165",
@@ -6097,10 +5167,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000166",
@@ -6110,10 +5178,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000167",
@@ -6123,10 +5189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000168",
@@ -6136,10 +5200,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000169",
@@ -6149,10 +5211,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000170",
@@ -6162,10 +5222,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000171",
@@ -6175,10 +5233,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000172",
@@ -6188,10 +5244,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000173",
@@ -6201,10 +5255,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000174",
@@ -6214,10 +5266,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000175",
@@ -6227,10 +5277,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000176",
@@ -6240,10 +5288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000177",
@@ -6253,10 +5299,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000178",
@@ -6266,10 +5310,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000179",
@@ -6279,10 +5321,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000180",
@@ -6292,10 +5332,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000181",
@@ -6305,10 +5343,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000182",
@@ -6318,10 +5354,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000183",
@@ -6331,10 +5365,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000184",
@@ -6344,10 +5376,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000185",
@@ -6357,10 +5387,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000186",
@@ -6370,10 +5398,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000187",
@@ -6383,10 +5409,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000188",
@@ -6396,10 +5420,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000189",
@@ -6409,10 +5431,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000190",
@@ -6422,10 +5442,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000191",
@@ -6435,10 +5453,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000192",
@@ -6448,10 +5464,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000193",
@@ -6461,10 +5475,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000194",
@@ -6474,10 +5486,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000195",
@@ -6487,10 +5497,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000196",
@@ -6500,10 +5508,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000197",
@@ -6513,10 +5519,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000198",
@@ -6526,10 +5530,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000199",
@@ -6539,10 +5541,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000200",
@@ -6552,10 +5552,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000201",
@@ -6565,10 +5563,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000202",
@@ -6578,10 +5574,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000203",
@@ -6591,10 +5585,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000204",
@@ -6604,10 +5596,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000205",
@@ -6617,10 +5607,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000206",
@@ -6630,10 +5618,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000207",
@@ -6643,10 +5629,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000208",
@@ -6656,10 +5640,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000209",
@@ -6669,10 +5651,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000210",
@@ -6682,10 +5662,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000211",
@@ -6695,10 +5673,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000212",
@@ -6708,10 +5684,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000213",
@@ -6721,10 +5695,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000214",
@@ -6734,10 +5706,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000215",
@@ -6747,10 +5717,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000216",
@@ -6760,10 +5728,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000217",
@@ -6773,10 +5739,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000218",
@@ -6786,10 +5750,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000219",
@@ -6799,10 +5761,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000220",
@@ -6812,10 +5772,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000221",
@@ -6825,10 +5783,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000222",
@@ -6838,10 +5794,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000223",
@@ -6851,10 +5805,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000224",
@@ -6864,10 +5816,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000225",
@@ -6877,10 +5827,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000226",
@@ -6890,10 +5838,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000227",
@@ -6903,10 +5849,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000228",
@@ -6916,10 +5860,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000229",
@@ -6929,10 +5871,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000230",
@@ -6942,10 +5882,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000231",
@@ -6955,10 +5893,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000232",
@@ -6968,10 +5904,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000233",
@@ -6981,10 +5915,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000234",
@@ -6994,10 +5926,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000235",
@@ -7007,10 +5937,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000236",
@@ -7020,10 +5948,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000237",
@@ -7033,10 +5959,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000238",
@@ -7046,10 +5970,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000239",
@@ -7059,10 +5981,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000240",
@@ -7072,10 +5992,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000241",
@@ -7085,10 +6003,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000242",
@@ -7098,10 +6014,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000243",
@@ -7111,10 +6025,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000244",
@@ -7124,10 +6036,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000245",
@@ -7137,10 +6047,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000246",
@@ -7150,10 +6058,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000247",
@@ -7163,10 +6069,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000248",
@@ -7176,10 +6080,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000249",
@@ -7189,10 +6091,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000250",
@@ -7202,10 +6102,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000251",
@@ -7215,10 +6113,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000252",
@@ -7228,10 +6124,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000253",
@@ -7241,10 +6135,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000254",
@@ -7254,10 +6146,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000255",
@@ -7267,10 +6157,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000256",
@@ -7280,10 +6168,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000257",
@@ -7293,10 +6179,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000258",
@@ -7306,10 +6190,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000259",
@@ -7319,10 +6201,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000260",
@@ -7332,10 +6212,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000261",
@@ -7345,10 +6223,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000262",
@@ -7358,10 +6234,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000263",
@@ -7371,10 +6245,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000264",
@@ -7384,10 +6256,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000265",
@@ -7397,10 +6267,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000266",
@@ -7410,10 +6278,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000267",
@@ -7423,10 +6289,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000268",
@@ -7436,10 +6300,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000269",
@@ -7449,10 +6311,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000270",
@@ -7462,10 +6322,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000271",
@@ -7475,10 +6333,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000272",
@@ -7488,10 +6344,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000273",
@@ -7501,10 +6355,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000274",
@@ -7514,10 +6366,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000001",
@@ -7527,10 +6377,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000002",
@@ -7540,10 +6388,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000003",
@@ -7553,10 +6399,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000004",
@@ -7566,10 +6410,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000005",
@@ -7579,10 +6421,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000006",
@@ -7592,10 +6432,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000007",
@@ -7605,10 +6443,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000008",
@@ -7618,10 +6454,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000009",
@@ -7631,10 +6465,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000010",
@@ -7644,10 +6476,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000011",
@@ -7657,10 +6487,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000012",
@@ -7670,10 +6498,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000013",
@@ -7683,10 +6509,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000014",
@@ -7696,10 +6520,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000015",
@@ -7709,10 +6531,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000016",
@@ -7722,10 +6542,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000017",
@@ -7735,10 +6553,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000018",
@@ -7748,10 +6564,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000019",
@@ -7761,10 +6575,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000020",
@@ -7774,10 +6586,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000021",
@@ -7787,10 +6597,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000022",
@@ -7800,10 +6608,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000023",
@@ -7813,10 +6619,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000024",
@@ -7826,10 +6630,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000025",
@@ -7839,10 +6641,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000026",
@@ -7852,10 +6652,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000027",
@@ -7865,10 +6663,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000028",
@@ -7878,10 +6674,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000029",
@@ -7891,10 +6685,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000030",
@@ -7904,10 +6696,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000031",
@@ -7917,10 +6707,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000032",
@@ -7930,10 +6718,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000033",
@@ -7943,10 +6729,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000034",
@@ -7956,10 +6740,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000035",
@@ -7969,10 +6751,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000036",
@@ -7982,10 +6762,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000037",
@@ -7995,10 +6773,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000038",
@@ -8008,10 +6784,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000039",
@@ -8021,10 +6795,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000040",
@@ -8034,10 +6806,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000041",
@@ -8047,10 +6817,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000042",
@@ -8060,10 +6828,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000043",
@@ -8073,10 +6839,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000044",
@@ -8086,10 +6850,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000045",
@@ -8099,10 +6861,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000046",
@@ -8112,10 +6872,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000047",
@@ -8125,10 +6883,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000048",
@@ -8138,10 +6894,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000049",
@@ -8151,10 +6905,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000050",
@@ -8164,10 +6916,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000051",
@@ -8177,10 +6927,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000052",
@@ -8190,10 +6938,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000053",
@@ -8203,10 +6949,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000054",
@@ -8216,10 +6960,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000055",
@@ -8229,10 +6971,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000056",
@@ -8242,10 +6982,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000057",
@@ -8255,10 +6993,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000058",
@@ -8268,10 +7004,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000059",
@@ -8328,10 +7062,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000062",
@@ -8341,10 +7073,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000063",
@@ -8354,10 +7084,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000064",
@@ -8367,10 +7095,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000065",
@@ -8380,10 +7106,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000066",
@@ -8393,10 +7117,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000067",
@@ -8406,10 +7128,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000068",
@@ -8419,10 +7139,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000069",
@@ -8432,10 +7150,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000070",
@@ -8445,10 +7161,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000071",
@@ -8458,10 +7172,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000072",
@@ -8471,10 +7183,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000073",
@@ -8484,10 +7194,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000074",
@@ -8497,10 +7205,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000075",
@@ -8510,10 +7216,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000076",
@@ -8523,10 +7227,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000077",
@@ -8536,10 +7238,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000078",
@@ -8549,10 +7249,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000079",
@@ -8562,10 +7260,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000080",
@@ -8575,10 +7271,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000081",
@@ -8588,10 +7282,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000082",
@@ -8601,10 +7293,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000083",
@@ -8614,10 +7304,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000084",
@@ -8627,10 +7315,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000085",
@@ -8640,10 +7326,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000086",
@@ -8653,10 +7337,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000087",
@@ -8666,10 +7348,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000088",
@@ -8679,10 +7359,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000089",
@@ -8692,10 +7370,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000090",
@@ -8705,10 +7381,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000091",
@@ -8718,10 +7392,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000092",
@@ -8731,10 +7403,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000093",
@@ -8744,10 +7414,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000094",
@@ -8757,10 +7425,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000095",
@@ -8770,10 +7436,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000096",
@@ -8783,10 +7447,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000097",
@@ -8796,10 +7458,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000098",
@@ -8809,10 +7469,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000099",
@@ -8822,10 +7480,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000100",
@@ -8835,10 +7491,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000101",
@@ -8848,10 +7502,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000102",
@@ -8861,10 +7513,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000103",
@@ -8874,10 +7524,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000104",
@@ -8887,10 +7535,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000105",
@@ -8900,10 +7546,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000106",
@@ -8913,10 +7557,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000107",
@@ -8926,10 +7568,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000108",
@@ -8939,10 +7579,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000109",
@@ -8952,10 +7590,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000110",
@@ -8965,10 +7601,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000111",
@@ -8978,10 +7612,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000112",
@@ -8991,10 +7623,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000113",
@@ -9004,10 +7634,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000114",
@@ -9017,10 +7645,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000115",
@@ -9030,10 +7656,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000116",
@@ -9043,10 +7667,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000117",
@@ -9056,10 +7678,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000118",
@@ -9069,10 +7689,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000119",
@@ -9082,10 +7700,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000120",
@@ -9095,10 +7711,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000121",
@@ -9108,10 +7722,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000122",
@@ -9121,10 +7733,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000123",
@@ -9134,10 +7744,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000124",
@@ -9147,10 +7755,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000125",
@@ -9160,10 +7766,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000126",
@@ -9173,10 +7777,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000127",
@@ -9215,10 +7817,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000129",
@@ -9228,10 +7828,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000130",
@@ -9241,10 +7839,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000131",
@@ -9254,10 +7850,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000132",
@@ -9267,10 +7861,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000133",
@@ -9280,10 +7872,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000134",
@@ -9293,10 +7883,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000135",
@@ -9306,10 +7894,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000136",
@@ -9319,10 +7905,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000137",
@@ -9332,10 +7916,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000138",
@@ -9345,10 +7927,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000139",
@@ -9358,10 +7938,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000140",
@@ -9371,10 +7949,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000141",
@@ -9384,10 +7960,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000142",
@@ -9397,10 +7971,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000143",
@@ -9410,10 +7982,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000144",
@@ -9423,10 +7993,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000145",
@@ -9436,10 +8004,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000146",
@@ -9449,10 +8015,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000147",
@@ -9462,10 +8026,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000148",
@@ -9475,10 +8037,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000149",
@@ -9488,10 +8048,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000150",
@@ -9501,10 +8059,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000151",
@@ -9514,10 +8070,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000152",
@@ -9527,10 +8081,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000153",
@@ -9540,10 +8092,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000154",
@@ -9553,10 +8103,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000155",
@@ -9566,10 +8114,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000156",
@@ -9579,10 +8125,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000157",
@@ -9592,10 +8136,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000158",
@@ -9605,10 +8147,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000159",
@@ -9618,10 +8158,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000160",
@@ -9631,10 +8169,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000161",
@@ -9644,10 +8180,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000162",
@@ -9657,10 +8191,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000163",
@@ -9670,10 +8202,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000164",
@@ -9683,10 +8213,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000165",
@@ -9696,10 +8224,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000166",
@@ -9709,10 +8235,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000167",
@@ -9722,10 +8246,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000168",
@@ -9735,10 +8257,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000169",
@@ -9748,10 +8268,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000170",
@@ -9761,10 +8279,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000171",
@@ -9774,10 +8290,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000172",
@@ -9787,10 +8301,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000173",
@@ -9800,10 +8312,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000174",
@@ -9813,10 +8323,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000175",
@@ -9826,10 +8334,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000176",
@@ -9839,10 +8345,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000177",
@@ -9852,10 +8356,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000178",
@@ -9865,10 +8367,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000179",
@@ -9878,10 +8378,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000180",
@@ -9891,10 +8389,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000181",
@@ -9904,10 +8400,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000182",
@@ -9917,10 +8411,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000183",
@@ -9930,10 +8422,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000184",
@@ -9943,10 +8433,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000185",
@@ -9956,10 +8444,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000186",
@@ -9988,10 +8474,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000188",
@@ -10010,10 +8494,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000190",
@@ -10023,10 +8505,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000191",
@@ -10036,10 +8516,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000192",
@@ -10049,10 +8527,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000193",
@@ -10062,10 +8538,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000194",
@@ -10075,10 +8549,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000195",
@@ -10088,10 +8560,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000196",
@@ -10101,10 +8571,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000197",
@@ -10114,10 +8582,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000198",
@@ -10127,10 +8593,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000199",
@@ -10140,10 +8604,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000200",
@@ -10153,10 +8615,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000201",
@@ -10166,10 +8626,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000202",
@@ -10179,10 +8637,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000203",
@@ -10192,10 +8648,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000204",
@@ -10205,10 +8659,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000205",
@@ -10218,10 +8670,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000206",
@@ -10231,10 +8681,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000207",
@@ -10244,10 +8692,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000208",
@@ -10257,10 +8703,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000209",
@@ -10270,10 +8714,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000210",
@@ -10283,10 +8725,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000211",
@@ -10296,10 +8736,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000212",
@@ -10309,10 +8747,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000213",
@@ -10322,10 +8758,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000214",
@@ -10335,10 +8769,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000215",
@@ -10348,10 +8780,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000216",
@@ -10361,10 +8791,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000217",
@@ -10374,10 +8802,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000218",
@@ -10387,10 +8813,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000219",
@@ -10400,10 +8824,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000220",
@@ -10413,10 +8835,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000221",
@@ -10426,10 +8846,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000222",
@@ -10439,10 +8857,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000223",
@@ -10452,10 +8868,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000224",
@@ -10465,10 +8879,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000225",
@@ -10478,10 +8890,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000226",
@@ -10491,10 +8901,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000227",
@@ -10504,10 +8912,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000228",
@@ -10517,10 +8923,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000229",
@@ -10530,10 +8934,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000230",
@@ -10543,10 +8945,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000231",
@@ -10556,10 +8956,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000232",
@@ -10573,10 +8971,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000234",
@@ -10586,10 +8982,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000235",
@@ -10599,10 +8993,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000236",
@@ -10612,10 +9004,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000237",
@@ -10625,10 +9015,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000238",
@@ -10638,10 +9026,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000239",
@@ -10651,10 +9037,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000240",
@@ -10664,10 +9048,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000241",
@@ -10677,10 +9059,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000242",
@@ -10690,10 +9070,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000243",
@@ -10703,10 +9081,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000244",
@@ -10716,10 +9092,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000245",
@@ -10729,10 +9103,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000246",
@@ -10742,10 +9114,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000247",
@@ -10755,10 +9125,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000248",
@@ -10768,10 +9136,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000249",
@@ -10781,10 +9147,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000250",
@@ -10794,10 +9158,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000251",
@@ -10807,10 +9169,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000252",
@@ -10820,10 +9180,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000253",
@@ -10833,10 +9191,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000254",
@@ -10846,10 +9202,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000255",
@@ -10859,10 +9213,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000256",
@@ -10872,10 +9224,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000257",
@@ -10885,10 +9235,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000258",
@@ -10898,10 +9246,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000259",
@@ -10911,10 +9257,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000260",
@@ -10924,10 +9268,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000261",
@@ -10937,10 +9279,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000262",
@@ -10950,10 +9290,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000263",
@@ -10963,10 +9301,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000264",
@@ -10976,10 +9312,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000265",
@@ -10989,10 +9323,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000266",
@@ -11002,10 +9334,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000267",
@@ -11015,10 +9345,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000268",
@@ -11028,10 +9356,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000269",
@@ -11041,10 +9367,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000270",
@@ -11054,10 +9378,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000271",
@@ -11067,10 +9389,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000272",
@@ -11080,10 +9400,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000273",
@@ -11093,10 +9411,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000274",
@@ -11106,10 +9422,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000275",
@@ -11119,10 +9433,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000276",
@@ -11132,10 +9444,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000277",
@@ -11145,10 +9455,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000278",
@@ -11158,10 +9466,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000279",
@@ -11171,10 +9477,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000280",
@@ -11184,10 +9488,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000281",
@@ -11197,10 +9499,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000282",
@@ -11210,10 +9510,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000283",
@@ -11223,10 +9521,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000284",
@@ -11236,10 +9532,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000285",
@@ -11249,10 +9543,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000286",
@@ -11262,10 +9554,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000287",
@@ -11275,10 +9565,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000288",
@@ -11288,10 +9576,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000289",
@@ -11301,10 +9587,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000290",
@@ -11314,10 +9598,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000291",
@@ -11327,10 +9609,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000292",
@@ -11340,10 +9620,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000293",
@@ -11353,10 +9631,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000294",
@@ -11366,10 +9642,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000295",
@@ -11379,10 +9653,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000296",
@@ -11392,10 +9664,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000297",
@@ -11405,10 +9675,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000298",
@@ -11418,10 +9686,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000299",
@@ -11431,10 +9697,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000300",
@@ -11444,10 +9708,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000301",
@@ -11457,10 +9719,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000302",
@@ -11470,10 +9730,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000303",
@@ -11506,10 +9764,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000306",
@@ -11523,10 +9779,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000308",
@@ -11536,10 +9790,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000309",
@@ -11549,10 +9801,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000310",
@@ -11562,10 +9812,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000311",
@@ -11575,10 +9823,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000312",
@@ -11588,10 +9834,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000313",
@@ -11601,10 +9845,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000314",
@@ -11614,10 +9856,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000315",
@@ -11627,10 +9867,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000316",
@@ -11640,10 +9878,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000317",
@@ -11653,10 +9889,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000318",
@@ -11666,10 +9900,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000319",
@@ -11679,10 +9911,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000320",
@@ -11692,10 +9922,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000321",
@@ -11705,10 +9933,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000322",
@@ -11718,10 +9944,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000323",
@@ -11731,10 +9955,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000324",
@@ -11744,10 +9966,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000325",
@@ -11757,10 +9977,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000326",
@@ -11770,10 +9988,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000327",
@@ -11783,10 +9999,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000328",
@@ -11796,10 +10010,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000329",
@@ -11809,10 +10021,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000330",
@@ -11822,10 +10032,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000331",
@@ -11887,10 +10095,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000337",
@@ -11900,10 +10106,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000338",
@@ -11913,10 +10117,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000339",
@@ -11926,10 +10128,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000340",
@@ -11939,10 +10139,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000341",
@@ -11952,10 +10150,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000342",
@@ -11965,10 +10161,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000343",
@@ -11978,10 +10172,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000344",
@@ -11991,10 +10183,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000345",
@@ -12004,10 +10194,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000346",
@@ -12017,10 +10205,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000347",
@@ -12030,10 +10216,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000348",
@@ -12043,10 +10227,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000349",
@@ -12056,10 +10238,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000350",
@@ -12069,10 +10249,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000351",
@@ -12082,10 +10260,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000352",
@@ -12095,10 +10271,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000353",
@@ -12108,10 +10282,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000354",
@@ -12121,10 +10293,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000355",
@@ -12134,10 +10304,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000356",
@@ -12147,10 +10315,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000357",
@@ -12160,10 +10326,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000358",
@@ -12173,10 +10337,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000359",
@@ -12186,10 +10348,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000360",
@@ -12199,10 +10359,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000361",
@@ -12212,10 +10370,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000362",
@@ -12225,10 +10381,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000363",
@@ -12238,10 +10392,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000364",
@@ -12251,10 +10403,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000365",
@@ -12264,10 +10414,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000366",
@@ -12277,10 +10425,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000367",
@@ -12290,10 +10436,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000368",
@@ -12303,10 +10447,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000369",
@@ -12316,10 +10458,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000370",
@@ -12329,10 +10469,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000371",
@@ -12342,10 +10480,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000372",
@@ -12355,10 +10491,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000373",
@@ -12368,10 +10502,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000374",
@@ -12381,10 +10513,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000375",
@@ -12394,10 +10524,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000376",
@@ -12407,10 +10535,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000377",
@@ -12420,10 +10546,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000378",
@@ -12433,10 +10557,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000379",
@@ -12446,10 +10568,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000380",
@@ -12459,10 +10579,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000381",
@@ -12472,10 +10590,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000382",
@@ -12485,10 +10601,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000383",
@@ -12498,10 +10612,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000384",
@@ -12511,10 +10623,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000385",
@@ -12524,10 +10634,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000386",
@@ -12537,10 +10645,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000387",
@@ -12550,10 +10656,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000388",
@@ -12563,10 +10667,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000389",
@@ -12576,10 +10678,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000390",
@@ -12589,10 +10689,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000391",
@@ -12602,10 +10700,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000392",
@@ -12615,10 +10711,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000393",
@@ -12628,10 +10722,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000394",
@@ -12641,10 +10733,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000395",
@@ -12654,10 +10744,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000396",
@@ -12667,10 +10755,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000397",
@@ -12680,10 +10766,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000398",
@@ -12693,10 +10777,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000399",
@@ -12706,10 +10788,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000400",
@@ -12719,10 +10799,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000401",
@@ -12732,10 +10810,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000402",
@@ -12745,10 +10821,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000403",
@@ -12758,10 +10832,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000404",
@@ -12771,10 +10843,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000405",
@@ -12784,10 +10854,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000406",
@@ -12797,10 +10865,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000407",
@@ -12810,10 +10876,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000408",
@@ -12823,10 +10887,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000409",
@@ -12836,10 +10898,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000410",
@@ -12849,10 +10909,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000411",
@@ -12862,10 +10920,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000412",
@@ -12875,10 +10931,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000413",
@@ -12888,10 +10942,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000414",
@@ -12901,10 +10953,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000415",
@@ -12914,10 +10964,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000416",
@@ -12927,10 +10975,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000417",
@@ -12940,10 +10986,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000418",
@@ -12953,10 +10997,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000419",
@@ -12966,10 +11008,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000420",
@@ -12979,10 +11019,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000421",
@@ -12992,10 +11030,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000422",
@@ -13005,10 +11041,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000423",
@@ -13018,10 +11052,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000424",
@@ -13031,10 +11063,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000425",
@@ -13044,10 +11074,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000426",
@@ -13057,10 +11085,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000427",
@@ -13070,10 +11096,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000428",
@@ -13083,10 +11107,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000429",
@@ -13182,10 +11204,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000434",
@@ -13195,10 +11215,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000435",
@@ -13208,10 +11226,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000436",
@@ -13221,10 +11237,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000437",
@@ -13234,10 +11248,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000438",
@@ -13247,10 +11259,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000439",
@@ -13260,10 +11270,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000440",
@@ -13273,10 +11281,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000441",
@@ -14622,10 +12628,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000489",
@@ -14635,10 +12639,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000490",
@@ -14648,10 +12650,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000491",
@@ -14661,10 +12661,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000492",
@@ -14674,10 +12672,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000493",
@@ -14687,10 +12683,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000494",
@@ -14700,10 +12694,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000495",
@@ -14713,10 +12705,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000496",
@@ -14726,10 +12716,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000497",
@@ -14739,10 +12727,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000498",
@@ -14752,10 +12738,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000499",
@@ -14765,10 +12749,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000500",
@@ -14778,10 +12760,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000501",
@@ -14791,10 +12771,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000502",
@@ -14804,10 +12782,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000503",
@@ -14817,10 +12793,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000504",
@@ -14830,10 +12804,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000505",
@@ -14843,10 +12815,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000506",
@@ -14856,10 +12826,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000507",
@@ -14869,10 +12837,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000508",
@@ -14882,10 +12848,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000509",
@@ -14895,10 +12859,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000510",
@@ -14908,10 +12870,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000511",
@@ -14921,10 +12881,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000512",
@@ -14934,10 +12892,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000513",
@@ -14947,10 +12903,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000514",
@@ -14960,10 +12914,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000515",
@@ -14973,10 +12925,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000516",
@@ -14986,10 +12936,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000517",
@@ -14999,10 +12947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000518",
@@ -15012,10 +12958,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000519",
@@ -15025,10 +12969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000520",
@@ -15038,10 +12980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000521",
@@ -15051,10 +12991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000522",
@@ -15064,10 +13002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000523",
@@ -15077,10 +13013,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000524",
@@ -15090,10 +13024,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000525",
@@ -15149,10 +13081,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000529",
@@ -15162,10 +13092,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000531",
@@ -16709,10 +14637,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000644",
@@ -16774,10 +14700,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000646",
@@ -17004,10 +14928,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000654",
@@ -17329,10 +15251,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000662",
@@ -17342,10 +15262,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000663",
@@ -19009,10 +16927,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000808",
@@ -19022,10 +16938,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000809",
@@ -19035,10 +16949,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000810",
@@ -19048,10 +16960,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000811",
@@ -19061,10 +16971,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000812",
@@ -19074,10 +16982,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000813",
@@ -19087,10 +16993,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000814",
@@ -19100,10 +17004,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000815",
@@ -19113,10 +17015,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000816",
@@ -19126,10 +17026,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000817",
@@ -19139,10 +17037,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000818",
@@ -19152,10 +17048,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000819",
@@ -19165,10 +17059,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000820",
@@ -19178,10 +17070,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000821",
@@ -19191,10 +17081,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000822",
@@ -19204,10 +17092,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000823",
@@ -19217,10 +17103,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000824",
@@ -19230,10 +17114,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000825",
@@ -19243,10 +17125,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000826",
@@ -19256,10 +17136,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000827",
@@ -19269,10 +17147,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000828",
@@ -19282,10 +17158,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000829",
@@ -19295,10 +17169,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000830",
@@ -19308,10 +17180,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000831",
@@ -19321,10 +17191,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000832",
@@ -19334,10 +17202,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000833",
@@ -19347,10 +17213,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000834",
@@ -19360,10 +17224,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000835",
@@ -19373,10 +17235,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000836",
@@ -19386,10 +17246,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000837",
@@ -19399,10 +17257,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000838",
@@ -19412,10 +17268,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000839",
@@ -19425,10 +17279,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000840",
@@ -19438,10 +17290,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000841",
@@ -19451,10 +17301,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000842",
@@ -19464,10 +17312,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000843",
@@ -19477,10 +17323,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000844",
@@ -19576,10 +17420,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000848",
@@ -19589,10 +17431,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000849",
@@ -19602,10 +17442,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000850",
@@ -19615,10 +17453,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000851",
@@ -19628,10 +17464,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000852",
@@ -19641,10 +17475,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000853",
@@ -19654,10 +17486,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000854",
@@ -19667,10 +17497,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000855",
@@ -19680,10 +17508,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000856",
@@ -19693,10 +17519,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000857",
@@ -19706,10 +17530,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000858",
@@ -19719,10 +17541,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000859",
@@ -19732,10 +17552,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000860",
@@ -19745,10 +17563,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000861",
@@ -19758,10 +17574,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000862",
@@ -19771,10 +17585,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000863",
@@ -19784,10 +17596,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000864",
@@ -19797,10 +17607,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000865",
@@ -19810,10 +17618,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000866",
@@ -19823,10 +17629,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000867",
@@ -19836,10 +17640,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000868",
@@ -19849,10 +17651,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000869",
@@ -19862,10 +17662,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000870",
@@ -20277,10 +18075,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001001",
@@ -20290,10 +18086,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001002",
@@ -20303,10 +18097,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001003",
@@ -20316,10 +18108,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001004",
@@ -20329,10 +18119,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001005",
@@ -20342,10 +18130,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001006",
@@ -20355,10 +18141,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001007",
@@ -20368,10 +18152,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001008",
@@ -20381,10 +18163,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001009",
@@ -20394,10 +18174,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001010",
@@ -20407,10 +18185,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001011",
@@ -20420,10 +18196,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001012",
@@ -20433,10 +18207,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001013",
@@ -20446,10 +18218,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001014",
@@ -20459,10 +18229,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001015",
@@ -20472,10 +18240,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001016",
@@ -20485,10 +18251,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001017",
@@ -20498,10 +18262,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001018",
@@ -20511,10 +18273,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001019",
@@ -20524,10 +18284,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001020",
@@ -20537,10 +18295,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001021",
@@ -20550,10 +18306,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001022",
@@ -20563,10 +18317,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001023",
@@ -20576,10 +18328,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001101",
@@ -20729,10 +18479,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002001",
@@ -20742,10 +18490,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002002",
@@ -20755,10 +18501,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002003",
@@ -20828,10 +18572,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002008",
@@ -20841,10 +18583,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002009",
@@ -20854,10 +18594,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002010",
@@ -20867,10 +18605,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002011",
@@ -20880,10 +18616,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002012",
@@ -20893,10 +18627,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002013",
@@ -20906,10 +18638,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002014",
@@ -20919,10 +18649,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002015",
@@ -20932,10 +18660,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002016",
@@ -20945,10 +18671,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002017",
@@ -20958,10 +18682,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002018",
@@ -20971,10 +18693,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002019",
@@ -20984,10 +18704,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002020",
@@ -20997,10 +18715,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002021",
@@ -21010,10 +18726,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002022",
@@ -21023,10 +18737,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002023",
@@ -21036,10 +18748,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002024",
@@ -21049,10 +18759,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002025",
@@ -21062,10 +18770,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002026",
@@ -21075,10 +18781,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002027",
@@ -21088,10 +18792,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002028",
@@ -21101,10 +18803,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002029",
@@ -21114,10 +18814,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002030",
@@ -21127,10 +18825,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002031",
@@ -21140,10 +18836,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002032",
@@ -21153,10 +18847,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002033",
@@ -21166,10 +18858,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002034",
@@ -21179,10 +18869,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002035",
@@ -21192,10 +18880,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002036",
@@ -21205,10 +18891,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002037",
@@ -21218,10 +18902,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002038",
@@ -21231,10 +18913,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002039",
@@ -21244,10 +18924,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002040",
@@ -21257,10 +18935,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1003000",
@@ -23099,10 +20775,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000000",
@@ -23113,10 +20787,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000001",
@@ -24000,10 +21672,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000053",
@@ -24014,10 +21684,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000054",
@@ -24028,10 +21696,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000055",
@@ -24042,10 +21708,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000056",
@@ -24056,10 +21720,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000057",
@@ -24070,10 +21732,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000064",
@@ -24168,10 +21828,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000202",
@@ -24199,10 +21857,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000204",
@@ -24213,10 +21869,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000205",
@@ -24227,10 +21881,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000206",
@@ -24241,10 +21893,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000207",
@@ -24285,10 +21935,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000214",
@@ -24299,10 +21947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000215",
@@ -24313,10 +21959,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000216",
@@ -24327,10 +21971,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000217",
@@ -24341,10 +21983,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000218",
@@ -24355,10 +21995,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000219",
@@ -24369,10 +22007,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000220",
@@ -24400,10 +22036,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000222",
@@ -24431,10 +22065,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000224",
@@ -24445,10 +22077,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000225",
@@ -24459,10 +22089,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000226",
@@ -24473,10 +22101,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000227",
@@ -24517,10 +22143,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000234",
@@ -24531,10 +22155,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000235",
@@ -24545,10 +22167,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000236",
@@ -24559,10 +22179,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000237",
@@ -24573,10 +22191,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000238",
@@ -24587,10 +22203,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000239",
@@ -24601,10 +22215,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000301",
@@ -24666,10 +22278,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000502",
@@ -24680,10 +22290,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000503",
@@ -24694,10 +22302,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000504",
@@ -24708,10 +22314,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000505",
@@ -24722,10 +22326,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000506",
@@ -24736,10 +22338,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000507",
@@ -24750,10 +22350,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000508",
@@ -24764,10 +22362,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000509",
@@ -24778,10 +22374,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000510",
@@ -24792,10 +22386,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000511",
@@ -24806,10 +22398,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000512",
@@ -24820,10 +22410,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000513",
@@ -24834,10 +22422,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000514",
@@ -24848,10 +22434,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000515",
@@ -24862,10 +22446,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000516",
@@ -24876,10 +22458,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000517",
@@ -25012,10 +22592,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000059",
@@ -25026,10 +22604,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000060",
@@ -25040,10 +22616,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000061",
@@ -25054,10 +22628,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000062",
@@ -25068,10 +22640,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000063",
@@ -25082,10 +22652,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000071",

--- a/metpo-base.owl
+++ b/metpo-base.owl
@@ -173,7 +173,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000000">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has susceptibility profile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1007,7 +1007,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000052">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1017,7 +1017,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000053">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1027,7 +1027,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000054">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1037,7 +1037,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000055">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1047,7 +1047,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000056">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has temperature delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1057,7 +1057,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000057">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has culture temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1160,7 +1160,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000201">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lyses</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1186,7 +1186,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000203">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete fixes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1196,7 +1196,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000204">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete catabolizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1206,7 +1206,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000205">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete mineralizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1216,7 +1216,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000206">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete conjugates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1288,7 +1288,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000213">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete binds</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1298,7 +1298,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000214">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chelates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1308,7 +1308,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000215">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete precipitates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1318,7 +1318,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000216">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete solubilizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1328,7 +1328,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000217">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete volatilizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1338,7 +1338,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000218">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete crystallizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1348,7 +1348,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000219">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete adsorbs</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1374,7 +1374,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000221">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not lyse</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1400,7 +1400,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000223">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not fix</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1410,7 +1410,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000224">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not catabolize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1420,7 +1420,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000225">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not mineralize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1430,7 +1430,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000226">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not conjugate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1502,7 +1502,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000233">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not bind</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1512,7 +1512,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000234">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not chelate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1522,7 +1522,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000235">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not precipitate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1532,7 +1532,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000236">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not solubilize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1542,7 +1542,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000237">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not volatilize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1552,7 +1552,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000238">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not crystallize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1562,7 +1562,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000239">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1625,7 +1625,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000501">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1635,7 +1635,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000502">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1645,7 +1645,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000503">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1655,7 +1655,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000504">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has pH delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1665,7 +1665,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000505">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has culture pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1675,7 +1675,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000506">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1685,7 +1685,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000507">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1695,7 +1695,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000508">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1705,7 +1705,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000509">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1715,7 +1715,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000510">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has NaCl delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1725,7 +1725,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000511">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1735,7 +1735,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000512">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1745,7 +1745,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000513">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1755,7 +1755,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000514">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1765,7 +1765,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000515">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1775,7 +1775,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000516">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has oxygen delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1914,7 +1914,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000058">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has observed spot value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1924,7 +1924,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000059">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has minimum observed value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1934,7 +1934,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000060">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has maximum observed value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1944,7 +1944,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000061">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has value comments</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1954,7 +1954,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000062">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete is negative data</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1964,7 +1964,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000063">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete observation data property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -2468,7 +2468,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2479,7 +2479,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2490,7 +2490,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2501,7 +2501,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2512,7 +2512,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2523,7 +2523,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2534,7 +2534,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2545,7 +2545,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2556,7 +2556,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2567,7 +2567,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2578,7 +2578,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2589,7 +2589,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2600,7 +2600,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2611,7 +2611,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2622,7 +2622,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2633,7 +2633,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2644,7 +2644,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2655,7 +2655,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2666,7 +2666,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2677,7 +2677,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2688,7 +2688,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2699,7 +2699,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2710,7 +2710,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete METPO Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2721,7 +2721,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2732,7 +2732,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2743,7 +2743,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mesophilie</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2754,7 +2754,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2765,7 +2765,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2776,7 +2776,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2787,7 +2787,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2798,7 +2798,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2809,7 +2809,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2820,7 +2820,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2831,7 +2831,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2842,7 +2842,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2853,7 +2853,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2864,7 +2864,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2875,7 +2875,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2886,7 +2886,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2897,7 +2897,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2908,7 +2908,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2919,7 +2919,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2930,7 +2930,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2941,7 +2941,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2952,7 +2952,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acid Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2963,7 +2963,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2974,7 +2974,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2985,7 +2985,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2996,7 +2996,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3007,7 +3007,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3018,7 +3018,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3029,7 +3029,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3040,7 +3040,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3051,7 +3051,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3062,7 +3062,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3073,7 +3073,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3084,7 +3084,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3095,7 +3095,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3106,7 +3106,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3117,7 +3117,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3128,7 +3128,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3139,7 +3139,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3150,7 +3150,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3161,7 +3161,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3172,7 +3172,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3183,7 +3183,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3194,7 +3194,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3205,7 +3205,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3216,7 +3216,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3227,7 +3227,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3238,7 +3238,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3249,7 +3249,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3260,7 +3260,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3271,7 +3271,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3282,7 +3282,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3293,7 +3293,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3304,7 +3304,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3315,7 +3315,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3326,7 +3326,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3337,7 +3337,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3348,7 +3348,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3359,7 +3359,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3370,7 +3370,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3381,7 +3381,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3392,7 +3392,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3403,7 +3403,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3414,7 +3414,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3425,7 +3425,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3436,7 +3436,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3447,7 +3447,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3458,7 +3458,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3469,7 +3469,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3480,7 +3480,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3491,7 +3491,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3502,7 +3502,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3513,7 +3513,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3524,7 +3524,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3535,7 +3535,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3546,7 +3546,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3557,7 +3557,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3568,7 +3568,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3579,7 +3579,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3590,7 +3590,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3601,7 +3601,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3612,7 +3612,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3623,7 +3623,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3634,7 +3634,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Endospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3645,7 +3645,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Exospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3656,7 +3656,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3667,7 +3667,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3678,7 +3678,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Arthrospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3689,7 +3689,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3700,7 +3700,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporangiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3711,7 +3711,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3722,7 +3722,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Akinetes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3733,7 +3733,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3744,7 +3744,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3755,7 +3755,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3766,7 +3766,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3777,7 +3777,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3788,7 +3788,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3799,7 +3799,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3810,7 +3810,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3821,7 +3821,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ascospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3832,7 +3832,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Basidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3843,7 +3843,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3854,7 +3854,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3865,7 +3865,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3876,7 +3876,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zoospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3887,7 +3887,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3898,7 +3898,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3909,7 +3909,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3920,7 +3920,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3931,7 +3931,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3942,7 +3942,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3953,7 +3953,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3964,7 +3964,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3975,7 +3975,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3986,7 +3986,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3997,7 +3997,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4008,7 +4008,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4019,7 +4019,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4030,7 +4030,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4041,7 +4041,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4052,7 +4052,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4063,7 +4063,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4074,7 +4074,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4085,7 +4085,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4096,7 +4096,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4107,7 +4107,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4118,7 +4118,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4129,7 +4129,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4140,7 +4140,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4151,7 +4151,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4162,7 +4162,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4173,7 +4173,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4184,7 +4184,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4195,7 +4195,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4206,7 +4206,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4217,7 +4217,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4228,7 +4228,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4239,7 +4239,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4250,7 +4250,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4261,7 +4261,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4272,7 +4272,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4283,7 +4283,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4294,7 +4294,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4305,7 +4305,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4316,7 +4316,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4327,7 +4327,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4338,7 +4338,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4349,7 +4349,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4360,7 +4360,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4371,7 +4371,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4382,7 +4382,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4393,7 +4393,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4404,7 +4404,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4415,7 +4415,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4426,7 +4426,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4437,7 +4437,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4448,7 +4448,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4459,7 +4459,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4470,7 +4470,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4481,7 +4481,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid4</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4492,7 +4492,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4503,7 +4503,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4514,7 +4514,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4525,7 +4525,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4536,7 +4536,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4547,7 +4547,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4558,7 +4558,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4569,7 +4569,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid4</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4580,7 +4580,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4591,7 +4591,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4602,7 +4602,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4613,7 +4613,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4624,7 +4624,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4635,7 +4635,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4646,7 +4646,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4657,7 +4657,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4668,7 +4668,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4679,7 +4679,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4690,7 +4690,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4701,7 +4701,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4712,7 +4712,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4723,7 +4723,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4734,7 +4734,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4745,7 +4745,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4756,7 +4756,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4767,7 +4767,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4778,7 +4778,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4789,7 +4789,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4800,7 +4800,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4811,7 +4811,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4822,7 +4822,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4833,7 +4833,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4844,7 +4844,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4855,7 +4855,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4866,7 +4866,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4877,7 +4877,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4888,7 +4888,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4899,7 +4899,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4910,7 +4910,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4921,7 +4921,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4932,7 +4932,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4943,7 +4943,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4954,7 +4954,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4965,7 +4965,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4976,7 +4976,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4987,7 +4987,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4998,7 +4998,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5009,7 +5009,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Branced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5020,7 +5020,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5031,7 +5031,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5042,7 +5042,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5053,7 +5053,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5064,7 +5064,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Curved Spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5075,7 +5075,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5086,7 +5086,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Disc</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5097,7 +5097,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dumbbell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5108,7 +5108,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Other</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5119,7 +5119,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5130,7 +5130,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5141,7 +5141,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flask</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5152,7 +5152,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5163,7 +5163,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5174,7 +5174,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5185,7 +5185,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5196,7 +5196,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5207,7 +5207,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5218,7 +5218,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5229,7 +5229,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5240,7 +5240,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5251,7 +5251,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5262,7 +5262,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5273,7 +5273,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5284,7 +5284,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5295,7 +5295,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5306,7 +5306,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Square</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5317,7 +5317,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Star</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5328,7 +5328,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Star - Dumbbell - Pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5339,7 +5339,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5350,7 +5350,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5361,7 +5361,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Triangular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5372,7 +5372,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5383,7 +5383,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5394,7 +5394,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Condition</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5405,7 +5405,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physiological Trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5416,7 +5416,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Metabolic Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5427,7 +5427,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5438,7 +5438,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5449,7 +5449,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5460,7 +5460,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5471,7 +5471,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mesophilie</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5482,7 +5482,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Structural Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5493,7 +5493,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5504,7 +5504,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5515,7 +5515,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5526,7 +5526,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5537,7 +5537,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5548,7 +5548,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5559,7 +5559,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Electron Donor Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5570,7 +5570,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5581,7 +5581,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5592,7 +5592,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5603,7 +5603,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5614,7 +5614,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5625,7 +5625,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Reproductive Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5636,7 +5636,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dormancy Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5647,7 +5647,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5658,7 +5658,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5669,7 +5669,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Genomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5680,7 +5680,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Dimension</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5691,7 +5691,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5702,7 +5702,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5713,7 +5713,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5724,7 +5724,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5735,7 +5735,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5746,7 +5746,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5757,7 +5757,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Colony Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5768,7 +5768,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physical Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5779,7 +5779,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Context</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5790,7 +5790,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Biological Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5801,7 +5801,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Functional Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5812,7 +5812,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Classification Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5823,7 +5823,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete METPO Biological Process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5834,7 +5834,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5845,7 +5845,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Measurable Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5856,7 +5856,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-stain negative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5867,7 +5867,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-stain positive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5878,7 +5878,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5889,7 +5889,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5900,7 +5900,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5911,7 +5911,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5922,7 +5922,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5933,7 +5933,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5944,7 +5944,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5955,7 +5955,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5966,7 +5966,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5977,7 +5977,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5988,7 +5988,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5999,7 +5999,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6010,7 +6010,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6021,7 +6021,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acid Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6032,7 +6032,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6043,7 +6043,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6054,7 +6054,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6065,7 +6065,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6076,7 +6076,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6087,7 +6087,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6098,7 +6098,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6109,7 +6109,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6120,7 +6120,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6131,7 +6131,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6142,7 +6142,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6153,7 +6153,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6164,7 +6164,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6175,7 +6175,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6186,7 +6186,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6197,7 +6197,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6208,7 +6208,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6219,7 +6219,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6230,7 +6230,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6241,7 +6241,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6252,7 +6252,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6263,7 +6263,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6274,7 +6274,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6285,7 +6285,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6296,7 +6296,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6307,7 +6307,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6318,7 +6318,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6329,7 +6329,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6340,7 +6340,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6351,7 +6351,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6362,7 +6362,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6373,7 +6373,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6384,7 +6384,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6395,7 +6395,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6406,7 +6406,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6417,7 +6417,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6428,7 +6428,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6439,7 +6439,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6450,7 +6450,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6461,7 +6461,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6472,7 +6472,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6483,7 +6483,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6494,7 +6494,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6505,7 +6505,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6516,7 +6516,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6527,7 +6527,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6538,7 +6538,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6549,7 +6549,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6560,7 +6560,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6571,7 +6571,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6582,7 +6582,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6593,7 +6593,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6604,7 +6604,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6615,7 +6615,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6626,7 +6626,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6637,7 +6637,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6648,7 +6648,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Endospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6659,7 +6659,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Exospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6670,7 +6670,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6681,7 +6681,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6692,7 +6692,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;organismal quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6703,7 +6703,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;physicial object quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6714,7 +6714,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6725,7 +6725,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6736,7 +6736,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete 1-D extent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6747,7 +6747,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6758,7 +6758,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6769,7 +6769,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6780,7 +6780,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;prokaryotic metabolically differentiated cell&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6791,7 +6791,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterotrophy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6802,7 +6802,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6813,7 +6813,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spore type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6824,7 +6824,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6835,7 +6835,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward NaCl</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6846,7 +6846,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6857,7 +6857,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6868,7 +6868,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Arthrospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6879,7 +6879,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic constraints</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6890,7 +6890,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell by chemical produced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6901,7 +6901,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6912,7 +6912,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporangiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6923,7 +6923,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6934,7 +6934,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Akinetes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6945,7 +6945,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6956,7 +6956,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6967,7 +6967,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6978,7 +6978,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6989,7 +6989,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7000,7 +7000,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7011,7 +7011,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7022,7 +7022,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ascospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7033,7 +7033,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Basidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7044,7 +7044,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7055,7 +7055,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7066,7 +7066,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7077,7 +7077,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zoospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7088,7 +7088,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7099,7 +7099,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7110,7 +7110,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7121,7 +7121,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7132,7 +7132,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7143,7 +7143,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7154,7 +7154,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7165,7 +7165,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7176,7 +7176,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7187,7 +7187,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7198,7 +7198,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7209,7 +7209,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7220,7 +7220,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7231,7 +7231,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7242,7 +7242,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7253,7 +7253,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7264,7 +7264,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7275,7 +7275,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7286,7 +7286,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7297,7 +7297,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7308,7 +7308,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7319,7 +7319,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7330,7 +7330,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7341,7 +7341,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7352,7 +7352,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7363,7 +7363,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7374,7 +7374,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7385,7 +7385,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7396,7 +7396,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7407,7 +7407,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7418,7 +7418,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7429,7 +7429,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7440,7 +7440,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% low ( &lt; 42.65)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7451,7 +7451,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% mid1 (42.65 - 57)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7462,7 +7462,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% mid2 (57 - 66.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7473,7 +7473,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% high ( &gt; 66.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7484,7 +7484,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM very low (&lt; 0.5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7495,7 +7495,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM low (0.5 - 0.65)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7506,7 +7506,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM mid (0.65 - 0.9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7517,7 +7517,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM high (&gt; 0.9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7528,7 +7528,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM very low (&lt;= 1.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7539,7 +7539,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM low (1.3 - 2)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7550,7 +7550,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM mid (2 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7561,7 +7561,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM high (&gt; 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7572,7 +7572,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C very low (&lt;= 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7583,7 +7583,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C low (10 - 22)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7594,7 +7594,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid1 (22 - 27)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7605,7 +7605,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid2 (27 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7616,7 +7616,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid3 (30 - 34)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7627,7 +7627,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid4 (34 - 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7638,7 +7638,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C high (&gt; 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7649,7 +7649,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C very low (&lt;= 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7660,7 +7660,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C low (10 - 22)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7671,7 +7671,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid1 (22 - 27)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7682,7 +7682,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid2 (27 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7693,7 +7693,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid3 (30 - 34)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7704,7 +7704,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid4 (34 - 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7715,7 +7715,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C high (&gt; 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7726,7 +7726,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum low (0 - 6)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7737,7 +7737,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid1 (6 - 7)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7748,7 +7748,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid2 (7 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7759,7 +7759,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum high (8 - 14)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7770,7 +7770,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range very low (0 - 4)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7781,7 +7781,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range low (4 - 6)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7792,7 +7792,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid1 (6 - 7)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7803,7 +7803,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid2 (7 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7814,7 +7814,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid3 (8 - 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7825,7 +7825,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range high (10 - 14)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7836,7 +7836,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7847,7 +7847,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum mid1 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7858,7 +7858,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7869,7 +7869,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum high (&gt; 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7880,7 +7880,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7891,7 +7891,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range mid1 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7902,7 +7902,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7913,7 +7913,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range high (&gt; 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7924,7 +7924,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta very low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7935,7 +7935,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta low (1 - 2)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7946,7 +7946,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid1 (2 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7957,7 +7957,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid2 (3 - 4)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7968,7 +7968,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid3 (4 - 5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7979,7 +7979,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta high (5 - 9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7990,7 +7990,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8001,7 +8001,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta mid2 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8012,7 +8012,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8023,7 +8023,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta high (&gt;= 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8034,7 +8034,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta very low (1 - 5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8045,7 +8045,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta low (5 - 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8056,7 +8056,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta mid1 (10 - 20)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8067,7 +8067,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta mid2 (20 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8078,7 +8078,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta high (&gt;= 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8089,7 +8089,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8100,7 +8100,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete branced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8111,7 +8111,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8122,7 +8122,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8133,7 +8133,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8144,7 +8144,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8155,7 +8155,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete curved spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8166,7 +8166,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8177,7 +8177,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete disc</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8188,7 +8188,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dumbbell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8199,7 +8199,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8210,7 +8210,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8221,7 +8221,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flask</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8232,7 +8232,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8243,7 +8243,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8254,7 +8254,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8265,7 +8265,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8276,7 +8276,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8287,7 +8287,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8298,7 +8298,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8309,7 +8309,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8320,7 +8320,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8331,7 +8331,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8342,7 +8342,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8353,7 +8353,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8364,7 +8364,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8375,7 +8375,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete square</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8386,7 +8386,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8397,7 +8397,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8408,7 +8408,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8419,7 +8419,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete triangular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8430,7 +8430,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8441,7 +8441,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8452,7 +8452,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Condition</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8463,7 +8463,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physiological Trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8474,7 +8474,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Metabolic Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8485,7 +8485,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8496,7 +8496,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8507,7 +8507,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8518,7 +8518,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8529,7 +8529,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Structural Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8540,7 +8540,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8551,7 +8551,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8562,7 +8562,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8573,7 +8573,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8584,7 +8584,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8595,7 +8595,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8606,7 +8606,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Electron Donor Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8617,7 +8617,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8628,7 +8628,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8639,7 +8639,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8650,7 +8650,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8661,7 +8661,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Reproductive Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8672,7 +8672,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dormancy Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8683,7 +8683,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8694,7 +8694,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8705,7 +8705,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GenomicFeature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8716,7 +8716,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Dimension</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8727,7 +8727,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8738,7 +8738,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8749,7 +8749,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8760,7 +8760,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8771,7 +8771,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8782,7 +8782,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Colony Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8793,7 +8793,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete acid-fast</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8804,7 +8804,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8815,7 +8815,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete active transport</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8826,7 +8826,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8837,7 +8837,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adaptive trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8848,7 +8848,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adhesin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8859,7 +8859,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adhesion structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8870,7 +8870,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8881,7 +8881,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerobic respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8892,7 +8892,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8903,7 +8903,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aggregate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8914,7 +8914,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete akinete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8925,7 +8925,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8936,7 +8936,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ammonification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8947,7 +8947,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete amylolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8958,7 +8958,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8969,7 +8969,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anaerobic respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8980,7 +8980,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anoxygenic photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8991,7 +8991,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antibiotic production</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9002,7 +9002,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antibiotic resistance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9013,7 +9013,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antimicrobial resistance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9024,7 +9024,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete appendage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9035,7 +9035,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete arthrospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9046,7 +9046,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ascospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9057,7 +9057,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9068,7 +9068,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete autotrophic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9079,7 +9079,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete auxotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9090,7 +9090,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete axial filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9101,7 +9101,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9112,7 +9112,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9123,7 +9123,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9134,7 +9134,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete basidiospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9145,7 +9145,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete binary fission</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9156,7 +9156,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9167,7 +9167,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9178,7 +9178,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm formation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9189,7 +9189,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biogeochemical cycling</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9200,7 +9200,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bioluminescence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9211,7 +9211,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete budding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9222,7 +9222,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete buoyancy structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9233,7 +9233,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9244,7 +9244,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete capsule</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9255,7 +9255,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carbon fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9266,7 +9266,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carbon source</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9277,7 +9277,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9288,7 +9288,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9299,7 +9299,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell envelope</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9310,7 +9310,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell length category</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9321,7 +9321,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9332,7 +9332,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9343,7 +9343,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell wall characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9354,7 +9354,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell wall component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9365,7 +9365,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell width category</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9376,7 +9376,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9387,7 +9387,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9398,7 +9398,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9409,7 +9409,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular product</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9420,7 +9420,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellulolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9468,7 +9468,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9479,7 +9479,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chemotaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9490,7 +9490,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chlamydospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9501,7 +9501,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete class</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9512,7 +9512,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete clinically relevant feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9523,7 +9523,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9534,7 +9534,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cold shock protein</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9545,7 +9545,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cold shock response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9556,7 +9556,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colonization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9567,7 +9567,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony elevation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9578,7 +9578,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony margin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9589,7 +9589,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9600,7 +9600,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony texture</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9611,7 +9611,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete commensalism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9622,7 +9622,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete community behavior</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9633,7 +9633,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete community structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9644,7 +9644,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete compatible solute</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9655,7 +9655,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete competence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9666,7 +9666,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9677,7 +9677,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete conidium</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9688,7 +9688,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete conjugation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9699,7 +9699,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete CRISPR</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9710,7 +9710,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete culturability</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9721,7 +9721,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cyst</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9732,7 +9732,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete death phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9743,7 +9743,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete denitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9754,7 +9754,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete developmental process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9765,7 +9765,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diagnostic enzyme</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9776,7 +9776,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diagnostic feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9787,7 +9787,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diazotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9798,7 +9798,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete differentiation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9809,7 +9809,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dimorphism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9820,7 +9820,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete disc-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9831,7 +9831,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete domain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9842,7 +9842,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dormancy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9853,7 +9853,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dormancy structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9864,7 +9864,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dumbbell-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9875,7 +9875,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological niche</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9886,7 +9886,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9897,7 +9897,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9908,7 +9908,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ectosymbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9919,7 +9919,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete electron acceptor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9930,7 +9930,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete electron donor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9941,7 +9941,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete endospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9952,7 +9952,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete endosymbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9963,7 +9963,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete energy metabolism process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9974,7 +9974,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete enzyme activity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9985,7 +9985,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete epigenetic modification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9996,7 +9996,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete evolutionary process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10007,7 +10007,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete exospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10018,7 +10018,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete exponential phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10029,7 +10029,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extracellular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10040,7 +10040,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extracellular polysaccharide</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10051,7 +10051,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10062,7 +10062,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extremophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10073,7 +10073,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete facultative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10084,7 +10084,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10095,7 +10095,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete family</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10106,7 +10106,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fastidious</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10117,7 +10117,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fermentation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10128,7 +10128,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete filamentous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10139,7 +10139,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fimbriae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10150,7 +10150,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flagellum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10161,7 +10161,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flask-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10172,7 +10172,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fungal spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10183,7 +10183,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete gas vesicle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10218,7 +10218,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete high GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10229,7 +10229,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete low GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10240,7 +10240,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lower-mid GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10251,7 +10251,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete upper-mid GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10262,7 +10262,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete generation time</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10273,7 +10273,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10284,7 +10284,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic exchange</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10295,7 +10295,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10306,7 +10306,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genome size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10317,7 +10317,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10328,7 +10328,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic island</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10339,7 +10339,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10350,7 +10350,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10361,7 +10361,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete gliding motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10372,7 +10372,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete global regulator</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10383,7 +10383,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-negative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10394,7 +10394,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-positive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10405,7 +10405,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram stain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10416,7 +10416,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10427,7 +10427,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth conditions constraints</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10438,7 +10438,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth pattern</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10449,7 +10449,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth rate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10460,7 +10460,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete habitat</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10471,7 +10471,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10482,7 +10482,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10493,7 +10493,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heat shock protein</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10504,7 +10504,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heat shock response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10515,7 +10515,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hemolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10526,7 +10526,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterocyst</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10537,7 +10537,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10548,7 +10548,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete holdfast</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10559,7 +10559,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete horizontal gene transfer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10570,7 +10570,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hydrolase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10581,7 +10581,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10592,7 +10592,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete inclusion body</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10603,7 +10603,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete infection</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10614,7 +10614,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10625,7 +10625,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with a phage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10636,7 +10636,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with an environment</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10647,7 +10647,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with host</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10658,7 +10658,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction within a community</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10669,7 +10669,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete intracellular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10680,7 +10680,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete invasion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10691,7 +10691,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete laboratory characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10702,7 +10702,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lag phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10713,7 +10713,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete life cycle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10724,7 +10724,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete life cycle phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10735,7 +10735,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lipolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10746,7 +10746,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lipopolysaccharide</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10757,7 +10757,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete localization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10768,7 +10768,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lysogeny</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10779,7 +10779,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete macroscopic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10790,7 +10790,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete magnetotaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10801,7 +10801,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mesophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10812,7 +10812,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic partner</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10823,7 +10823,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10834,7 +10834,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10845,7 +10845,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete methylation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10872,7 +10872,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10892,7 +10892,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10903,7 +10903,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10914,7 +10914,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mobile genetic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10925,7 +10925,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10936,7 +10936,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete morphological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10947,7 +10947,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete motility process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10958,7 +10958,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete motility structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10969,7 +10969,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mutualism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10980,7 +10980,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mycolic acid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10991,7 +10991,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mycorrhization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11002,7 +11002,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11013,7 +11013,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11024,7 +11024,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nitrogen fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11035,7 +11035,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nodulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11046,7 +11046,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nucleoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11057,7 +11057,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nutrient utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11068,7 +11068,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11079,7 +11079,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11090,7 +11090,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11101,7 +11101,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11112,7 +11112,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete order</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11123,7 +11123,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by growth conditions</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11134,7 +11134,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by nutritional requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11145,7 +11145,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by product produced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11156,7 +11156,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11167,7 +11167,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to ph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11178,7 +11178,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11189,7 +11189,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to salt concentration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11200,7 +11200,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11211,7 +11211,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11222,7 +11222,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11233,7 +11233,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete osmophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11244,7 +11244,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete osmoregulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11255,7 +11255,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxidative stress response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11266,7 +11266,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxidoreductase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11277,7 +11277,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxygen requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11288,7 +11288,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxygenic photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11299,7 +11299,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pan-genome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11310,7 +11310,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete parasitism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11321,7 +11321,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete passive transport</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11332,7 +11332,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pathogenicity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11343,7 +11343,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pathogenicity island</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11354,7 +11354,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete peptidoglycan</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11375,7 +11375,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH optimum (growth range)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11386,7 +11386,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11397,7 +11397,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH range (growth tolerance)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11408,7 +11408,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH tolerance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11419,7 +11419,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phage defense</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11430,7 +11430,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11441,7 +11441,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11452,7 +11452,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11463,7 +11463,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phototaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11474,7 +11474,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phylum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11485,7 +11485,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11496,7 +11496,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological state</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11507,7 +11507,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11518,7 +11518,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11529,7 +11529,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pigment</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11540,7 +11540,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pigmentation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11551,7 +11551,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pilus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11562,7 +11562,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete plant growth promotion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11573,7 +11573,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete plasmid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11584,7 +11584,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pleomorphism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11595,7 +11595,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11606,7 +11606,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prophage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11617,7 +11617,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prostheca</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11628,7 +11628,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete protein synthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11639,7 +11639,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete proteolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11650,7 +11650,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11661,7 +11661,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11672,7 +11672,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete qualifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11683,7 +11683,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete quorum sensing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11694,7 +11694,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete regulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11705,7 +11705,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete regulatory mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11716,7 +11716,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete reproductive process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11727,7 +11727,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete reproductive structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11738,7 +11738,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete resistance mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11749,7 +11749,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11760,7 +11760,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete restriction-modification system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11771,7 +11771,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ribosome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11782,7 +11782,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete S-layer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11793,7 +11793,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete salinity delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11804,7 +11804,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete salinity preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11815,7 +11815,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secondary metabolite</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11826,7 +11826,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secretion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11837,7 +11837,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secretion system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11848,7 +11848,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sheathed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11859,7 +11859,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete siderophore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11870,7 +11870,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sigma factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11881,7 +11881,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete signaling</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11892,7 +11892,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete slime layer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11903,7 +11903,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete specialized cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11914,7 +11914,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete species</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11925,7 +11925,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirillum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11936,7 +11936,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11947,7 +11947,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sporangiospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11958,7 +11958,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11969,7 +11969,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete square cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11980,7 +11980,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stalk</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11991,7 +11991,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12002,7 +12002,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stationary phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12013,7 +12013,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete storage structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12024,7 +12024,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete strain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12035,7 +12035,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stress response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12046,7 +12046,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12057,7 +12057,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12068,7 +12068,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12079,7 +12079,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete symbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12090,7 +12090,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete symbiotic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12101,7 +12101,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete syntrophy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12112,7 +12112,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete taxonomic identifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12123,7 +12123,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete taxonomic rank</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12134,7 +12134,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete teichoic acid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12173,7 +12173,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete temperature preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12194,7 +12194,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete thermal tolerance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12205,7 +12205,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12216,7 +12216,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete toxin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12227,7 +12227,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transcription factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12238,7 +12238,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12249,7 +12249,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transferase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12260,7 +12260,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transformation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12271,7 +12271,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transport system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12282,7 +12282,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transposon</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12293,7 +12293,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete triangular cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12304,7 +12304,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete trichome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12315,7 +12315,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete twitching motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12326,7 +12326,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete two-component system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12337,7 +12337,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete viable but non-culturable</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12348,7 +12348,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12359,7 +12359,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12370,7 +12370,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12381,7 +12381,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12392,7 +12392,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete xylanolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12403,7 +12403,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete zoospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12414,7 +12414,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete zygospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12425,7 +12425,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12436,7 +12436,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature optimum (metabolic activity)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12447,7 +12447,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature range (metabolic viability)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12519,7 +12519,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12530,7 +12530,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12541,7 +12541,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12552,7 +12552,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12563,7 +12563,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12574,7 +12574,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12585,7 +12585,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12596,7 +12596,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12607,7 +12607,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete acid tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12618,7 +12618,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete alkali tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12629,7 +12629,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12640,7 +12640,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12651,7 +12651,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12662,7 +12662,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12673,7 +12673,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12684,7 +12684,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12695,7 +12695,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12706,7 +12706,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12717,7 +12717,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12728,7 +12728,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12739,7 +12739,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12750,7 +12750,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12761,7 +12761,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12772,7 +12772,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12783,7 +12783,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12794,7 +12794,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12805,7 +12805,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12816,7 +12816,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12827,7 +12827,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12838,7 +12838,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12849,7 +12849,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12860,7 +12860,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12871,7 +12871,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12882,7 +12882,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12893,7 +12893,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12904,7 +12904,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12915,7 +12915,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12926,7 +12926,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12937,7 +12937,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12948,7 +12948,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12959,7 +12959,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12970,7 +12970,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12981,7 +12981,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12992,7 +12992,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13003,7 +13003,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13014,7 +13014,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13025,7 +13025,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13036,7 +13036,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13047,7 +13047,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13058,7 +13058,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13069,7 +13069,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13080,7 +13080,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13091,7 +13091,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13102,7 +13102,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13113,7 +13113,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13124,7 +13124,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13135,7 +13135,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13146,7 +13146,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13157,7 +13157,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13168,7 +13168,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13179,7 +13179,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13190,7 +13190,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13201,7 +13201,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13212,7 +13212,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13223,7 +13223,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13234,7 +13234,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13245,7 +13245,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13256,7 +13256,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13267,7 +13267,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13278,7 +13278,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13289,7 +13289,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13300,7 +13300,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13311,7 +13311,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13322,7 +13322,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13333,7 +13333,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13344,7 +13344,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13355,7 +13355,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13366,7 +13366,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13377,7 +13377,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13388,7 +13388,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13399,7 +13399,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13410,7 +13410,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13421,7 +13421,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13432,7 +13432,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13443,7 +13443,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13454,7 +13454,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13465,7 +13465,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13476,7 +13476,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13487,7 +13487,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13498,7 +13498,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13509,7 +13509,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13520,7 +13520,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13531,7 +13531,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13698,7 +13698,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13709,7 +13709,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13720,7 +13720,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13731,7 +13731,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13742,7 +13742,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13753,7 +13753,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13764,7 +13764,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13775,7 +13775,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15762,7 +15762,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete branched</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15773,7 +15773,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15784,7 +15784,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15795,7 +15795,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15806,7 +15806,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete curved spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15817,7 +15817,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15828,7 +15828,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15839,7 +15839,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15850,7 +15850,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15861,7 +15861,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15872,7 +15872,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15883,7 +15883,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15894,7 +15894,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15905,7 +15905,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15916,7 +15916,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15927,7 +15927,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15938,7 +15938,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15949,7 +15949,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15960,7 +15960,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15971,7 +15971,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15982,7 +15982,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15993,7 +15993,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16004,7 +16004,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete salinity adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16015,7 +16015,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16026,7 +16026,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete bacterial spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16037,7 +16037,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure adaptation type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16048,7 +16048,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure tolerance range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16059,7 +16059,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16070,7 +16070,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16081,7 +16081,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16092,7 +16092,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete 1-D extent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16103,7 +16103,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16114,7 +16114,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16125,7 +16125,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16136,7 +16136,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward nacl</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16147,7 +16147,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward ph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16158,7 +16158,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16214,7 +16214,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete structured susceptibility detail</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16225,7 +16225,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17503,7 +17503,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete denitrifying</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17558,7 +17558,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17739,7 +17739,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete nitrogen-fixing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17995,7 +17995,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -18006,7 +18006,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfur-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19367,7 +19367,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19378,7 +19378,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19389,7 +19389,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Denitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19400,7 +19400,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Dissimilatory nitrate reduction to ammonium</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19411,7 +19411,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19422,7 +19422,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic ammonium oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19433,7 +19433,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitric oxide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19444,7 +19444,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrous oxide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19455,7 +19455,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur and sulfoxide compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19466,7 +19466,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19477,7 +19477,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19488,7 +19488,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19499,7 +19499,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19510,7 +19510,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19521,7 +19521,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Dimethyl sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19532,7 +19532,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methionine sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19543,7 +19543,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19554,7 +19554,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19565,7 +19565,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19576,7 +19576,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Tetrathionate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19587,7 +19587,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Polysulfide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19598,7 +19598,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Metal and metalloid respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19609,7 +19609,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19620,7 +19620,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19631,7 +19631,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent Fe(II) oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19642,7 +19642,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19653,7 +19653,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19664,7 +19664,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Uranium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19675,7 +19675,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Vanadium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19686,7 +19686,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chromium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19697,7 +19697,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Technetium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19708,7 +19708,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Cobalt reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19719,7 +19719,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19730,7 +19730,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19741,7 +19741,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19752,7 +19752,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19763,7 +19763,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon and organic compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19834,7 +19834,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Fumarate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19845,7 +19845,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Trimethylamine N-oxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19856,7 +19856,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Humus respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19867,7 +19867,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Halogenated compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19878,7 +19878,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Organohalide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19889,7 +19889,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete (Per)chlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19900,7 +19900,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Perchlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19911,7 +19911,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19922,7 +19922,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Bromate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19933,7 +19933,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iodate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19944,7 +19944,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19955,7 +19955,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19966,7 +19966,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogen oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19977,7 +19977,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19988,7 +19988,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19999,7 +19999,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Complete ammonia oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20010,7 +20010,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon monoxide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20021,7 +20021,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogenotrophic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20032,7 +20032,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Acetoclastic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20043,7 +20043,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methylotrophic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20054,7 +20054,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20065,7 +20065,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Lanthanide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20076,7 +20076,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Lanthanide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20574,7 +20574,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20585,7 +20585,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20596,7 +20596,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20607,7 +20607,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20618,7 +20618,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20629,7 +20629,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20640,7 +20640,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20651,7 +20651,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20662,7 +20662,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20673,7 +20673,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20684,7 +20684,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20695,7 +20695,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20706,7 +20706,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20717,7 +20717,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20728,7 +20728,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20739,7 +20739,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20750,7 +20750,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20761,7 +20761,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20772,7 +20772,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20783,7 +20783,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20794,7 +20794,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20805,7 +20805,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20816,7 +20816,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20827,7 +20827,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20956,7 +20956,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20967,7 +20967,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Fe(III)-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20978,7 +20978,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Mn(IV)-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21040,7 +21040,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur disproportionation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21051,7 +21051,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21062,7 +21062,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21073,7 +21073,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic ammonium-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21084,7 +21084,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrous oxide-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21095,7 +21095,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21106,7 +21106,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21117,7 +21117,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21128,7 +21128,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21139,7 +21139,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-disproportionating</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21150,7 +21150,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfide-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21161,7 +21161,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21172,7 +21172,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21183,7 +21183,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21194,7 +21194,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21205,7 +21205,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent Fe(II)-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21216,7 +21216,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21227,7 +21227,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21238,7 +21238,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Uranium-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21249,7 +21249,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21260,7 +21260,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21271,7 +21271,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenite-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21282,7 +21282,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Perchlorate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21293,7 +21293,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chlorate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21304,7 +21304,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Bromate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21315,7 +21315,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iodate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21326,7 +21326,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogen-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21337,7 +21337,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21348,7 +21348,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Ammonia oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21359,7 +21359,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21370,7 +21370,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Complete ammonia-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21381,7 +21381,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21392,7 +21392,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon monoxide-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21403,7 +21403,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen-fixing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -22932,7 +22932,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obsolete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
 </rdf:RDF>
 

--- a/metpo-full.json
+++ b/metpo-full.json
@@ -50,10 +50,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000002",
@@ -63,10 +61,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000003",
@@ -76,10 +72,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000004",
@@ -89,10 +83,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000005",
@@ -102,10 +94,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000006",
@@ -115,10 +105,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000007",
@@ -128,10 +116,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000008",
@@ -141,10 +127,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000009",
@@ -154,10 +138,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000001",
@@ -167,10 +149,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000010",
@@ -180,10 +160,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000011",
@@ -193,10 +171,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000012",
@@ -206,10 +182,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000013",
@@ -219,10 +193,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000014",
@@ -232,10 +204,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000015",
@@ -245,10 +215,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000016",
@@ -258,10 +226,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000017",
@@ -271,10 +237,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000018",
@@ -284,10 +248,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000019",
@@ -297,10 +259,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000002",
@@ -310,10 +270,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000020",
@@ -323,10 +281,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000021",
@@ -336,10 +292,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000022",
@@ -349,10 +303,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000023",
@@ -362,10 +314,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000024",
@@ -375,10 +325,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000025",
@@ -388,10 +336,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000026",
@@ -401,10 +347,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000027",
@@ -414,10 +358,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000028",
@@ -427,10 +369,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000029",
@@ -440,10 +380,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000003",
@@ -453,10 +391,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000030",
@@ -466,10 +402,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000031",
@@ -479,10 +413,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000032",
@@ -492,10 +424,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000033",
@@ -505,10 +435,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000034",
@@ -518,10 +446,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000035",
@@ -531,10 +457,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000036",
@@ -544,10 +468,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000037",
@@ -557,10 +479,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000038",
@@ -570,10 +490,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000039",
@@ -583,10 +501,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000004",
@@ -596,10 +512,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000040",
@@ -609,10 +523,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000041",
@@ -622,10 +534,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000042",
@@ -635,10 +545,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000043",
@@ -648,10 +556,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000044",
@@ -661,10 +567,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000045",
@@ -674,10 +578,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000046",
@@ -687,10 +589,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000047",
@@ -700,10 +600,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000048",
@@ -713,10 +611,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000049",
@@ -726,10 +622,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000005",
@@ -739,10 +633,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000050",
@@ -752,10 +644,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000051",
@@ -765,10 +655,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000052",
@@ -778,10 +666,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000053",
@@ -791,10 +677,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000054",
@@ -804,10 +688,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000055",
@@ -817,10 +699,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000056",
@@ -830,10 +710,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000057",
@@ -843,10 +721,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000058",
@@ -856,10 +732,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000059",
@@ -869,10 +743,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000006",
@@ -882,10 +754,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000060",
@@ -895,10 +765,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000061",
@@ -908,10 +776,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000062",
@@ -921,10 +787,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000063",
@@ -934,10 +798,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000064",
@@ -947,10 +809,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000065",
@@ -960,10 +820,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000066",
@@ -973,10 +831,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000067",
@@ -986,10 +842,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000068",
@@ -999,10 +853,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000069",
@@ -1012,10 +864,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000007",
@@ -1025,10 +875,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000070",
@@ -1038,10 +886,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000071",
@@ -1051,10 +897,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000072",
@@ -1064,10 +908,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000073",
@@ -1077,10 +919,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000074",
@@ -1090,10 +930,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000075",
@@ -1103,10 +941,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000076",
@@ -1116,10 +952,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000077",
@@ -1129,10 +963,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000078",
@@ -1142,10 +974,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000079",
@@ -1155,10 +985,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000008",
@@ -1168,10 +996,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000080",
@@ -1181,10 +1007,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000081",
@@ -1194,10 +1018,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000082",
@@ -1207,10 +1029,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000083",
@@ -1220,10 +1040,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000084",
@@ -1233,10 +1051,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000085",
@@ -1246,10 +1062,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000086",
@@ -1259,10 +1073,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000087",
@@ -1272,10 +1084,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000088",
@@ -1285,10 +1095,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000089",
@@ -1298,10 +1106,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000009",
@@ -1311,10 +1117,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000090",
@@ -1324,10 +1128,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000091",
@@ -1337,10 +1139,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000092",
@@ -1350,10 +1150,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000093",
@@ -1363,10 +1161,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000094",
@@ -1376,10 +1172,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000095",
@@ -1389,10 +1183,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000096",
@@ -1402,10 +1194,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000097",
@@ -1415,10 +1205,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000098",
@@ -1428,10 +1216,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000099",
@@ -1441,10 +1227,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000010",
@@ -1454,10 +1238,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000100",
@@ -1467,10 +1249,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000101",
@@ -1480,10 +1260,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000102",
@@ -1493,10 +1271,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000103",
@@ -1506,10 +1282,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000104",
@@ -1519,10 +1293,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000105",
@@ -1532,10 +1304,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000106",
@@ -1545,10 +1315,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000107",
@@ -1558,10 +1326,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000108",
@@ -1571,10 +1337,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000109",
@@ -1584,10 +1348,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000011",
@@ -1597,10 +1359,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000110",
@@ -1610,10 +1370,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000111",
@@ -1623,10 +1381,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000112",
@@ -1636,10 +1392,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000113",
@@ -1649,10 +1403,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000114",
@@ -1662,10 +1414,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000115",
@@ -1675,10 +1425,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000116",
@@ -1688,10 +1436,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000117",
@@ -1701,10 +1447,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000118",
@@ -1714,10 +1458,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000119",
@@ -1727,10 +1469,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000012",
@@ -1740,10 +1480,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000120",
@@ -1753,10 +1491,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000121",
@@ -1766,10 +1502,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000122",
@@ -1779,10 +1513,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000123",
@@ -1792,10 +1524,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000124",
@@ -1805,10 +1535,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000125",
@@ -1818,10 +1546,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000126",
@@ -1831,10 +1557,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000127",
@@ -1844,10 +1568,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000128",
@@ -1857,10 +1579,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000129",
@@ -1870,10 +1590,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000013",
@@ -1883,10 +1601,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000130",
@@ -1896,10 +1612,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000131",
@@ -1909,10 +1623,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000132",
@@ -1922,10 +1634,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000133",
@@ -1935,10 +1645,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000134",
@@ -1948,10 +1656,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000135",
@@ -1961,10 +1667,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000136",
@@ -1974,10 +1678,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000137",
@@ -1987,10 +1689,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000138",
@@ -2000,10 +1700,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000139",
@@ -2013,10 +1711,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000014",
@@ -2026,10 +1722,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000140",
@@ -2039,10 +1733,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000141",
@@ -2052,10 +1744,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000142",
@@ -2065,10 +1755,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000143",
@@ -2078,10 +1766,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000144",
@@ -2091,10 +1777,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000145",
@@ -2104,10 +1788,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000146",
@@ -2117,10 +1799,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000147",
@@ -2130,10 +1810,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000148",
@@ -2143,10 +1821,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000149",
@@ -2156,10 +1832,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000015",
@@ -2169,10 +1843,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000150",
@@ -2182,10 +1854,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000151",
@@ -2195,10 +1865,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000152",
@@ -2208,10 +1876,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000153",
@@ -2221,10 +1887,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000154",
@@ -2234,10 +1898,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000155",
@@ -2247,10 +1909,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000156",
@@ -2260,10 +1920,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000157",
@@ -2273,10 +1931,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000158",
@@ -2286,10 +1942,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000159",
@@ -2299,10 +1953,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000016",
@@ -2312,10 +1964,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000160",
@@ -2325,10 +1975,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000161",
@@ -2338,10 +1986,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000162",
@@ -2351,10 +1997,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000163",
@@ -2364,10 +2008,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000164",
@@ -2377,10 +2019,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000165",
@@ -2390,10 +2030,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000166",
@@ -2403,10 +2041,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000167",
@@ -2416,10 +2052,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000168",
@@ -2429,10 +2063,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000169",
@@ -2442,10 +2074,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000017",
@@ -2455,10 +2085,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000170",
@@ -2468,10 +2096,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000171",
@@ -2481,10 +2107,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000172",
@@ -2494,10 +2118,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000173",
@@ -2507,10 +2129,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000174",
@@ -2520,10 +2140,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000175",
@@ -2533,10 +2151,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000176",
@@ -2546,10 +2162,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000177",
@@ -2559,10 +2173,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000178",
@@ -2572,10 +2184,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000179",
@@ -2585,10 +2195,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000018",
@@ -2598,10 +2206,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000180",
@@ -2611,10 +2217,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000181",
@@ -2624,10 +2228,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000182",
@@ -2637,10 +2239,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000183",
@@ -2650,10 +2250,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000184",
@@ -2663,10 +2261,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000185",
@@ -2676,10 +2272,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000186",
@@ -2689,10 +2283,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000187",
@@ -2702,10 +2294,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000188",
@@ -2715,10 +2305,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000189",
@@ -2728,10 +2316,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000019",
@@ -2741,10 +2327,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000190",
@@ -2754,10 +2338,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000191",
@@ -2767,10 +2349,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000192",
@@ -2780,10 +2360,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000193",
@@ -2793,10 +2371,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000194",
@@ -2806,10 +2382,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000195",
@@ -2819,10 +2393,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000196",
@@ -2832,10 +2404,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000197",
@@ -2845,10 +2415,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000198",
@@ -2858,10 +2426,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000199",
@@ -2871,10 +2437,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000020",
@@ -2884,10 +2448,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000200",
@@ -2897,10 +2459,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000201",
@@ -2910,10 +2470,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000202",
@@ -2923,10 +2481,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000203",
@@ -2936,10 +2492,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000204",
@@ -2949,10 +2503,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000205",
@@ -2962,10 +2514,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000206",
@@ -2975,10 +2525,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000207",
@@ -2988,10 +2536,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000208",
@@ -3001,10 +2547,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000209",
@@ -3014,10 +2558,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000021",
@@ -3027,10 +2569,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000210",
@@ -3040,10 +2580,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000211",
@@ -3053,10 +2591,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000212",
@@ -3066,10 +2602,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000213",
@@ -3079,10 +2613,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000214",
@@ -3092,10 +2624,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000215",
@@ -3105,10 +2635,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000216",
@@ -3118,10 +2646,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000217",
@@ -3131,10 +2657,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000218",
@@ -3144,10 +2668,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000219",
@@ -3157,10 +2679,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000022",
@@ -3170,10 +2690,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000220",
@@ -3183,10 +2701,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000221",
@@ -3196,10 +2712,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000222",
@@ -3209,10 +2723,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000223",
@@ -3222,10 +2734,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000224",
@@ -3235,10 +2745,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000225",
@@ -3248,10 +2756,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000226",
@@ -3261,10 +2767,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000227",
@@ -3274,10 +2778,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000228",
@@ -3287,10 +2789,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000229",
@@ -3300,10 +2800,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000023",
@@ -3313,10 +2811,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000230",
@@ -3326,10 +2822,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000231",
@@ -3339,10 +2833,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000232",
@@ -3352,10 +2844,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000233",
@@ -3365,10 +2855,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000234",
@@ -3378,10 +2866,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000235",
@@ -3391,10 +2877,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000236",
@@ -3404,10 +2888,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000237",
@@ -3417,10 +2899,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000238",
@@ -3430,10 +2910,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000239",
@@ -3443,10 +2921,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000024",
@@ -3456,10 +2932,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000240",
@@ -3469,10 +2943,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000241",
@@ -3482,10 +2954,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000242",
@@ -3495,10 +2965,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000243",
@@ -3508,10 +2976,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000244",
@@ -3521,10 +2987,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000245",
@@ -3534,10 +2998,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000246",
@@ -3547,10 +3009,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000247",
@@ -3560,10 +3020,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000248",
@@ -3573,10 +3031,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000249",
@@ -3586,10 +3042,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000025",
@@ -3599,10 +3053,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000250",
@@ -3612,10 +3064,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000251",
@@ -3625,10 +3075,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000252",
@@ -3638,10 +3086,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000253",
@@ -3651,10 +3097,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000254",
@@ -3664,10 +3108,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000255",
@@ -3677,10 +3119,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000256",
@@ -3690,10 +3130,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000257",
@@ -3703,10 +3141,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000258",
@@ -3716,10 +3152,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000259",
@@ -3729,10 +3163,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000026",
@@ -3742,10 +3174,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000260",
@@ -3755,10 +3185,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000261",
@@ -3768,10 +3196,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000262",
@@ -3781,10 +3207,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000263",
@@ -3794,10 +3218,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000264",
@@ -3807,10 +3229,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000265",
@@ -3820,10 +3240,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000266",
@@ -3833,10 +3251,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000267",
@@ -3846,10 +3262,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000268",
@@ -3859,10 +3273,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000269",
@@ -3872,10 +3284,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000027",
@@ -3885,10 +3295,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000270",
@@ -3898,10 +3306,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000271",
@@ -3911,10 +3317,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000272",
@@ -3924,10 +3328,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000273",
@@ -3937,10 +3339,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000274",
@@ -3950,10 +3350,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000275",
@@ -3963,10 +3361,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000276",
@@ -3976,10 +3372,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000277",
@@ -3989,10 +3383,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000278",
@@ -4002,10 +3394,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000279",
@@ -4015,10 +3405,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000028",
@@ -4028,10 +3416,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000280",
@@ -4041,10 +3427,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000281",
@@ -4054,10 +3438,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000282",
@@ -4067,10 +3449,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000029",
@@ -4080,10 +3460,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000030",
@@ -4093,10 +3471,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000031",
@@ -4106,10 +3482,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000032",
@@ -4119,10 +3493,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000033",
@@ -4132,10 +3504,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000034",
@@ -4145,10 +3515,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000035",
@@ -4158,10 +3526,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000036",
@@ -4171,10 +3537,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000037",
@@ -4184,10 +3548,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000038",
@@ -4197,10 +3559,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000039",
@@ -4210,10 +3570,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000040",
@@ -4223,10 +3581,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000041",
@@ -4236,10 +3592,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000042",
@@ -4249,10 +3603,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000043",
@@ -4262,10 +3614,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000044",
@@ -4275,10 +3625,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000045",
@@ -4288,10 +3636,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000046",
@@ -4301,10 +3647,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000047",
@@ -4314,10 +3658,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000048",
@@ -4327,10 +3669,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000049",
@@ -4340,10 +3680,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000050",
@@ -4353,10 +3691,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000051",
@@ -4366,10 +3702,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000052",
@@ -4379,10 +3713,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000053",
@@ -4392,10 +3724,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000054",
@@ -4405,10 +3735,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000055",
@@ -4418,10 +3746,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000056",
@@ -4431,10 +3757,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000057",
@@ -4444,10 +3768,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000058",
@@ -4457,10 +3779,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000059",
@@ -4470,10 +3790,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000060",
@@ -4483,10 +3801,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000061",
@@ -4496,10 +3812,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000062",
@@ -4509,10 +3823,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000063",
@@ -4522,10 +3834,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000064",
@@ -4535,10 +3845,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000065",
@@ -4548,10 +3856,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000066",
@@ -4561,10 +3867,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000067",
@@ -4574,10 +3878,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000068",
@@ -4587,10 +3889,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000069",
@@ -4600,10 +3900,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000070",
@@ -4613,10 +3911,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000071",
@@ -4626,10 +3922,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000072",
@@ -4639,10 +3933,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000073",
@@ -4652,10 +3944,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000074",
@@ -4665,10 +3955,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000075",
@@ -4678,10 +3966,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000076",
@@ -4691,10 +3977,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000077",
@@ -4704,10 +3988,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000078",
@@ -4717,10 +3999,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000079",
@@ -4730,10 +4010,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000080",
@@ -4743,10 +4021,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000081",
@@ -4756,10 +4032,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000082",
@@ -4769,10 +4043,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000083",
@@ -4782,10 +4054,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000084",
@@ -4795,10 +4065,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000085",
@@ -4808,10 +4076,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000086",
@@ -4821,10 +4087,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000087",
@@ -4834,10 +4098,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000088",
@@ -4847,10 +4109,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000089",
@@ -4860,10 +4120,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000090",
@@ -4873,10 +4131,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000091",
@@ -4886,10 +4142,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000092",
@@ -4899,10 +4153,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000093",
@@ -4912,10 +4164,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000094",
@@ -4925,10 +4175,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000095",
@@ -4938,10 +4186,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000096",
@@ -4951,10 +4197,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000097",
@@ -4964,10 +4208,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000098",
@@ -4977,10 +4219,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000099",
@@ -4990,10 +4230,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000100",
@@ -5003,10 +4241,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001000",
@@ -5016,10 +4252,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001001",
@@ -5029,10 +4263,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001002",
@@ -5042,10 +4274,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001003",
@@ -5055,10 +4285,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001004",
@@ -5068,10 +4296,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001006",
@@ -5081,10 +4307,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001007",
@@ -5094,10 +4318,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001008",
@@ -5107,10 +4329,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001009",
@@ -5120,10 +4340,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000101",
@@ -5133,10 +4351,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001010",
@@ -5146,10 +4362,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001012",
@@ -5159,10 +4373,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001013",
@@ -5172,10 +4384,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001014",
@@ -5185,10 +4395,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001016",
@@ -5198,10 +4406,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001017",
@@ -5211,10 +4417,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001018",
@@ -5224,10 +4428,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001019",
@@ -5237,10 +4439,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000102",
@@ -5250,10 +4450,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001020",
@@ -5263,10 +4461,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001021",
@@ -5276,10 +4472,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000103",
@@ -5289,10 +4483,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000104",
@@ -5302,10 +4494,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000105",
@@ -5315,10 +4505,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000106",
@@ -5328,10 +4516,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000107",
@@ -5341,10 +4527,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000108",
@@ -5354,10 +4538,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000109",
@@ -5367,10 +4549,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000110",
@@ -5380,10 +4560,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000111",
@@ -5393,10 +4571,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000112",
@@ -5406,10 +4582,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000113",
@@ -5419,10 +4593,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000114",
@@ -5432,10 +4604,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000115",
@@ -5445,10 +4615,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000116",
@@ -5458,10 +4626,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000117",
@@ -5471,10 +4637,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000118",
@@ -5484,10 +4648,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000119",
@@ -5497,10 +4659,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000120",
@@ -5510,10 +4670,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000121",
@@ -5523,10 +4681,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000122",
@@ -5536,10 +4692,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000123",
@@ -5549,10 +4703,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000124",
@@ -5562,10 +4714,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000125",
@@ -5575,10 +4725,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000126",
@@ -5588,10 +4736,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000127",
@@ -5601,10 +4747,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000128",
@@ -5614,10 +4758,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000129",
@@ -5627,10 +4769,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000130",
@@ -5640,10 +4780,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000131",
@@ -5653,10 +4791,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000132",
@@ -5666,10 +4802,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000133",
@@ -5679,10 +4813,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000134",
@@ -5692,10 +4824,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000135",
@@ -5705,10 +4835,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000136",
@@ -5718,10 +4846,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000137",
@@ -5731,10 +4857,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000138",
@@ -5744,10 +4868,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000139",
@@ -5757,10 +4879,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000140",
@@ -5770,10 +4890,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000141",
@@ -5783,10 +4901,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000142",
@@ -5796,10 +4912,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000143",
@@ -5809,10 +4923,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000144",
@@ -5822,10 +4934,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000145",
@@ -5835,10 +4945,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000146",
@@ -5848,10 +4956,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000147",
@@ -5861,10 +4967,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000148",
@@ -5874,10 +4978,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000149",
@@ -5887,10 +4989,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000150",
@@ -5900,10 +5000,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000151",
@@ -5913,10 +5011,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000152",
@@ -5926,10 +5022,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000153",
@@ -5939,10 +5033,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000154",
@@ -5952,10 +5044,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000155",
@@ -5965,10 +5055,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000156",
@@ -5978,10 +5066,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000157",
@@ -5991,10 +5077,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000158",
@@ -6004,10 +5088,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000159",
@@ -6017,10 +5099,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000160",
@@ -6030,10 +5110,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000161",
@@ -6043,10 +5121,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000162",
@@ -6056,10 +5132,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000163",
@@ -6069,10 +5143,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000164",
@@ -6082,10 +5154,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000165",
@@ -6095,10 +5165,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000166",
@@ -6108,10 +5176,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000167",
@@ -6121,10 +5187,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000168",
@@ -6134,10 +5198,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000169",
@@ -6147,10 +5209,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000170",
@@ -6160,10 +5220,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000171",
@@ -6173,10 +5231,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000172",
@@ -6186,10 +5242,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000173",
@@ -6199,10 +5253,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000174",
@@ -6212,10 +5264,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000175",
@@ -6225,10 +5275,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000176",
@@ -6238,10 +5286,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000177",
@@ -6251,10 +5297,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000178",
@@ -6264,10 +5308,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000179",
@@ -6277,10 +5319,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000180",
@@ -6290,10 +5330,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000181",
@@ -6303,10 +5341,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000182",
@@ -6316,10 +5352,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000183",
@@ -6329,10 +5363,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000184",
@@ -6342,10 +5374,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000185",
@@ -6355,10 +5385,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000186",
@@ -6368,10 +5396,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000187",
@@ -6381,10 +5407,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000188",
@@ -6394,10 +5418,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000189",
@@ -6407,10 +5429,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000190",
@@ -6420,10 +5440,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000191",
@@ -6433,10 +5451,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000192",
@@ -6446,10 +5462,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000193",
@@ -6459,10 +5473,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000194",
@@ -6472,10 +5484,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000195",
@@ -6485,10 +5495,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000196",
@@ -6498,10 +5506,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000197",
@@ -6511,10 +5517,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000198",
@@ -6524,10 +5528,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000199",
@@ -6537,10 +5539,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000200",
@@ -6550,10 +5550,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000201",
@@ -6563,10 +5561,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000202",
@@ -6576,10 +5572,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000203",
@@ -6589,10 +5583,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000204",
@@ -6602,10 +5594,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000205",
@@ -6615,10 +5605,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000206",
@@ -6628,10 +5616,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000207",
@@ -6641,10 +5627,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000208",
@@ -6654,10 +5638,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000209",
@@ -6667,10 +5649,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000210",
@@ -6680,10 +5660,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000211",
@@ -6693,10 +5671,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000212",
@@ -6706,10 +5682,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000213",
@@ -6719,10 +5693,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000214",
@@ -6732,10 +5704,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000215",
@@ -6745,10 +5715,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000216",
@@ -6758,10 +5726,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000217",
@@ -6771,10 +5737,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000218",
@@ -6784,10 +5748,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000219",
@@ -6797,10 +5759,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000220",
@@ -6810,10 +5770,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000221",
@@ -6823,10 +5781,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000222",
@@ -6836,10 +5792,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000223",
@@ -6849,10 +5803,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000224",
@@ -6862,10 +5814,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000225",
@@ -6875,10 +5825,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000226",
@@ -6888,10 +5836,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000227",
@@ -6901,10 +5847,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000228",
@@ -6914,10 +5858,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000229",
@@ -6927,10 +5869,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000230",
@@ -6940,10 +5880,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000231",
@@ -6953,10 +5891,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000232",
@@ -6966,10 +5902,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000233",
@@ -6979,10 +5913,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000234",
@@ -6992,10 +5924,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000235",
@@ -7005,10 +5935,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000236",
@@ -7018,10 +5946,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000237",
@@ -7031,10 +5957,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000238",
@@ -7044,10 +5968,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000239",
@@ -7057,10 +5979,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000240",
@@ -7070,10 +5990,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000241",
@@ -7083,10 +6001,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000242",
@@ -7096,10 +6012,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000243",
@@ -7109,10 +6023,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000244",
@@ -7122,10 +6034,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000245",
@@ -7135,10 +6045,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000246",
@@ -7148,10 +6056,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000247",
@@ -7161,10 +6067,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000248",
@@ -7174,10 +6078,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000249",
@@ -7187,10 +6089,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000250",
@@ -7200,10 +6100,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000251",
@@ -7213,10 +6111,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000252",
@@ -7226,10 +6122,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000253",
@@ -7239,10 +6133,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000254",
@@ -7252,10 +6144,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000255",
@@ -7265,10 +6155,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000256",
@@ -7278,10 +6166,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000257",
@@ -7291,10 +6177,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000258",
@@ -7304,10 +6188,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000259",
@@ -7317,10 +6199,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000260",
@@ -7330,10 +6210,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000261",
@@ -7343,10 +6221,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000262",
@@ -7356,10 +6232,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000263",
@@ -7369,10 +6243,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000264",
@@ -7382,10 +6254,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000265",
@@ -7395,10 +6265,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000266",
@@ -7408,10 +6276,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000267",
@@ -7421,10 +6287,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000268",
@@ -7434,10 +6298,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000269",
@@ -7447,10 +6309,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000270",
@@ -7460,10 +6320,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000271",
@@ -7473,10 +6331,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000272",
@@ -7486,10 +6342,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000273",
@@ -7499,10 +6353,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000274",
@@ -7512,10 +6364,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000001",
@@ -7525,10 +6375,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000002",
@@ -7538,10 +6386,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000003",
@@ -7551,10 +6397,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000004",
@@ -7564,10 +6408,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000005",
@@ -7577,10 +6419,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000006",
@@ -7590,10 +6430,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000007",
@@ -7603,10 +6441,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000008",
@@ -7616,10 +6452,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000009",
@@ -7629,10 +6463,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000010",
@@ -7642,10 +6474,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000011",
@@ -7655,10 +6485,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000012",
@@ -7668,10 +6496,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000013",
@@ -7681,10 +6507,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000014",
@@ -7694,10 +6518,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000015",
@@ -7707,10 +6529,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000016",
@@ -7720,10 +6540,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000017",
@@ -7733,10 +6551,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000018",
@@ -7746,10 +6562,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000019",
@@ -7759,10 +6573,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000020",
@@ -7772,10 +6584,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000021",
@@ -7785,10 +6595,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000022",
@@ -7798,10 +6606,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000023",
@@ -7811,10 +6617,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000024",
@@ -7824,10 +6628,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000025",
@@ -7837,10 +6639,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000026",
@@ -7850,10 +6650,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000027",
@@ -7863,10 +6661,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000028",
@@ -7876,10 +6672,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000029",
@@ -7889,10 +6683,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000030",
@@ -7902,10 +6694,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000031",
@@ -7915,10 +6705,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000032",
@@ -7928,10 +6716,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000033",
@@ -7941,10 +6727,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000034",
@@ -7954,10 +6738,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000035",
@@ -7967,10 +6749,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000036",
@@ -7980,10 +6760,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000037",
@@ -7993,10 +6771,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000038",
@@ -8006,10 +6782,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000039",
@@ -8019,10 +6793,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000040",
@@ -8032,10 +6804,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000041",
@@ -8045,10 +6815,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000042",
@@ -8058,10 +6826,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000043",
@@ -8071,10 +6837,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000044",
@@ -8084,10 +6848,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000045",
@@ -8097,10 +6859,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000046",
@@ -8110,10 +6870,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000047",
@@ -8123,10 +6881,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000048",
@@ -8136,10 +6892,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000049",
@@ -8149,10 +6903,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000050",
@@ -8162,10 +6914,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000051",
@@ -8175,10 +6925,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000052",
@@ -8188,10 +6936,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000053",
@@ -8201,10 +6947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000054",
@@ -8214,10 +6958,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000055",
@@ -8227,10 +6969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000056",
@@ -8240,10 +6980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000057",
@@ -8253,10 +6991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000058",
@@ -8266,10 +7002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000059",
@@ -8326,10 +7060,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000062",
@@ -8339,10 +7071,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000063",
@@ -8352,10 +7082,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000064",
@@ -8365,10 +7093,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000065",
@@ -8378,10 +7104,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000066",
@@ -8391,10 +7115,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000067",
@@ -8404,10 +7126,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000068",
@@ -8417,10 +7137,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000069",
@@ -8430,10 +7148,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000070",
@@ -8443,10 +7159,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000071",
@@ -8456,10 +7170,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000072",
@@ -8469,10 +7181,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000073",
@@ -8482,10 +7192,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000074",
@@ -8495,10 +7203,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000075",
@@ -8508,10 +7214,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000076",
@@ -8521,10 +7225,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000077",
@@ -8534,10 +7236,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000078",
@@ -8547,10 +7247,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000079",
@@ -8560,10 +7258,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000080",
@@ -8573,10 +7269,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000081",
@@ -8586,10 +7280,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000082",
@@ -8599,10 +7291,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000083",
@@ -8612,10 +7302,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000084",
@@ -8625,10 +7313,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000085",
@@ -8638,10 +7324,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000086",
@@ -8651,10 +7335,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000087",
@@ -8664,10 +7346,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000088",
@@ -8677,10 +7357,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000089",
@@ -8690,10 +7368,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000090",
@@ -8703,10 +7379,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000091",
@@ -8716,10 +7390,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000092",
@@ -8729,10 +7401,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000093",
@@ -8742,10 +7412,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000094",
@@ -8755,10 +7423,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000095",
@@ -8768,10 +7434,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000096",
@@ -8781,10 +7445,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000097",
@@ -8794,10 +7456,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000098",
@@ -8807,10 +7467,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000099",
@@ -8820,10 +7478,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000100",
@@ -8833,10 +7489,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000101",
@@ -8846,10 +7500,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000102",
@@ -8859,10 +7511,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000103",
@@ -8872,10 +7522,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000104",
@@ -8885,10 +7533,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000105",
@@ -8898,10 +7544,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000106",
@@ -8911,10 +7555,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000107",
@@ -8924,10 +7566,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000108",
@@ -8937,10 +7577,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000109",
@@ -8950,10 +7588,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000110",
@@ -8963,10 +7599,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000111",
@@ -8976,10 +7610,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000112",
@@ -8989,10 +7621,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000113",
@@ -9002,10 +7632,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000114",
@@ -9015,10 +7643,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000115",
@@ -9028,10 +7654,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000116",
@@ -9041,10 +7665,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000117",
@@ -9054,10 +7676,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000118",
@@ -9067,10 +7687,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000119",
@@ -9080,10 +7698,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000120",
@@ -9093,10 +7709,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000121",
@@ -9106,10 +7720,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000122",
@@ -9119,10 +7731,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000123",
@@ -9132,10 +7742,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000124",
@@ -9145,10 +7753,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000125",
@@ -9158,10 +7764,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000126",
@@ -9171,10 +7775,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000127",
@@ -9213,10 +7815,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000129",
@@ -9226,10 +7826,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000130",
@@ -9239,10 +7837,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000131",
@@ -9252,10 +7848,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000132",
@@ -9265,10 +7859,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000133",
@@ -9278,10 +7870,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000134",
@@ -9291,10 +7881,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000135",
@@ -9304,10 +7892,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000136",
@@ -9317,10 +7903,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000137",
@@ -9330,10 +7914,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000138",
@@ -9343,10 +7925,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000139",
@@ -9356,10 +7936,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000140",
@@ -9369,10 +7947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000141",
@@ -9382,10 +7958,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000142",
@@ -9395,10 +7969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000143",
@@ -9408,10 +7980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000144",
@@ -9421,10 +7991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000145",
@@ -9434,10 +8002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000146",
@@ -9447,10 +8013,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000147",
@@ -9460,10 +8024,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000148",
@@ -9473,10 +8035,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000149",
@@ -9486,10 +8046,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000150",
@@ -9499,10 +8057,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000151",
@@ -9512,10 +8068,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000152",
@@ -9525,10 +8079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000153",
@@ -9538,10 +8090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000154",
@@ -9551,10 +8101,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000155",
@@ -9564,10 +8112,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000156",
@@ -9577,10 +8123,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000157",
@@ -9590,10 +8134,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000158",
@@ -9603,10 +8145,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000159",
@@ -9616,10 +8156,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000160",
@@ -9629,10 +8167,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000161",
@@ -9642,10 +8178,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000162",
@@ -9655,10 +8189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000163",
@@ -9668,10 +8200,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000164",
@@ -9681,10 +8211,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000165",
@@ -9694,10 +8222,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000166",
@@ -9707,10 +8233,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000167",
@@ -9720,10 +8244,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000168",
@@ -9733,10 +8255,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000169",
@@ -9746,10 +8266,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000170",
@@ -9759,10 +8277,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000171",
@@ -9772,10 +8288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000172",
@@ -9785,10 +8299,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000173",
@@ -9798,10 +8310,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000174",
@@ -9811,10 +8321,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000175",
@@ -9824,10 +8332,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000176",
@@ -9837,10 +8343,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000177",
@@ -9850,10 +8354,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000178",
@@ -9863,10 +8365,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000179",
@@ -9876,10 +8376,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000180",
@@ -9889,10 +8387,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000181",
@@ -9902,10 +8398,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000182",
@@ -9915,10 +8409,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000183",
@@ -9928,10 +8420,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000184",
@@ -9941,10 +8431,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000185",
@@ -9954,10 +8442,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000186",
@@ -9986,10 +8472,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000188",
@@ -10008,10 +8492,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000190",
@@ -10021,10 +8503,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000191",
@@ -10034,10 +8514,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000192",
@@ -10047,10 +8525,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000193",
@@ -10060,10 +8536,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000194",
@@ -10073,10 +8547,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000195",
@@ -10086,10 +8558,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000196",
@@ -10099,10 +8569,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000197",
@@ -10112,10 +8580,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000198",
@@ -10125,10 +8591,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000199",
@@ -10138,10 +8602,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000200",
@@ -10151,10 +8613,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000201",
@@ -10164,10 +8624,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000202",
@@ -10177,10 +8635,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000203",
@@ -10190,10 +8646,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000204",
@@ -10203,10 +8657,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000205",
@@ -10216,10 +8668,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000206",
@@ -10229,10 +8679,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000207",
@@ -10242,10 +8690,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000208",
@@ -10255,10 +8701,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000209",
@@ -10268,10 +8712,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000210",
@@ -10281,10 +8723,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000211",
@@ -10294,10 +8734,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000212",
@@ -10307,10 +8745,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000213",
@@ -10320,10 +8756,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000214",
@@ -10333,10 +8767,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000215",
@@ -10346,10 +8778,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000216",
@@ -10359,10 +8789,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000217",
@@ -10372,10 +8800,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000218",
@@ -10385,10 +8811,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000219",
@@ -10398,10 +8822,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000220",
@@ -10411,10 +8833,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000221",
@@ -10424,10 +8844,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000222",
@@ -10437,10 +8855,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000223",
@@ -10450,10 +8866,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000224",
@@ -10463,10 +8877,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000225",
@@ -10476,10 +8888,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000226",
@@ -10489,10 +8899,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000227",
@@ -10502,10 +8910,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000228",
@@ -10515,10 +8921,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000229",
@@ -10528,10 +8932,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000230",
@@ -10541,10 +8943,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000231",
@@ -10554,10 +8954,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000232",
@@ -10571,10 +8969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000234",
@@ -10584,10 +8980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000235",
@@ -10597,10 +8991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000236",
@@ -10610,10 +9002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000237",
@@ -10623,10 +9013,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000238",
@@ -10636,10 +9024,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000239",
@@ -10649,10 +9035,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000240",
@@ -10662,10 +9046,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000241",
@@ -10675,10 +9057,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000242",
@@ -10688,10 +9068,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000243",
@@ -10701,10 +9079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000244",
@@ -10714,10 +9090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000245",
@@ -10727,10 +9101,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000246",
@@ -10740,10 +9112,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000247",
@@ -10753,10 +9123,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000248",
@@ -10766,10 +9134,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000249",
@@ -10779,10 +9145,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000250",
@@ -10792,10 +9156,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000251",
@@ -10805,10 +9167,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000252",
@@ -10818,10 +9178,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000253",
@@ -10831,10 +9189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000254",
@@ -10844,10 +9200,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000255",
@@ -10857,10 +9211,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000256",
@@ -10870,10 +9222,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000257",
@@ -10883,10 +9233,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000258",
@@ -10896,10 +9244,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000259",
@@ -10909,10 +9255,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000260",
@@ -10922,10 +9266,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000261",
@@ -10935,10 +9277,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000262",
@@ -10948,10 +9288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000263",
@@ -10961,10 +9299,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000264",
@@ -10974,10 +9310,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000265",
@@ -10987,10 +9321,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000266",
@@ -11000,10 +9332,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000267",
@@ -11013,10 +9343,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000268",
@@ -11026,10 +9354,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000269",
@@ -11039,10 +9365,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000270",
@@ -11052,10 +9376,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000271",
@@ -11065,10 +9387,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000272",
@@ -11078,10 +9398,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000273",
@@ -11091,10 +9409,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000274",
@@ -11104,10 +9420,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000275",
@@ -11117,10 +9431,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000276",
@@ -11130,10 +9442,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000277",
@@ -11143,10 +9453,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000278",
@@ -11156,10 +9464,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000279",
@@ -11169,10 +9475,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000280",
@@ -11182,10 +9486,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000281",
@@ -11195,10 +9497,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000282",
@@ -11208,10 +9508,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000283",
@@ -11221,10 +9519,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000284",
@@ -11234,10 +9530,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000285",
@@ -11247,10 +9541,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000286",
@@ -11260,10 +9552,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000287",
@@ -11273,10 +9563,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000288",
@@ -11286,10 +9574,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000289",
@@ -11299,10 +9585,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000290",
@@ -11312,10 +9596,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000291",
@@ -11325,10 +9607,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000292",
@@ -11338,10 +9618,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000293",
@@ -11351,10 +9629,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000294",
@@ -11364,10 +9640,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000295",
@@ -11377,10 +9651,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000296",
@@ -11390,10 +9662,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000297",
@@ -11403,10 +9673,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000298",
@@ -11416,10 +9684,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000299",
@@ -11429,10 +9695,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000300",
@@ -11442,10 +9706,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000301",
@@ -11455,10 +9717,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000302",
@@ -11468,10 +9728,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000303",
@@ -11504,10 +9762,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000306",
@@ -11521,10 +9777,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000308",
@@ -11534,10 +9788,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000309",
@@ -11547,10 +9799,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000310",
@@ -11560,10 +9810,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000311",
@@ -11573,10 +9821,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000312",
@@ -11586,10 +9832,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000313",
@@ -11599,10 +9843,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000314",
@@ -11612,10 +9854,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000315",
@@ -11625,10 +9865,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000316",
@@ -11638,10 +9876,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000317",
@@ -11651,10 +9887,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000318",
@@ -11664,10 +9898,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000319",
@@ -11677,10 +9909,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000320",
@@ -11690,10 +9920,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000321",
@@ -11703,10 +9931,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000322",
@@ -11716,10 +9942,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000323",
@@ -11729,10 +9953,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000324",
@@ -11742,10 +9964,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000325",
@@ -11755,10 +9975,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000326",
@@ -11768,10 +9986,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000327",
@@ -11781,10 +9997,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000328",
@@ -11794,10 +10008,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000329",
@@ -11807,10 +10019,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000330",
@@ -11820,10 +10030,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000331",
@@ -11885,10 +10093,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000337",
@@ -11898,10 +10104,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000338",
@@ -11911,10 +10115,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000339",
@@ -11924,10 +10126,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000340",
@@ -11937,10 +10137,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000341",
@@ -11950,10 +10148,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000342",
@@ -11963,10 +10159,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000343",
@@ -11976,10 +10170,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000344",
@@ -11989,10 +10181,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000345",
@@ -12002,10 +10192,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000346",
@@ -12015,10 +10203,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000347",
@@ -12028,10 +10214,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000348",
@@ -12041,10 +10225,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000349",
@@ -12054,10 +10236,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000350",
@@ -12067,10 +10247,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000351",
@@ -12080,10 +10258,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000352",
@@ -12093,10 +10269,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000353",
@@ -12106,10 +10280,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000354",
@@ -12119,10 +10291,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000355",
@@ -12132,10 +10302,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000356",
@@ -12145,10 +10313,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000357",
@@ -12158,10 +10324,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000358",
@@ -12171,10 +10335,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000359",
@@ -12184,10 +10346,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000360",
@@ -12197,10 +10357,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000361",
@@ -12210,10 +10368,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000362",
@@ -12223,10 +10379,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000363",
@@ -12236,10 +10390,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000364",
@@ -12249,10 +10401,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000365",
@@ -12262,10 +10412,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000366",
@@ -12275,10 +10423,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000367",
@@ -12288,10 +10434,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000368",
@@ -12301,10 +10445,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000369",
@@ -12314,10 +10456,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000370",
@@ -12327,10 +10467,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000371",
@@ -12340,10 +10478,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000372",
@@ -12353,10 +10489,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000373",
@@ -12366,10 +10500,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000374",
@@ -12379,10 +10511,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000375",
@@ -12392,10 +10522,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000376",
@@ -12405,10 +10533,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000377",
@@ -12418,10 +10544,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000378",
@@ -12431,10 +10555,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000379",
@@ -12444,10 +10566,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000380",
@@ -12457,10 +10577,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000381",
@@ -12470,10 +10588,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000382",
@@ -12483,10 +10599,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000383",
@@ -12496,10 +10610,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000384",
@@ -12509,10 +10621,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000385",
@@ -12522,10 +10632,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000386",
@@ -12535,10 +10643,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000387",
@@ -12548,10 +10654,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000388",
@@ -12561,10 +10665,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000389",
@@ -12574,10 +10676,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000390",
@@ -12587,10 +10687,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000391",
@@ -12600,10 +10698,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000392",
@@ -12613,10 +10709,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000393",
@@ -12626,10 +10720,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000394",
@@ -12639,10 +10731,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000395",
@@ -12652,10 +10742,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000396",
@@ -12665,10 +10753,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000397",
@@ -12678,10 +10764,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000398",
@@ -12691,10 +10775,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000399",
@@ -12704,10 +10786,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000400",
@@ -12717,10 +10797,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000401",
@@ -12730,10 +10808,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000402",
@@ -12743,10 +10819,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000403",
@@ -12756,10 +10830,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000404",
@@ -12769,10 +10841,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000405",
@@ -12782,10 +10852,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000406",
@@ -12795,10 +10863,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000407",
@@ -12808,10 +10874,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000408",
@@ -12821,10 +10885,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000409",
@@ -12834,10 +10896,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000410",
@@ -12847,10 +10907,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000411",
@@ -12860,10 +10918,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000412",
@@ -12873,10 +10929,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000413",
@@ -12886,10 +10940,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000414",
@@ -12899,10 +10951,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000415",
@@ -12912,10 +10962,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000416",
@@ -12925,10 +10973,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000417",
@@ -12938,10 +10984,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000418",
@@ -12951,10 +10995,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000419",
@@ -12964,10 +11006,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000420",
@@ -12977,10 +11017,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000421",
@@ -12990,10 +11028,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000422",
@@ -13003,10 +11039,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000423",
@@ -13016,10 +11050,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000424",
@@ -13029,10 +11061,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000425",
@@ -13042,10 +11072,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000426",
@@ -13055,10 +11083,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000427",
@@ -13068,10 +11094,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000428",
@@ -13081,10 +11105,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000429",
@@ -13180,10 +11202,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000434",
@@ -13193,10 +11213,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000435",
@@ -13206,10 +11224,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000436",
@@ -13219,10 +11235,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000437",
@@ -13232,10 +11246,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000438",
@@ -13245,10 +11257,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000439",
@@ -13258,10 +11268,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000440",
@@ -13271,10 +11279,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000441",
@@ -14620,10 +12626,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000489",
@@ -14633,10 +12637,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000490",
@@ -14646,10 +12648,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000491",
@@ -14659,10 +12659,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000492",
@@ -14672,10 +12670,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000493",
@@ -14685,10 +12681,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000494",
@@ -14698,10 +12692,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000495",
@@ -14711,10 +12703,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000496",
@@ -14724,10 +12714,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000497",
@@ -14737,10 +12725,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000498",
@@ -14750,10 +12736,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000499",
@@ -14763,10 +12747,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000500",
@@ -14776,10 +12758,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000501",
@@ -14789,10 +12769,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000502",
@@ -14802,10 +12780,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000503",
@@ -14815,10 +12791,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000504",
@@ -14828,10 +12802,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000505",
@@ -14841,10 +12813,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000506",
@@ -14854,10 +12824,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000507",
@@ -14867,10 +12835,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000508",
@@ -14880,10 +12846,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000509",
@@ -14893,10 +12857,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000510",
@@ -14906,10 +12868,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000511",
@@ -14919,10 +12879,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000512",
@@ -14932,10 +12890,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000513",
@@ -14945,10 +12901,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000514",
@@ -14958,10 +12912,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000515",
@@ -14971,10 +12923,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000516",
@@ -14984,10 +12934,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000517",
@@ -14997,10 +12945,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000518",
@@ -15010,10 +12956,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000519",
@@ -15023,10 +12967,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000520",
@@ -15036,10 +12978,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000521",
@@ -15049,10 +12989,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000522",
@@ -15062,10 +13000,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000523",
@@ -15075,10 +13011,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000524",
@@ -15088,10 +13022,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000525",
@@ -15147,10 +13079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000529",
@@ -15160,10 +13090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000531",
@@ -16707,10 +14635,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000644",
@@ -16772,10 +14698,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000646",
@@ -17002,10 +14926,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000654",
@@ -17327,10 +15249,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000662",
@@ -17340,10 +15260,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000663",
@@ -19007,10 +16925,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000808",
@@ -19020,10 +16936,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000809",
@@ -19033,10 +16947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000810",
@@ -19046,10 +16958,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000811",
@@ -19059,10 +16969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000812",
@@ -19072,10 +16980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000813",
@@ -19085,10 +16991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000814",
@@ -19098,10 +17002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000815",
@@ -19111,10 +17013,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000816",
@@ -19124,10 +17024,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000817",
@@ -19137,10 +17035,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000818",
@@ -19150,10 +17046,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000819",
@@ -19163,10 +17057,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000820",
@@ -19176,10 +17068,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000821",
@@ -19189,10 +17079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000822",
@@ -19202,10 +17090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000823",
@@ -19215,10 +17101,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000824",
@@ -19228,10 +17112,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000825",
@@ -19241,10 +17123,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000826",
@@ -19254,10 +17134,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000827",
@@ -19267,10 +17145,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000828",
@@ -19280,10 +17156,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000829",
@@ -19293,10 +17167,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000830",
@@ -19306,10 +17178,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000831",
@@ -19319,10 +17189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000832",
@@ -19332,10 +17200,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000833",
@@ -19345,10 +17211,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000834",
@@ -19358,10 +17222,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000835",
@@ -19371,10 +17233,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000836",
@@ -19384,10 +17244,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000837",
@@ -19397,10 +17255,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000838",
@@ -19410,10 +17266,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000839",
@@ -19423,10 +17277,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000840",
@@ -19436,10 +17288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000841",
@@ -19449,10 +17299,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000842",
@@ -19462,10 +17310,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000843",
@@ -19475,10 +17321,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000844",
@@ -19574,10 +17418,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000848",
@@ -19587,10 +17429,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000849",
@@ -19600,10 +17440,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000850",
@@ -19613,10 +17451,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000851",
@@ -19626,10 +17462,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000852",
@@ -19639,10 +17473,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000853",
@@ -19652,10 +17484,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000854",
@@ -19665,10 +17495,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000855",
@@ -19678,10 +17506,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000856",
@@ -19691,10 +17517,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000857",
@@ -19704,10 +17528,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000858",
@@ -19717,10 +17539,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000859",
@@ -19730,10 +17550,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000860",
@@ -19743,10 +17561,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000861",
@@ -19756,10 +17572,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000862",
@@ -19769,10 +17583,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000863",
@@ -19782,10 +17594,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000864",
@@ -19795,10 +17605,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000865",
@@ -19808,10 +17616,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000866",
@@ -19821,10 +17627,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000867",
@@ -19834,10 +17638,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000868",
@@ -19847,10 +17649,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000869",
@@ -19860,10 +17660,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000870",
@@ -20275,10 +18073,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001001",
@@ -20288,10 +18084,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001002",
@@ -20301,10 +18095,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001003",
@@ -20314,10 +18106,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001004",
@@ -20327,10 +18117,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001005",
@@ -20340,10 +18128,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001006",
@@ -20353,10 +18139,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001007",
@@ -20366,10 +18150,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001008",
@@ -20379,10 +18161,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001009",
@@ -20392,10 +18172,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001010",
@@ -20405,10 +18183,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001011",
@@ -20418,10 +18194,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001012",
@@ -20431,10 +18205,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001013",
@@ -20444,10 +18216,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001014",
@@ -20457,10 +18227,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001015",
@@ -20470,10 +18238,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001016",
@@ -20483,10 +18249,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001017",
@@ -20496,10 +18260,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001018",
@@ -20509,10 +18271,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001019",
@@ -20522,10 +18282,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001020",
@@ -20535,10 +18293,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001021",
@@ -20548,10 +18304,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001022",
@@ -20561,10 +18315,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001023",
@@ -20574,10 +18326,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001101",
@@ -20727,10 +18477,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002001",
@@ -20740,10 +18488,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002002",
@@ -20753,10 +18499,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002003",
@@ -20826,10 +18570,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002008",
@@ -20839,10 +18581,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002009",
@@ -20852,10 +18592,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002010",
@@ -20865,10 +18603,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002011",
@@ -20878,10 +18614,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002012",
@@ -20891,10 +18625,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002013",
@@ -20904,10 +18636,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002014",
@@ -20917,10 +18647,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002015",
@@ -20930,10 +18658,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002016",
@@ -20943,10 +18669,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002017",
@@ -20956,10 +18680,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002018",
@@ -20969,10 +18691,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002019",
@@ -20982,10 +18702,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002020",
@@ -20995,10 +18713,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002021",
@@ -21008,10 +18724,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002022",
@@ -21021,10 +18735,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002023",
@@ -21034,10 +18746,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002024",
@@ -21047,10 +18757,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002025",
@@ -21060,10 +18768,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002026",
@@ -21073,10 +18779,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002027",
@@ -21086,10 +18790,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002028",
@@ -21099,10 +18801,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002029",
@@ -21112,10 +18812,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002030",
@@ -21125,10 +18823,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002031",
@@ -21138,10 +18834,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002032",
@@ -21151,10 +18845,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002033",
@@ -21164,10 +18856,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002034",
@@ -21177,10 +18867,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002035",
@@ -21190,10 +18878,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002036",
@@ -21203,10 +18889,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002037",
@@ -21216,10 +18900,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002038",
@@ -21229,10 +18911,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002039",
@@ -21242,10 +18922,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002040",
@@ -21255,10 +18933,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1003000",
@@ -23097,10 +20773,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000000",
@@ -23111,10 +20785,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000001",
@@ -23998,10 +21670,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000053",
@@ -24012,10 +21682,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000054",
@@ -24026,10 +21694,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000055",
@@ -24040,10 +21706,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000056",
@@ -24054,10 +21718,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000057",
@@ -24068,10 +21730,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000064",
@@ -24166,10 +21826,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000202",
@@ -24197,10 +21855,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000204",
@@ -24211,10 +21867,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000205",
@@ -24225,10 +21879,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000206",
@@ -24239,10 +21891,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000207",
@@ -24283,10 +21933,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000214",
@@ -24297,10 +21945,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000215",
@@ -24311,10 +21957,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000216",
@@ -24325,10 +21969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000217",
@@ -24339,10 +21981,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000218",
@@ -24353,10 +21993,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000219",
@@ -24367,10 +22005,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000220",
@@ -24398,10 +22034,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000222",
@@ -24429,10 +22063,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000224",
@@ -24443,10 +22075,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000225",
@@ -24457,10 +22087,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000226",
@@ -24471,10 +22099,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000227",
@@ -24515,10 +22141,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000234",
@@ -24529,10 +22153,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000235",
@@ -24543,10 +22165,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000236",
@@ -24557,10 +22177,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000237",
@@ -24571,10 +22189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000238",
@@ -24585,10 +22201,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000239",
@@ -24599,10 +22213,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000301",
@@ -24664,10 +22276,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000502",
@@ -24678,10 +22288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000503",
@@ -24692,10 +22300,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000504",
@@ -24706,10 +22312,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000505",
@@ -24720,10 +22324,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000506",
@@ -24734,10 +22336,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000507",
@@ -24748,10 +22348,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000508",
@@ -24762,10 +22360,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000509",
@@ -24776,10 +22372,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000510",
@@ -24790,10 +22384,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000511",
@@ -24804,10 +22396,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000512",
@@ -24818,10 +22408,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000513",
@@ -24832,10 +22420,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000514",
@@ -24846,10 +22432,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000515",
@@ -24860,10 +22444,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000516",
@@ -24874,10 +22456,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000517",
@@ -25010,10 +22590,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000059",
@@ -25024,10 +22602,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000060",
@@ -25038,10 +22614,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000061",
@@ -25052,10 +22626,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000062",
@@ -25066,10 +22638,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000063",
@@ -25080,10 +22650,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000071",

--- a/metpo-full.owl
+++ b/metpo-full.owl
@@ -181,7 +181,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000000">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has susceptibility profile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1015,7 +1015,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000052">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1025,7 +1025,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000053">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1035,7 +1035,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000054">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1045,7 +1045,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000055">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1055,7 +1055,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000056">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has temperature delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1065,7 +1065,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000057">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has culture temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1168,7 +1168,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000201">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lyses</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1194,7 +1194,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000203">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete fixes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1204,7 +1204,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000204">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete catabolizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1214,7 +1214,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000205">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete mineralizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1224,7 +1224,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000206">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete conjugates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1296,7 +1296,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000213">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete binds</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1306,7 +1306,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000214">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chelates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1316,7 +1316,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000215">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete precipitates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1326,7 +1326,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000216">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete solubilizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1336,7 +1336,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000217">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete volatilizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1346,7 +1346,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000218">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete crystallizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1356,7 +1356,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000219">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete adsorbs</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1382,7 +1382,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000221">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not lyse</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1408,7 +1408,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000223">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not fix</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1418,7 +1418,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000224">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not catabolize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1428,7 +1428,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000225">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not mineralize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1438,7 +1438,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000226">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not conjugate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1510,7 +1510,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000233">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not bind</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1520,7 +1520,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000234">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not chelate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1530,7 +1530,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000235">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not precipitate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1540,7 +1540,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000236">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not solubilize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1550,7 +1550,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000237">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not volatilize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1560,7 +1560,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000238">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not crystallize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1570,7 +1570,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000239">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1633,7 +1633,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000501">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1643,7 +1643,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000502">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1653,7 +1653,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000503">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1663,7 +1663,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000504">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has pH delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1673,7 +1673,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000505">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has culture pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1683,7 +1683,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000506">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1693,7 +1693,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000507">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1703,7 +1703,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000508">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1713,7 +1713,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000509">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1723,7 +1723,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000510">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has NaCl delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1733,7 +1733,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000511">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1743,7 +1743,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000512">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1753,7 +1753,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000513">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1763,7 +1763,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000514">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1773,7 +1773,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000515">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1783,7 +1783,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000516">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has oxygen delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1922,7 +1922,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000058">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has observed spot value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1932,7 +1932,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000059">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has minimum observed value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1942,7 +1942,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000060">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has maximum observed value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1952,7 +1952,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000061">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has value comments</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1962,7 +1962,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000062">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete is negative data</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1972,7 +1972,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000063">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete observation data property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -2478,7 +2478,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2489,7 +2489,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2500,7 +2500,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2511,7 +2511,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2522,7 +2522,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2533,7 +2533,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2544,7 +2544,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2555,7 +2555,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2566,7 +2566,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2577,7 +2577,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2588,7 +2588,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2599,7 +2599,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2610,7 +2610,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2621,7 +2621,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2632,7 +2632,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2643,7 +2643,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2654,7 +2654,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2665,7 +2665,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2676,7 +2676,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2687,7 +2687,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2698,7 +2698,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2709,7 +2709,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2720,7 +2720,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete METPO Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2731,7 +2731,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2742,7 +2742,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2753,7 +2753,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mesophilie</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2764,7 +2764,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2775,7 +2775,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2786,7 +2786,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2797,7 +2797,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2808,7 +2808,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2819,7 +2819,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2830,7 +2830,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2841,7 +2841,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2852,7 +2852,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2863,7 +2863,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2874,7 +2874,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2885,7 +2885,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2896,7 +2896,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2907,7 +2907,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2918,7 +2918,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2929,7 +2929,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2940,7 +2940,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2951,7 +2951,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2962,7 +2962,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acid Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2973,7 +2973,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2984,7 +2984,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2995,7 +2995,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3006,7 +3006,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3017,7 +3017,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3028,7 +3028,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3039,7 +3039,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3050,7 +3050,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3061,7 +3061,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3072,7 +3072,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3083,7 +3083,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3094,7 +3094,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3105,7 +3105,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3116,7 +3116,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3127,7 +3127,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3138,7 +3138,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3149,7 +3149,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3160,7 +3160,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3171,7 +3171,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3182,7 +3182,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3193,7 +3193,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3204,7 +3204,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3215,7 +3215,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3226,7 +3226,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3237,7 +3237,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3248,7 +3248,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3259,7 +3259,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3270,7 +3270,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3281,7 +3281,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3292,7 +3292,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3303,7 +3303,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3314,7 +3314,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3325,7 +3325,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3336,7 +3336,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3347,7 +3347,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3358,7 +3358,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3369,7 +3369,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3380,7 +3380,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3391,7 +3391,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3402,7 +3402,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3413,7 +3413,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3424,7 +3424,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3435,7 +3435,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3446,7 +3446,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3457,7 +3457,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3468,7 +3468,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3479,7 +3479,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3490,7 +3490,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3501,7 +3501,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3512,7 +3512,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3523,7 +3523,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3534,7 +3534,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3545,7 +3545,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3556,7 +3556,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3567,7 +3567,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3578,7 +3578,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3589,7 +3589,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3600,7 +3600,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3611,7 +3611,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3622,7 +3622,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3633,7 +3633,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3644,7 +3644,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Endospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3655,7 +3655,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Exospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3666,7 +3666,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3677,7 +3677,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3688,7 +3688,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Arthrospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3699,7 +3699,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3710,7 +3710,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporangiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3721,7 +3721,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3732,7 +3732,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Akinetes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3743,7 +3743,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3754,7 +3754,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3765,7 +3765,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3776,7 +3776,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3787,7 +3787,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3798,7 +3798,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3809,7 +3809,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3820,7 +3820,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3831,7 +3831,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ascospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3842,7 +3842,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Basidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3853,7 +3853,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3864,7 +3864,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3875,7 +3875,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3886,7 +3886,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zoospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3897,7 +3897,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3908,7 +3908,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3919,7 +3919,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3930,7 +3930,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3941,7 +3941,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3952,7 +3952,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3963,7 +3963,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3974,7 +3974,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3985,7 +3985,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3996,7 +3996,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4007,7 +4007,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4018,7 +4018,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4029,7 +4029,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4040,7 +4040,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4051,7 +4051,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4062,7 +4062,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4073,7 +4073,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4084,7 +4084,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4095,7 +4095,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4106,7 +4106,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4117,7 +4117,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4128,7 +4128,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4139,7 +4139,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4150,7 +4150,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4161,7 +4161,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4172,7 +4172,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4183,7 +4183,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4194,7 +4194,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4205,7 +4205,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4216,7 +4216,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4227,7 +4227,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4238,7 +4238,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4249,7 +4249,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4260,7 +4260,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4271,7 +4271,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4282,7 +4282,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4293,7 +4293,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4304,7 +4304,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4315,7 +4315,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4326,7 +4326,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4337,7 +4337,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4348,7 +4348,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4359,7 +4359,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4370,7 +4370,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4381,7 +4381,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4392,7 +4392,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4403,7 +4403,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4414,7 +4414,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4425,7 +4425,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4436,7 +4436,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4447,7 +4447,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4458,7 +4458,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4469,7 +4469,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4480,7 +4480,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4491,7 +4491,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid4</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4502,7 +4502,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4513,7 +4513,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4524,7 +4524,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4535,7 +4535,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4546,7 +4546,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4557,7 +4557,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4568,7 +4568,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4579,7 +4579,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid4</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4590,7 +4590,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4601,7 +4601,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4612,7 +4612,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4623,7 +4623,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4634,7 +4634,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4645,7 +4645,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4656,7 +4656,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4667,7 +4667,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4678,7 +4678,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4689,7 +4689,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4700,7 +4700,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4711,7 +4711,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4722,7 +4722,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4733,7 +4733,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4744,7 +4744,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4755,7 +4755,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4766,7 +4766,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4777,7 +4777,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4788,7 +4788,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4799,7 +4799,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4810,7 +4810,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4821,7 +4821,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4832,7 +4832,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4843,7 +4843,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4854,7 +4854,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4865,7 +4865,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4876,7 +4876,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4887,7 +4887,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4898,7 +4898,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4909,7 +4909,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4920,7 +4920,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4931,7 +4931,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4942,7 +4942,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4953,7 +4953,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4964,7 +4964,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4975,7 +4975,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4986,7 +4986,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4997,7 +4997,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5008,7 +5008,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5019,7 +5019,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Branced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5030,7 +5030,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5041,7 +5041,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5052,7 +5052,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5063,7 +5063,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5074,7 +5074,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Curved Spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5085,7 +5085,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5096,7 +5096,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Disc</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5107,7 +5107,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dumbbell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5118,7 +5118,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Other</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5129,7 +5129,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5140,7 +5140,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5151,7 +5151,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flask</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5162,7 +5162,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5173,7 +5173,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5184,7 +5184,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5195,7 +5195,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5206,7 +5206,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5217,7 +5217,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5228,7 +5228,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5239,7 +5239,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5250,7 +5250,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5261,7 +5261,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5272,7 +5272,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5283,7 +5283,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5294,7 +5294,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5305,7 +5305,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5316,7 +5316,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Square</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5327,7 +5327,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Star</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5338,7 +5338,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Star - Dumbbell - Pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5349,7 +5349,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5360,7 +5360,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5371,7 +5371,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Triangular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5382,7 +5382,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5393,7 +5393,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5404,7 +5404,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Condition</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5415,7 +5415,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physiological Trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5426,7 +5426,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Metabolic Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5437,7 +5437,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5448,7 +5448,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5459,7 +5459,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5470,7 +5470,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5481,7 +5481,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mesophilie</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5492,7 +5492,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Structural Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5503,7 +5503,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5514,7 +5514,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5525,7 +5525,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5536,7 +5536,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5547,7 +5547,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5558,7 +5558,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5569,7 +5569,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Electron Donor Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5580,7 +5580,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5591,7 +5591,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5602,7 +5602,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5613,7 +5613,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5624,7 +5624,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5635,7 +5635,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Reproductive Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5646,7 +5646,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dormancy Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5657,7 +5657,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5668,7 +5668,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5679,7 +5679,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Genomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5690,7 +5690,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Dimension</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5701,7 +5701,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5712,7 +5712,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5723,7 +5723,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5734,7 +5734,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5745,7 +5745,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5756,7 +5756,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5767,7 +5767,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Colony Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5778,7 +5778,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physical Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5789,7 +5789,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Context</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5800,7 +5800,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Biological Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5811,7 +5811,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Functional Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5822,7 +5822,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Classification Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5833,7 +5833,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete METPO Biological Process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5844,7 +5844,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5855,7 +5855,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Measurable Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5866,7 +5866,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-stain negative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5877,7 +5877,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-stain positive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5888,7 +5888,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5899,7 +5899,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5910,7 +5910,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5921,7 +5921,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5932,7 +5932,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5943,7 +5943,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5954,7 +5954,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5965,7 +5965,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5976,7 +5976,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5987,7 +5987,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5998,7 +5998,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6009,7 +6009,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6020,7 +6020,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6031,7 +6031,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acid Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6042,7 +6042,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6053,7 +6053,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6064,7 +6064,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6075,7 +6075,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6086,7 +6086,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6097,7 +6097,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6108,7 +6108,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6119,7 +6119,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6130,7 +6130,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6141,7 +6141,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6152,7 +6152,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6163,7 +6163,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6174,7 +6174,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6185,7 +6185,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6196,7 +6196,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6207,7 +6207,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6218,7 +6218,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6229,7 +6229,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6240,7 +6240,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6251,7 +6251,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6262,7 +6262,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6273,7 +6273,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6284,7 +6284,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6295,7 +6295,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6306,7 +6306,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6317,7 +6317,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6328,7 +6328,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6339,7 +6339,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6350,7 +6350,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6361,7 +6361,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6372,7 +6372,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6383,7 +6383,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6394,7 +6394,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6405,7 +6405,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6416,7 +6416,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6427,7 +6427,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6438,7 +6438,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6449,7 +6449,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6460,7 +6460,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6471,7 +6471,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6482,7 +6482,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6493,7 +6493,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6504,7 +6504,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6515,7 +6515,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6526,7 +6526,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6537,7 +6537,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6548,7 +6548,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6559,7 +6559,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6570,7 +6570,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6581,7 +6581,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6592,7 +6592,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6603,7 +6603,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6614,7 +6614,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6625,7 +6625,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6636,7 +6636,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6647,7 +6647,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6658,7 +6658,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Endospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6669,7 +6669,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Exospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6680,7 +6680,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6691,7 +6691,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6702,7 +6702,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;organismal quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6713,7 +6713,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;physicial object quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6724,7 +6724,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6735,7 +6735,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6746,7 +6746,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete 1-D extent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6757,7 +6757,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6768,7 +6768,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6779,7 +6779,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6790,7 +6790,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;prokaryotic metabolically differentiated cell&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6801,7 +6801,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterotrophy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6812,7 +6812,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6823,7 +6823,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spore type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6834,7 +6834,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6845,7 +6845,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward NaCl</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6856,7 +6856,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6867,7 +6867,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6878,7 +6878,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Arthrospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6889,7 +6889,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic constraints</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6900,7 +6900,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell by chemical produced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6911,7 +6911,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6922,7 +6922,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporangiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6933,7 +6933,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6944,7 +6944,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Akinetes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6955,7 +6955,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6966,7 +6966,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6977,7 +6977,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6988,7 +6988,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6999,7 +6999,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7010,7 +7010,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7021,7 +7021,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7032,7 +7032,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ascospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7043,7 +7043,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Basidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7054,7 +7054,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7065,7 +7065,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7076,7 +7076,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7087,7 +7087,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zoospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7098,7 +7098,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7109,7 +7109,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7120,7 +7120,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7131,7 +7131,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7142,7 +7142,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7153,7 +7153,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7164,7 +7164,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7175,7 +7175,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7186,7 +7186,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7197,7 +7197,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7208,7 +7208,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7219,7 +7219,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7230,7 +7230,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7241,7 +7241,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7252,7 +7252,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7263,7 +7263,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7274,7 +7274,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7285,7 +7285,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7296,7 +7296,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7307,7 +7307,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7318,7 +7318,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7329,7 +7329,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7340,7 +7340,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7351,7 +7351,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7362,7 +7362,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7373,7 +7373,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7384,7 +7384,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7395,7 +7395,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7406,7 +7406,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7417,7 +7417,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7428,7 +7428,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7439,7 +7439,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7450,7 +7450,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% low ( &lt; 42.65)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7461,7 +7461,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% mid1 (42.65 - 57)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7472,7 +7472,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% mid2 (57 - 66.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7483,7 +7483,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% high ( &gt; 66.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7494,7 +7494,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM very low (&lt; 0.5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7505,7 +7505,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM low (0.5 - 0.65)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7516,7 +7516,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM mid (0.65 - 0.9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7527,7 +7527,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM high (&gt; 0.9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7538,7 +7538,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM very low (&lt;= 1.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7549,7 +7549,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM low (1.3 - 2)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7560,7 +7560,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM mid (2 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7571,7 +7571,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM high (&gt; 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7582,7 +7582,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C very low (&lt;= 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7593,7 +7593,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C low (10 - 22)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7604,7 +7604,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid1 (22 - 27)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7615,7 +7615,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid2 (27 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7626,7 +7626,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid3 (30 - 34)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7637,7 +7637,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid4 (34 - 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7648,7 +7648,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C high (&gt; 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7659,7 +7659,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C very low (&lt;= 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7670,7 +7670,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C low (10 - 22)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7681,7 +7681,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid1 (22 - 27)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7692,7 +7692,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid2 (27 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7703,7 +7703,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid3 (30 - 34)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7714,7 +7714,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid4 (34 - 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7725,7 +7725,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C high (&gt; 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7736,7 +7736,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum low (0 - 6)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7747,7 +7747,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid1 (6 - 7)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7758,7 +7758,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid2 (7 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7769,7 +7769,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum high (8 - 14)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7780,7 +7780,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range very low (0 - 4)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7791,7 +7791,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range low (4 - 6)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7802,7 +7802,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid1 (6 - 7)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7813,7 +7813,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid2 (7 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7824,7 +7824,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid3 (8 - 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7835,7 +7835,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range high (10 - 14)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7846,7 +7846,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7857,7 +7857,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum mid1 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7868,7 +7868,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7879,7 +7879,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum high (&gt; 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7890,7 +7890,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7901,7 +7901,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range mid1 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7912,7 +7912,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7923,7 +7923,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range high (&gt; 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7934,7 +7934,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta very low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7945,7 +7945,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta low (1 - 2)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7956,7 +7956,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid1 (2 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7967,7 +7967,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid2 (3 - 4)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7978,7 +7978,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid3 (4 - 5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7989,7 +7989,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta high (5 - 9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8000,7 +8000,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8011,7 +8011,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta mid2 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8022,7 +8022,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8033,7 +8033,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta high (&gt;= 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8044,7 +8044,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta very low (1 - 5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8055,7 +8055,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta low (5 - 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8066,7 +8066,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta mid1 (10 - 20)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8077,7 +8077,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta mid2 (20 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8088,7 +8088,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta high (&gt;= 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8099,7 +8099,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8110,7 +8110,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete branced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8121,7 +8121,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8132,7 +8132,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8143,7 +8143,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8154,7 +8154,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8165,7 +8165,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete curved spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8176,7 +8176,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8187,7 +8187,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete disc</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8198,7 +8198,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dumbbell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8209,7 +8209,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8220,7 +8220,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8231,7 +8231,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flask</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8242,7 +8242,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8253,7 +8253,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8264,7 +8264,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8275,7 +8275,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8286,7 +8286,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8297,7 +8297,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8308,7 +8308,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8319,7 +8319,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8330,7 +8330,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8341,7 +8341,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8352,7 +8352,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8363,7 +8363,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8374,7 +8374,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8385,7 +8385,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete square</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8396,7 +8396,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8407,7 +8407,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8418,7 +8418,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8429,7 +8429,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete triangular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8440,7 +8440,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8451,7 +8451,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8462,7 +8462,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Condition</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8473,7 +8473,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physiological Trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8484,7 +8484,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Metabolic Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8495,7 +8495,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8506,7 +8506,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8517,7 +8517,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8528,7 +8528,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8539,7 +8539,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Structural Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8550,7 +8550,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8561,7 +8561,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8572,7 +8572,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8583,7 +8583,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8594,7 +8594,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8605,7 +8605,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8616,7 +8616,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Electron Donor Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8627,7 +8627,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8638,7 +8638,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8649,7 +8649,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8660,7 +8660,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8671,7 +8671,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Reproductive Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8682,7 +8682,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dormancy Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8693,7 +8693,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8704,7 +8704,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8715,7 +8715,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GenomicFeature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8726,7 +8726,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Dimension</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8737,7 +8737,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8748,7 +8748,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8759,7 +8759,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8770,7 +8770,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8781,7 +8781,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8792,7 +8792,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Colony Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8803,7 +8803,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete acid-fast</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8814,7 +8814,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8825,7 +8825,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete active transport</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8836,7 +8836,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8847,7 +8847,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adaptive trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8858,7 +8858,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adhesin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8869,7 +8869,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adhesion structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8880,7 +8880,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8891,7 +8891,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerobic respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8902,7 +8902,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8913,7 +8913,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aggregate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8924,7 +8924,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete akinete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8935,7 +8935,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8946,7 +8946,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ammonification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8957,7 +8957,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete amylolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8968,7 +8968,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8979,7 +8979,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anaerobic respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8990,7 +8990,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anoxygenic photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9001,7 +9001,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antibiotic production</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9012,7 +9012,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antibiotic resistance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9023,7 +9023,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antimicrobial resistance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9034,7 +9034,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete appendage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9045,7 +9045,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete arthrospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9056,7 +9056,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ascospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9067,7 +9067,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9078,7 +9078,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete autotrophic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9089,7 +9089,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete auxotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9100,7 +9100,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete axial filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9111,7 +9111,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9122,7 +9122,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9133,7 +9133,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9144,7 +9144,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete basidiospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9155,7 +9155,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete binary fission</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9166,7 +9166,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9177,7 +9177,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9188,7 +9188,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm formation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9199,7 +9199,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biogeochemical cycling</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9210,7 +9210,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bioluminescence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9221,7 +9221,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete budding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9232,7 +9232,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete buoyancy structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9243,7 +9243,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9254,7 +9254,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete capsule</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9265,7 +9265,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carbon fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9276,7 +9276,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carbon source</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9287,7 +9287,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9298,7 +9298,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9309,7 +9309,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell envelope</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9320,7 +9320,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell length category</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9331,7 +9331,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9342,7 +9342,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9353,7 +9353,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell wall characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9364,7 +9364,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell wall component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9375,7 +9375,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell width category</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9386,7 +9386,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9397,7 +9397,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9408,7 +9408,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9419,7 +9419,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular product</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9430,7 +9430,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellulolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9478,7 +9478,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9489,7 +9489,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chemotaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9500,7 +9500,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chlamydospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9511,7 +9511,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete class</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9522,7 +9522,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete clinically relevant feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9533,7 +9533,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9544,7 +9544,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cold shock protein</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9555,7 +9555,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cold shock response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9566,7 +9566,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colonization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9577,7 +9577,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony elevation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9588,7 +9588,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony margin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9599,7 +9599,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9610,7 +9610,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony texture</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9621,7 +9621,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete commensalism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9632,7 +9632,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete community behavior</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9643,7 +9643,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete community structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9654,7 +9654,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete compatible solute</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9665,7 +9665,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete competence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9676,7 +9676,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9687,7 +9687,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete conidium</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9698,7 +9698,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete conjugation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9709,7 +9709,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete CRISPR</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9720,7 +9720,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete culturability</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9731,7 +9731,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cyst</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9742,7 +9742,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete death phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9753,7 +9753,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete denitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9764,7 +9764,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete developmental process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9775,7 +9775,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diagnostic enzyme</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9786,7 +9786,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diagnostic feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9797,7 +9797,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diazotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9808,7 +9808,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete differentiation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9819,7 +9819,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dimorphism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9830,7 +9830,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete disc-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9841,7 +9841,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete domain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9852,7 +9852,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dormancy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9863,7 +9863,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dormancy structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9874,7 +9874,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dumbbell-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9885,7 +9885,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological niche</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9896,7 +9896,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9907,7 +9907,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9918,7 +9918,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ectosymbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9929,7 +9929,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete electron acceptor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9940,7 +9940,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete electron donor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9951,7 +9951,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete endospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9962,7 +9962,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete endosymbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9973,7 +9973,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete energy metabolism process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9984,7 +9984,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete enzyme activity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9995,7 +9995,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete epigenetic modification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10006,7 +10006,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete evolutionary process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10017,7 +10017,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete exospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10028,7 +10028,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete exponential phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10039,7 +10039,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extracellular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10050,7 +10050,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extracellular polysaccharide</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10061,7 +10061,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10072,7 +10072,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extremophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10083,7 +10083,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete facultative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10094,7 +10094,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10105,7 +10105,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete family</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10116,7 +10116,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fastidious</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10127,7 +10127,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fermentation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10138,7 +10138,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete filamentous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10149,7 +10149,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fimbriae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10160,7 +10160,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flagellum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10171,7 +10171,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flask-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10182,7 +10182,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fungal spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10193,7 +10193,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete gas vesicle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10228,7 +10228,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete high GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10239,7 +10239,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete low GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10250,7 +10250,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lower-mid GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10261,7 +10261,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete upper-mid GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10272,7 +10272,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete generation time</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10283,7 +10283,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10294,7 +10294,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic exchange</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10305,7 +10305,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10316,7 +10316,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genome size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10327,7 +10327,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10338,7 +10338,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic island</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10349,7 +10349,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10360,7 +10360,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10371,7 +10371,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete gliding motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10382,7 +10382,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete global regulator</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10393,7 +10393,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-negative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10404,7 +10404,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-positive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10415,7 +10415,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram stain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10426,7 +10426,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10437,7 +10437,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth conditions constraints</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10448,7 +10448,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth pattern</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10459,7 +10459,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth rate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10470,7 +10470,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete habitat</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10481,7 +10481,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10492,7 +10492,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10503,7 +10503,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heat shock protein</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10514,7 +10514,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heat shock response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10525,7 +10525,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hemolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10536,7 +10536,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterocyst</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10547,7 +10547,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10558,7 +10558,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete holdfast</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10569,7 +10569,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete horizontal gene transfer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10580,7 +10580,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hydrolase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10591,7 +10591,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10602,7 +10602,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete inclusion body</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10613,7 +10613,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete infection</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10624,7 +10624,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10635,7 +10635,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with a phage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10646,7 +10646,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with an environment</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10657,7 +10657,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with host</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10668,7 +10668,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction within a community</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10679,7 +10679,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete intracellular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10690,7 +10690,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete invasion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10701,7 +10701,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete laboratory characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10712,7 +10712,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lag phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10723,7 +10723,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete life cycle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10734,7 +10734,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete life cycle phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10745,7 +10745,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lipolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10756,7 +10756,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lipopolysaccharide</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10767,7 +10767,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete localization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10778,7 +10778,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lysogeny</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10789,7 +10789,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete macroscopic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10800,7 +10800,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete magnetotaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10811,7 +10811,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mesophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10822,7 +10822,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic partner</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10833,7 +10833,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10844,7 +10844,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10855,7 +10855,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete methylation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10882,7 +10882,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10902,7 +10902,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10913,7 +10913,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10924,7 +10924,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mobile genetic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10935,7 +10935,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10946,7 +10946,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete morphological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10957,7 +10957,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete motility process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10968,7 +10968,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete motility structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10979,7 +10979,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mutualism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10990,7 +10990,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mycolic acid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11001,7 +11001,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mycorrhization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11012,7 +11012,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11023,7 +11023,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11034,7 +11034,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nitrogen fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11045,7 +11045,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nodulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11056,7 +11056,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nucleoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11067,7 +11067,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nutrient utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11078,7 +11078,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11089,7 +11089,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11100,7 +11100,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11111,7 +11111,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11122,7 +11122,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete order</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11133,7 +11133,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by growth conditions</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11144,7 +11144,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by nutritional requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11155,7 +11155,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by product produced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11166,7 +11166,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11177,7 +11177,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to ph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11188,7 +11188,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11199,7 +11199,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to salt concentration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11210,7 +11210,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11221,7 +11221,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11232,7 +11232,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11243,7 +11243,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete osmophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11254,7 +11254,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete osmoregulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11265,7 +11265,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxidative stress response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11276,7 +11276,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxidoreductase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11287,7 +11287,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxygen requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11298,7 +11298,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxygenic photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11309,7 +11309,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pan-genome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11320,7 +11320,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete parasitism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11331,7 +11331,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete passive transport</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11342,7 +11342,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pathogenicity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11353,7 +11353,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pathogenicity island</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11364,7 +11364,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete peptidoglycan</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11385,7 +11385,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH optimum (growth range)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11396,7 +11396,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11407,7 +11407,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH range (growth tolerance)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11418,7 +11418,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH tolerance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11429,7 +11429,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phage defense</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11440,7 +11440,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11451,7 +11451,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11462,7 +11462,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11473,7 +11473,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phototaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11484,7 +11484,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phylum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11495,7 +11495,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11506,7 +11506,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological state</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11517,7 +11517,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11528,7 +11528,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11539,7 +11539,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pigment</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11550,7 +11550,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pigmentation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11561,7 +11561,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pilus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11572,7 +11572,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete plant growth promotion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11583,7 +11583,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete plasmid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11594,7 +11594,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pleomorphism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11605,7 +11605,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11616,7 +11616,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prophage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11627,7 +11627,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prostheca</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11638,7 +11638,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete protein synthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11649,7 +11649,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete proteolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11660,7 +11660,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11671,7 +11671,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11682,7 +11682,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete qualifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11693,7 +11693,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete quorum sensing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11704,7 +11704,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete regulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11715,7 +11715,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete regulatory mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11726,7 +11726,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete reproductive process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11737,7 +11737,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete reproductive structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11748,7 +11748,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete resistance mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11759,7 +11759,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11770,7 +11770,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete restriction-modification system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11781,7 +11781,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ribosome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11792,7 +11792,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete S-layer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11803,7 +11803,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete salinity delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11814,7 +11814,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete salinity preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11825,7 +11825,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secondary metabolite</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11836,7 +11836,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secretion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11847,7 +11847,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secretion system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11858,7 +11858,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sheathed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11869,7 +11869,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete siderophore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11880,7 +11880,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sigma factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11891,7 +11891,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete signaling</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11902,7 +11902,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete slime layer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11913,7 +11913,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete specialized cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11924,7 +11924,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete species</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11935,7 +11935,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirillum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11946,7 +11946,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11957,7 +11957,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sporangiospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11968,7 +11968,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11979,7 +11979,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete square cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11990,7 +11990,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stalk</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12001,7 +12001,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12012,7 +12012,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stationary phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12023,7 +12023,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete storage structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12034,7 +12034,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete strain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12045,7 +12045,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stress response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12056,7 +12056,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12067,7 +12067,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12078,7 +12078,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12089,7 +12089,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete symbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12100,7 +12100,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete symbiotic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12111,7 +12111,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete syntrophy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12122,7 +12122,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete taxonomic identifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12133,7 +12133,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete taxonomic rank</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12144,7 +12144,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete teichoic acid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12183,7 +12183,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete temperature preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12204,7 +12204,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete thermal tolerance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12215,7 +12215,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12226,7 +12226,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete toxin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12237,7 +12237,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transcription factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12248,7 +12248,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12259,7 +12259,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transferase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12270,7 +12270,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transformation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12281,7 +12281,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transport system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12292,7 +12292,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transposon</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12303,7 +12303,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete triangular cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12314,7 +12314,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete trichome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12325,7 +12325,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete twitching motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12336,7 +12336,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete two-component system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12347,7 +12347,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete viable but non-culturable</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12358,7 +12358,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12369,7 +12369,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12380,7 +12380,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12391,7 +12391,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12402,7 +12402,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete xylanolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12413,7 +12413,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete zoospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12424,7 +12424,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete zygospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12435,7 +12435,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12446,7 +12446,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature optimum (metabolic activity)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12457,7 +12457,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature range (metabolic viability)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12529,7 +12529,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12540,7 +12540,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12551,7 +12551,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12562,7 +12562,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12573,7 +12573,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12584,7 +12584,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12595,7 +12595,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12606,7 +12606,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12617,7 +12617,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete acid tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12628,7 +12628,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete alkali tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12639,7 +12639,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12650,7 +12650,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12661,7 +12661,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12672,7 +12672,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12683,7 +12683,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12694,7 +12694,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12705,7 +12705,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12716,7 +12716,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12727,7 +12727,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12738,7 +12738,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12749,7 +12749,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12760,7 +12760,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12771,7 +12771,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12782,7 +12782,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12793,7 +12793,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12804,7 +12804,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12815,7 +12815,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12826,7 +12826,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12837,7 +12837,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12848,7 +12848,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12859,7 +12859,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12870,7 +12870,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12881,7 +12881,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12892,7 +12892,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12903,7 +12903,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12914,7 +12914,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12925,7 +12925,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12936,7 +12936,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12947,7 +12947,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12958,7 +12958,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12969,7 +12969,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12980,7 +12980,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12991,7 +12991,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13002,7 +13002,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13013,7 +13013,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13024,7 +13024,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13035,7 +13035,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13046,7 +13046,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13057,7 +13057,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13068,7 +13068,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13079,7 +13079,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13090,7 +13090,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13101,7 +13101,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13112,7 +13112,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13123,7 +13123,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13134,7 +13134,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13145,7 +13145,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13156,7 +13156,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13167,7 +13167,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13178,7 +13178,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13189,7 +13189,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13200,7 +13200,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13211,7 +13211,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13222,7 +13222,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13233,7 +13233,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13244,7 +13244,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13255,7 +13255,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13266,7 +13266,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13277,7 +13277,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13288,7 +13288,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13299,7 +13299,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13310,7 +13310,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13321,7 +13321,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13332,7 +13332,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13343,7 +13343,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13354,7 +13354,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13365,7 +13365,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13376,7 +13376,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13387,7 +13387,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13398,7 +13398,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13409,7 +13409,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13420,7 +13420,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13431,7 +13431,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13442,7 +13442,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13453,7 +13453,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13464,7 +13464,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13475,7 +13475,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13486,7 +13486,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13497,7 +13497,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13508,7 +13508,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13519,7 +13519,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13530,7 +13530,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13541,7 +13541,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13708,7 +13708,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13719,7 +13719,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13730,7 +13730,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13741,7 +13741,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13752,7 +13752,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13763,7 +13763,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13774,7 +13774,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13785,7 +13785,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15772,7 +15772,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete branched</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15783,7 +15783,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15794,7 +15794,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15805,7 +15805,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15816,7 +15816,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete curved spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15827,7 +15827,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15838,7 +15838,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15849,7 +15849,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15860,7 +15860,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15871,7 +15871,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15882,7 +15882,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15893,7 +15893,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15904,7 +15904,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15915,7 +15915,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15926,7 +15926,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15937,7 +15937,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15948,7 +15948,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15959,7 +15959,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15970,7 +15970,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15981,7 +15981,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15992,7 +15992,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16003,7 +16003,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16014,7 +16014,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete salinity adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16025,7 +16025,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16036,7 +16036,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete bacterial spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16047,7 +16047,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure adaptation type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16058,7 +16058,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure tolerance range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16069,7 +16069,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16080,7 +16080,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16091,7 +16091,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16102,7 +16102,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete 1-D extent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16113,7 +16113,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16124,7 +16124,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16135,7 +16135,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16146,7 +16146,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward nacl</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16157,7 +16157,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward ph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16168,7 +16168,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16224,7 +16224,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete structured susceptibility detail</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16235,7 +16235,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17513,7 +17513,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete denitrifying</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17568,7 +17568,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17749,7 +17749,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete nitrogen-fixing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -18005,7 +18005,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -18016,7 +18016,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfur-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19377,7 +19377,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19388,7 +19388,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19399,7 +19399,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Denitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19410,7 +19410,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Dissimilatory nitrate reduction to ammonium</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19421,7 +19421,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19432,7 +19432,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic ammonium oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19443,7 +19443,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitric oxide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19454,7 +19454,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrous oxide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19465,7 +19465,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur and sulfoxide compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19476,7 +19476,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19487,7 +19487,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19498,7 +19498,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19509,7 +19509,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19520,7 +19520,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19531,7 +19531,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Dimethyl sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19542,7 +19542,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methionine sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19553,7 +19553,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19564,7 +19564,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19575,7 +19575,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19586,7 +19586,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Tetrathionate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19597,7 +19597,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Polysulfide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19608,7 +19608,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Metal and metalloid respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19619,7 +19619,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19630,7 +19630,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19641,7 +19641,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent Fe(II) oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19652,7 +19652,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19663,7 +19663,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19674,7 +19674,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Uranium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19685,7 +19685,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Vanadium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19696,7 +19696,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chromium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19707,7 +19707,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Technetium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19718,7 +19718,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Cobalt reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19729,7 +19729,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19740,7 +19740,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19751,7 +19751,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19762,7 +19762,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19773,7 +19773,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon and organic compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19844,7 +19844,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Fumarate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19855,7 +19855,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Trimethylamine N-oxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19866,7 +19866,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Humus respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19877,7 +19877,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Halogenated compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19888,7 +19888,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Organohalide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19899,7 +19899,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete (Per)chlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19910,7 +19910,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Perchlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19921,7 +19921,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19932,7 +19932,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Bromate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19943,7 +19943,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iodate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19954,7 +19954,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19965,7 +19965,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19976,7 +19976,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogen oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19987,7 +19987,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19998,7 +19998,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20009,7 +20009,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Complete ammonia oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20020,7 +20020,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon monoxide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20031,7 +20031,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogenotrophic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20042,7 +20042,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Acetoclastic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20053,7 +20053,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methylotrophic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20064,7 +20064,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20075,7 +20075,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Lanthanide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20086,7 +20086,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Lanthanide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20584,7 +20584,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20595,7 +20595,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20606,7 +20606,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20617,7 +20617,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20628,7 +20628,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20639,7 +20639,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20650,7 +20650,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20661,7 +20661,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20672,7 +20672,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20683,7 +20683,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20694,7 +20694,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20705,7 +20705,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20716,7 +20716,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20727,7 +20727,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20738,7 +20738,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20749,7 +20749,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20760,7 +20760,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20771,7 +20771,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20782,7 +20782,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20793,7 +20793,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20804,7 +20804,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20815,7 +20815,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20826,7 +20826,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20837,7 +20837,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20966,7 +20966,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20977,7 +20977,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Fe(III)-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20988,7 +20988,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Mn(IV)-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21050,7 +21050,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur disproportionation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21061,7 +21061,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21072,7 +21072,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21083,7 +21083,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic ammonium-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21094,7 +21094,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrous oxide-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21105,7 +21105,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21116,7 +21116,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21127,7 +21127,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21138,7 +21138,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21149,7 +21149,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-disproportionating</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21160,7 +21160,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfide-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21171,7 +21171,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21182,7 +21182,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21193,7 +21193,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21204,7 +21204,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21215,7 +21215,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent Fe(II)-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21226,7 +21226,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21237,7 +21237,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21248,7 +21248,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Uranium-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21259,7 +21259,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21270,7 +21270,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21281,7 +21281,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenite-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21292,7 +21292,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Perchlorate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21303,7 +21303,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chlorate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21314,7 +21314,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Bromate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21325,7 +21325,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iodate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21336,7 +21336,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogen-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21347,7 +21347,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21358,7 +21358,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Ammonia oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21369,7 +21369,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21380,7 +21380,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Complete ammonia-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21391,7 +21391,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21402,7 +21402,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon monoxide-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21413,7 +21413,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen-fixing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -22942,7 +22942,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obsolete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
 </rdf:RDF>
 

--- a/metpo.json
+++ b/metpo.json
@@ -50,10 +50,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000002",
@@ -63,10 +61,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000003",
@@ -76,10 +72,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000004",
@@ -89,10 +83,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000005",
@@ -102,10 +94,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000006",
@@ -115,10 +105,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000007",
@@ -128,10 +116,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000008",
@@ -141,10 +127,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000009",
@@ -154,10 +138,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000001",
@@ -167,10 +149,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000010",
@@ -180,10 +160,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000011",
@@ -193,10 +171,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000012",
@@ -206,10 +182,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000013",
@@ -219,10 +193,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000014",
@@ -232,10 +204,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000015",
@@ -245,10 +215,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000016",
@@ -258,10 +226,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000017",
@@ -271,10 +237,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000018",
@@ -284,10 +248,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000019",
@@ -297,10 +259,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000002",
@@ -310,10 +270,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000020",
@@ -323,10 +281,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000021",
@@ -336,10 +292,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000022",
@@ -349,10 +303,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000023",
@@ -362,10 +314,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000024",
@@ -375,10 +325,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000025",
@@ -388,10 +336,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000026",
@@ -401,10 +347,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000027",
@@ -414,10 +358,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000028",
@@ -427,10 +369,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000029",
@@ -440,10 +380,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000003",
@@ -453,10 +391,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000030",
@@ -466,10 +402,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000031",
@@ -479,10 +413,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000032",
@@ -492,10 +424,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000033",
@@ -505,10 +435,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000034",
@@ -518,10 +446,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000035",
@@ -531,10 +457,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000036",
@@ -544,10 +468,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000037",
@@ -557,10 +479,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000038",
@@ -570,10 +490,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000039",
@@ -583,10 +501,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000004",
@@ -596,10 +512,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000040",
@@ -609,10 +523,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000041",
@@ -622,10 +534,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000042",
@@ -635,10 +545,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000043",
@@ -648,10 +556,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000044",
@@ -661,10 +567,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000045",
@@ -674,10 +578,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000046",
@@ -687,10 +589,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000047",
@@ -700,10 +600,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000048",
@@ -713,10 +611,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000049",
@@ -726,10 +622,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000005",
@@ -739,10 +633,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000050",
@@ -752,10 +644,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000051",
@@ -765,10 +655,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000052",
@@ -778,10 +666,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000053",
@@ -791,10 +677,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000054",
@@ -804,10 +688,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000055",
@@ -817,10 +699,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000056",
@@ -830,10 +710,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000057",
@@ -843,10 +721,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000058",
@@ -856,10 +732,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000059",
@@ -869,10 +743,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000006",
@@ -882,10 +754,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000060",
@@ -895,10 +765,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000061",
@@ -908,10 +776,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000062",
@@ -921,10 +787,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000063",
@@ -934,10 +798,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000064",
@@ -947,10 +809,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000065",
@@ -960,10 +820,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000066",
@@ -973,10 +831,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000067",
@@ -986,10 +842,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000068",
@@ -999,10 +853,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000069",
@@ -1012,10 +864,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000007",
@@ -1025,10 +875,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000070",
@@ -1038,10 +886,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000071",
@@ -1051,10 +897,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000072",
@@ -1064,10 +908,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000073",
@@ -1077,10 +919,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000074",
@@ -1090,10 +930,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000075",
@@ -1103,10 +941,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000076",
@@ -1116,10 +952,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000077",
@@ -1129,10 +963,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000078",
@@ -1142,10 +974,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000079",
@@ -1155,10 +985,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000008",
@@ -1168,10 +996,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000080",
@@ -1181,10 +1007,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000081",
@@ -1194,10 +1018,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000082",
@@ -1207,10 +1029,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000083",
@@ -1220,10 +1040,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000084",
@@ -1233,10 +1051,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000085",
@@ -1246,10 +1062,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000086",
@@ -1259,10 +1073,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000087",
@@ -1272,10 +1084,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000088",
@@ -1285,10 +1095,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000089",
@@ -1298,10 +1106,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000009",
@@ -1311,10 +1117,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000090",
@@ -1324,10 +1128,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000091",
@@ -1337,10 +1139,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000092",
@@ -1350,10 +1150,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000093",
@@ -1363,10 +1161,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000094",
@@ -1376,10 +1172,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000095",
@@ -1389,10 +1183,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000096",
@@ -1402,10 +1194,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000097",
@@ -1415,10 +1205,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000098",
@@ -1428,10 +1216,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000099",
@@ -1441,10 +1227,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000010",
@@ -1454,10 +1238,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000100",
@@ -1467,10 +1249,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000101",
@@ -1480,10 +1260,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000102",
@@ -1493,10 +1271,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000103",
@@ -1506,10 +1282,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000104",
@@ -1519,10 +1293,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000105",
@@ -1532,10 +1304,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000106",
@@ -1545,10 +1315,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000107",
@@ -1558,10 +1326,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000108",
@@ -1571,10 +1337,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000109",
@@ -1584,10 +1348,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000011",
@@ -1597,10 +1359,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000110",
@@ -1610,10 +1370,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000111",
@@ -1623,10 +1381,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000112",
@@ -1636,10 +1392,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000113",
@@ -1649,10 +1403,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000114",
@@ -1662,10 +1414,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000115",
@@ -1675,10 +1425,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000116",
@@ -1688,10 +1436,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000117",
@@ -1701,10 +1447,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000118",
@@ -1714,10 +1458,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000119",
@@ -1727,10 +1469,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000012",
@@ -1740,10 +1480,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000120",
@@ -1753,10 +1491,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000121",
@@ -1766,10 +1502,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000122",
@@ -1779,10 +1513,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000123",
@@ -1792,10 +1524,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000124",
@@ -1805,10 +1535,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000125",
@@ -1818,10 +1546,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000126",
@@ -1831,10 +1557,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000127",
@@ -1844,10 +1568,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000128",
@@ -1857,10 +1579,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000129",
@@ -1870,10 +1590,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000013",
@@ -1883,10 +1601,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000130",
@@ -1896,10 +1612,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000131",
@@ -1909,10 +1623,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000132",
@@ -1922,10 +1634,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000133",
@@ -1935,10 +1645,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000134",
@@ -1948,10 +1656,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000135",
@@ -1961,10 +1667,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000136",
@@ -1974,10 +1678,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000137",
@@ -1987,10 +1689,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000138",
@@ -2000,10 +1700,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000139",
@@ -2013,10 +1711,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000014",
@@ -2026,10 +1722,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000140",
@@ -2039,10 +1733,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000141",
@@ -2052,10 +1744,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000142",
@@ -2065,10 +1755,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000143",
@@ -2078,10 +1766,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000144",
@@ -2091,10 +1777,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000145",
@@ -2104,10 +1788,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000146",
@@ -2117,10 +1799,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000147",
@@ -2130,10 +1810,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000148",
@@ -2143,10 +1821,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000149",
@@ -2156,10 +1832,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000015",
@@ -2169,10 +1843,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000150",
@@ -2182,10 +1854,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000151",
@@ -2195,10 +1865,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000152",
@@ -2208,10 +1876,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000153",
@@ -2221,10 +1887,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000154",
@@ -2234,10 +1898,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000155",
@@ -2247,10 +1909,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000156",
@@ -2260,10 +1920,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000157",
@@ -2273,10 +1931,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000158",
@@ -2286,10 +1942,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000159",
@@ -2299,10 +1953,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000016",
@@ -2312,10 +1964,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000160",
@@ -2325,10 +1975,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000161",
@@ -2338,10 +1986,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000162",
@@ -2351,10 +1997,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000163",
@@ -2364,10 +2008,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000164",
@@ -2377,10 +2019,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000165",
@@ -2390,10 +2030,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000166",
@@ -2403,10 +2041,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000167",
@@ -2416,10 +2052,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000168",
@@ -2429,10 +2063,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000169",
@@ -2442,10 +2074,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000017",
@@ -2455,10 +2085,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000170",
@@ -2468,10 +2096,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000171",
@@ -2481,10 +2107,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000172",
@@ -2494,10 +2118,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000173",
@@ -2507,10 +2129,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000174",
@@ -2520,10 +2140,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000175",
@@ -2533,10 +2151,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000176",
@@ -2546,10 +2162,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000177",
@@ -2559,10 +2173,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000178",
@@ -2572,10 +2184,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000179",
@@ -2585,10 +2195,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000018",
@@ -2598,10 +2206,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000180",
@@ -2611,10 +2217,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000181",
@@ -2624,10 +2228,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000182",
@@ -2637,10 +2239,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000183",
@@ -2650,10 +2250,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000184",
@@ -2663,10 +2261,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000185",
@@ -2676,10 +2272,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000186",
@@ -2689,10 +2283,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000187",
@@ -2702,10 +2294,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000188",
@@ -2715,10 +2305,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000189",
@@ -2728,10 +2316,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000019",
@@ -2741,10 +2327,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000190",
@@ -2754,10 +2338,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000191",
@@ -2767,10 +2349,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000192",
@@ -2780,10 +2360,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000193",
@@ -2793,10 +2371,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000194",
@@ -2806,10 +2382,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000195",
@@ -2819,10 +2393,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000196",
@@ -2832,10 +2404,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000197",
@@ -2845,10 +2415,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000198",
@@ -2858,10 +2426,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000199",
@@ -2871,10 +2437,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000020",
@@ -2884,10 +2448,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000200",
@@ -2897,10 +2459,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000201",
@@ -2910,10 +2470,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000202",
@@ -2923,10 +2481,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000203",
@@ -2936,10 +2492,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000204",
@@ -2949,10 +2503,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000205",
@@ -2962,10 +2514,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000206",
@@ -2975,10 +2525,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000207",
@@ -2988,10 +2536,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000208",
@@ -3001,10 +2547,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000209",
@@ -3014,10 +2558,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000021",
@@ -3027,10 +2569,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000210",
@@ -3040,10 +2580,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000211",
@@ -3053,10 +2591,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000212",
@@ -3066,10 +2602,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000213",
@@ -3079,10 +2613,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000214",
@@ -3092,10 +2624,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000215",
@@ -3105,10 +2635,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000216",
@@ -3118,10 +2646,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000217",
@@ -3131,10 +2657,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000218",
@@ -3144,10 +2668,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000219",
@@ -3157,10 +2679,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000022",
@@ -3170,10 +2690,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000220",
@@ -3183,10 +2701,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000221",
@@ -3196,10 +2712,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000222",
@@ -3209,10 +2723,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000223",
@@ -3222,10 +2734,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000224",
@@ -3235,10 +2745,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000225",
@@ -3248,10 +2756,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000226",
@@ -3261,10 +2767,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000227",
@@ -3274,10 +2778,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000228",
@@ -3287,10 +2789,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000229",
@@ -3300,10 +2800,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000023",
@@ -3313,10 +2811,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000230",
@@ -3326,10 +2822,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000231",
@@ -3339,10 +2833,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000232",
@@ -3352,10 +2844,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000233",
@@ -3365,10 +2855,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000234",
@@ -3378,10 +2866,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000235",
@@ -3391,10 +2877,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000236",
@@ -3404,10 +2888,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000237",
@@ -3417,10 +2899,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000238",
@@ -3430,10 +2910,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000239",
@@ -3443,10 +2921,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000024",
@@ -3456,10 +2932,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000240",
@@ -3469,10 +2943,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000241",
@@ -3482,10 +2954,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000242",
@@ -3495,10 +2965,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000243",
@@ -3508,10 +2976,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000244",
@@ -3521,10 +2987,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000245",
@@ -3534,10 +2998,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000246",
@@ -3547,10 +3009,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000247",
@@ -3560,10 +3020,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000248",
@@ -3573,10 +3031,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000249",
@@ -3586,10 +3042,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000025",
@@ -3599,10 +3053,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000250",
@@ -3612,10 +3064,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000251",
@@ -3625,10 +3075,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000252",
@@ -3638,10 +3086,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000253",
@@ -3651,10 +3097,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000254",
@@ -3664,10 +3108,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000255",
@@ -3677,10 +3119,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000256",
@@ -3690,10 +3130,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000257",
@@ -3703,10 +3141,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000258",
@@ -3716,10 +3152,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000259",
@@ -3729,10 +3163,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000026",
@@ -3742,10 +3174,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000260",
@@ -3755,10 +3185,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000261",
@@ -3768,10 +3196,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000262",
@@ -3781,10 +3207,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000263",
@@ -3794,10 +3218,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000264",
@@ -3807,10 +3229,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000265",
@@ -3820,10 +3240,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000266",
@@ -3833,10 +3251,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000267",
@@ -3846,10 +3262,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000268",
@@ -3859,10 +3273,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000269",
@@ -3872,10 +3284,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000027",
@@ -3885,10 +3295,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000270",
@@ -3898,10 +3306,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000271",
@@ -3911,10 +3317,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000272",
@@ -3924,10 +3328,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000273",
@@ -3937,10 +3339,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000274",
@@ -3950,10 +3350,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000275",
@@ -3963,10 +3361,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000276",
@@ -3976,10 +3372,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000277",
@@ -3989,10 +3383,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000278",
@@ -4002,10 +3394,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000279",
@@ -4015,10 +3405,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000028",
@@ -4028,10 +3416,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000280",
@@ -4041,10 +3427,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000281",
@@ -4054,10 +3438,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0000282",
@@ -4067,10 +3449,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000029",
@@ -4080,10 +3460,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000030",
@@ -4093,10 +3471,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000031",
@@ -4106,10 +3482,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000032",
@@ -4119,10 +3493,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000033",
@@ -4132,10 +3504,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000034",
@@ -4145,10 +3515,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000035",
@@ -4158,10 +3526,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000036",
@@ -4171,10 +3537,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000037",
@@ -4184,10 +3548,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000038",
@@ -4197,10 +3559,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000039",
@@ -4210,10 +3570,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000040",
@@ -4223,10 +3581,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000041",
@@ -4236,10 +3592,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000042",
@@ -4249,10 +3603,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000043",
@@ -4262,10 +3614,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000044",
@@ -4275,10 +3625,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000045",
@@ -4288,10 +3636,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000046",
@@ -4301,10 +3647,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000047",
@@ -4314,10 +3658,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000048",
@@ -4327,10 +3669,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000049",
@@ -4340,10 +3680,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000050",
@@ -4353,10 +3691,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000051",
@@ -4366,10 +3702,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000052",
@@ -4379,10 +3713,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000053",
@@ -4392,10 +3724,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000054",
@@ -4405,10 +3735,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000055",
@@ -4418,10 +3746,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000056",
@@ -4431,10 +3757,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000057",
@@ -4444,10 +3768,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000058",
@@ -4457,10 +3779,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000059",
@@ -4470,10 +3790,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000060",
@@ -4483,10 +3801,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000061",
@@ -4496,10 +3812,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000062",
@@ -4509,10 +3823,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000063",
@@ -4522,10 +3834,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000064",
@@ -4535,10 +3845,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000065",
@@ -4548,10 +3856,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000066",
@@ -4561,10 +3867,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000067",
@@ -4574,10 +3878,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000068",
@@ -4587,10 +3889,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000069",
@@ -4600,10 +3900,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000070",
@@ -4613,10 +3911,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000071",
@@ -4626,10 +3922,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000072",
@@ -4639,10 +3933,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000073",
@@ -4652,10 +3944,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000074",
@@ -4665,10 +3955,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000075",
@@ -4678,10 +3966,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000076",
@@ -4691,10 +3977,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000077",
@@ -4704,10 +3988,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000078",
@@ -4717,10 +3999,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000079",
@@ -4730,10 +4010,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000080",
@@ -4743,10 +4021,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000081",
@@ -4756,10 +4032,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000082",
@@ -4769,10 +4043,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000083",
@@ -4782,10 +4054,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000084",
@@ -4795,10 +4065,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000085",
@@ -4808,10 +4076,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000086",
@@ -4821,10 +4087,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000087",
@@ -4834,10 +4098,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000088",
@@ -4847,10 +4109,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000089",
@@ -4860,10 +4120,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000090",
@@ -4873,10 +4131,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000091",
@@ -4886,10 +4142,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000092",
@@ -4899,10 +4153,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000093",
@@ -4912,10 +4164,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000094",
@@ -4925,10 +4175,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000095",
@@ -4938,10 +4186,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000096",
@@ -4951,10 +4197,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000097",
@@ -4964,10 +4208,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000098",
@@ -4977,10 +4219,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000099",
@@ -4990,10 +4230,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000100",
@@ -5003,10 +4241,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001000",
@@ -5016,10 +4252,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001001",
@@ -5029,10 +4263,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001002",
@@ -5042,10 +4274,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001003",
@@ -5055,10 +4285,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001004",
@@ -5068,10 +4296,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001006",
@@ -5081,10 +4307,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001007",
@@ -5094,10 +4318,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001008",
@@ -5107,10 +4329,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001009",
@@ -5120,10 +4340,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000101",
@@ -5133,10 +4351,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001010",
@@ -5146,10 +4362,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001012",
@@ -5159,10 +4373,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001013",
@@ -5172,10 +4384,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001014",
@@ -5185,10 +4395,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001016",
@@ -5198,10 +4406,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001017",
@@ -5211,10 +4417,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001018",
@@ -5224,10 +4428,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001019",
@@ -5237,10 +4439,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000102",
@@ -5250,10 +4450,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001020",
@@ -5263,10 +4461,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/0001021",
@@ -5276,10 +4472,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000103",
@@ -5289,10 +4483,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000104",
@@ -5302,10 +4494,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000105",
@@ -5315,10 +4505,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000106",
@@ -5328,10 +4516,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000107",
@@ -5341,10 +4527,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000108",
@@ -5354,10 +4538,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000109",
@@ -5367,10 +4549,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000110",
@@ -5380,10 +4560,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000111",
@@ -5393,10 +4571,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000112",
@@ -5406,10 +4582,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000113",
@@ -5419,10 +4593,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000114",
@@ -5432,10 +4604,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000115",
@@ -5445,10 +4615,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000116",
@@ -5458,10 +4626,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000117",
@@ -5471,10 +4637,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000118",
@@ -5484,10 +4648,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000119",
@@ -5497,10 +4659,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000120",
@@ -5510,10 +4670,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000121",
@@ -5523,10 +4681,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000122",
@@ -5536,10 +4692,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000123",
@@ -5549,10 +4703,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000124",
@@ -5562,10 +4714,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000125",
@@ -5575,10 +4725,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000126",
@@ -5588,10 +4736,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000127",
@@ -5601,10 +4747,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000128",
@@ -5614,10 +4758,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000129",
@@ -5627,10 +4769,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000130",
@@ -5640,10 +4780,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000131",
@@ -5653,10 +4791,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000132",
@@ -5666,10 +4802,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000133",
@@ -5679,10 +4813,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000134",
@@ -5692,10 +4824,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000135",
@@ -5705,10 +4835,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000136",
@@ -5718,10 +4846,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000137",
@@ -5731,10 +4857,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000138",
@@ -5744,10 +4868,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000139",
@@ -5757,10 +4879,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000140",
@@ -5770,10 +4890,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000141",
@@ -5783,10 +4901,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000142",
@@ -5796,10 +4912,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000143",
@@ -5809,10 +4923,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000144",
@@ -5822,10 +4934,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000145",
@@ -5835,10 +4945,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000146",
@@ -5848,10 +4956,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000147",
@@ -5861,10 +4967,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000148",
@@ -5874,10 +4978,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000149",
@@ -5887,10 +4989,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000150",
@@ -5900,10 +5000,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000151",
@@ -5913,10 +5011,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000152",
@@ -5926,10 +5022,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000153",
@@ -5939,10 +5033,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000154",
@@ -5952,10 +5044,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000155",
@@ -5965,10 +5055,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000156",
@@ -5978,10 +5066,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000157",
@@ -5991,10 +5077,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000158",
@@ -6004,10 +5088,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000159",
@@ -6017,10 +5099,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000160",
@@ -6030,10 +5110,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000161",
@@ -6043,10 +5121,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000162",
@@ -6056,10 +5132,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000163",
@@ -6069,10 +5143,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000164",
@@ -6082,10 +5154,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000165",
@@ -6095,10 +5165,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000166",
@@ -6108,10 +5176,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000167",
@@ -6121,10 +5187,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000168",
@@ -6134,10 +5198,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000169",
@@ -6147,10 +5209,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000170",
@@ -6160,10 +5220,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000171",
@@ -6173,10 +5231,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000172",
@@ -6186,10 +5242,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000173",
@@ -6199,10 +5253,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000174",
@@ -6212,10 +5264,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000175",
@@ -6225,10 +5275,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000176",
@@ -6238,10 +5286,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000177",
@@ -6251,10 +5297,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000178",
@@ -6264,10 +5308,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000179",
@@ -6277,10 +5319,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000180",
@@ -6290,10 +5330,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000181",
@@ -6303,10 +5341,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000182",
@@ -6316,10 +5352,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000183",
@@ -6329,10 +5363,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000184",
@@ -6342,10 +5374,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000185",
@@ -6355,10 +5385,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000186",
@@ -6368,10 +5396,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000187",
@@ -6381,10 +5407,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000188",
@@ -6394,10 +5418,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000189",
@@ -6407,10 +5429,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000190",
@@ -6420,10 +5440,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000191",
@@ -6433,10 +5451,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000192",
@@ -6446,10 +5462,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000193",
@@ -6459,10 +5473,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000194",
@@ -6472,10 +5484,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000195",
@@ -6485,10 +5495,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000196",
@@ -6498,10 +5506,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000197",
@@ -6511,10 +5517,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000198",
@@ -6524,10 +5528,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000199",
@@ -6537,10 +5539,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000200",
@@ -6550,10 +5550,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000201",
@@ -6563,10 +5561,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000202",
@@ -6576,10 +5572,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000203",
@@ -6589,10 +5583,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000204",
@@ -6602,10 +5594,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000205",
@@ -6615,10 +5605,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000206",
@@ -6628,10 +5616,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000207",
@@ -6641,10 +5627,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000208",
@@ -6654,10 +5638,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000209",
@@ -6667,10 +5649,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000210",
@@ -6680,10 +5660,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000211",
@@ -6693,10 +5671,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000212",
@@ -6706,10 +5682,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000213",
@@ -6719,10 +5693,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000214",
@@ -6732,10 +5704,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000215",
@@ -6745,10 +5715,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000216",
@@ -6758,10 +5726,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000217",
@@ -6771,10 +5737,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000218",
@@ -6784,10 +5748,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000219",
@@ -6797,10 +5759,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000220",
@@ -6810,10 +5770,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000221",
@@ -6823,10 +5781,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000222",
@@ -6836,10 +5792,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000223",
@@ -6849,10 +5803,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000224",
@@ -6862,10 +5814,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000225",
@@ -6875,10 +5825,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000226",
@@ -6888,10 +5836,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000227",
@@ -6901,10 +5847,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000228",
@@ -6914,10 +5858,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000229",
@@ -6927,10 +5869,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000230",
@@ -6940,10 +5880,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000231",
@@ -6953,10 +5891,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000232",
@@ -6966,10 +5902,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000233",
@@ -6979,10 +5913,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000234",
@@ -6992,10 +5924,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000235",
@@ -7005,10 +5935,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000236",
@@ -7018,10 +5946,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000237",
@@ -7031,10 +5957,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000238",
@@ -7044,10 +5968,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000239",
@@ -7057,10 +5979,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000240",
@@ -7070,10 +5990,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000241",
@@ -7083,10 +6001,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000242",
@@ -7096,10 +6012,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000243",
@@ -7109,10 +6023,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000244",
@@ -7122,10 +6034,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000245",
@@ -7135,10 +6045,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000246",
@@ -7148,10 +6056,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000247",
@@ -7161,10 +6067,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000248",
@@ -7174,10 +6078,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000249",
@@ -7187,10 +6089,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000250",
@@ -7200,10 +6100,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000251",
@@ -7213,10 +6111,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000252",
@@ -7226,10 +6122,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000253",
@@ -7239,10 +6133,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000254",
@@ -7252,10 +6144,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000255",
@@ -7265,10 +6155,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000256",
@@ -7278,10 +6166,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000257",
@@ -7291,10 +6177,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000258",
@@ -7304,10 +6188,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000259",
@@ -7317,10 +6199,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000260",
@@ -7330,10 +6210,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000261",
@@ -7343,10 +6221,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000262",
@@ -7356,10 +6232,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000263",
@@ -7369,10 +6243,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000264",
@@ -7382,10 +6254,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000265",
@@ -7395,10 +6265,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000266",
@@ -7408,10 +6276,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000267",
@@ -7421,10 +6287,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000268",
@@ -7434,10 +6298,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000269",
@@ -7447,10 +6309,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000270",
@@ -7460,10 +6320,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000271",
@@ -7473,10 +6331,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000272",
@@ -7486,10 +6342,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000273",
@@ -7499,10 +6353,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/000274",
@@ -7512,10 +6364,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000001",
@@ -7525,10 +6375,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000002",
@@ -7538,10 +6386,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000003",
@@ -7551,10 +6397,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000004",
@@ -7564,10 +6408,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000005",
@@ -7577,10 +6419,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000006",
@@ -7590,10 +6430,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000007",
@@ -7603,10 +6441,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000008",
@@ -7616,10 +6452,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000009",
@@ -7629,10 +6463,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000010",
@@ -7642,10 +6474,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000011",
@@ -7655,10 +6485,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000012",
@@ -7668,10 +6496,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000013",
@@ -7681,10 +6507,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000014",
@@ -7694,10 +6518,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000015",
@@ -7707,10 +6529,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000016",
@@ -7720,10 +6540,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000017",
@@ -7733,10 +6551,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000018",
@@ -7746,10 +6562,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000019",
@@ -7759,10 +6573,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000020",
@@ -7772,10 +6584,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000021",
@@ -7785,10 +6595,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000022",
@@ -7798,10 +6606,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000023",
@@ -7811,10 +6617,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000024",
@@ -7824,10 +6628,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000025",
@@ -7837,10 +6639,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000026",
@@ -7850,10 +6650,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000027",
@@ -7863,10 +6661,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000028",
@@ -7876,10 +6672,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000029",
@@ -7889,10 +6683,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000030",
@@ -7902,10 +6694,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000031",
@@ -7915,10 +6705,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000032",
@@ -7928,10 +6716,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000033",
@@ -7941,10 +6727,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000034",
@@ -7954,10 +6738,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000035",
@@ -7967,10 +6749,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000036",
@@ -7980,10 +6760,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000037",
@@ -7993,10 +6771,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000038",
@@ -8006,10 +6782,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000039",
@@ -8019,10 +6793,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000040",
@@ -8032,10 +6804,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000041",
@@ -8045,10 +6815,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000042",
@@ -8058,10 +6826,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000043",
@@ -8071,10 +6837,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000044",
@@ -8084,10 +6848,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000045",
@@ -8097,10 +6859,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000046",
@@ -8110,10 +6870,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000047",
@@ -8123,10 +6881,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000048",
@@ -8136,10 +6892,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000049",
@@ -8149,10 +6903,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000050",
@@ -8162,10 +6914,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000051",
@@ -8175,10 +6925,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000052",
@@ -8188,10 +6936,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000053",
@@ -8201,10 +6947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000054",
@@ -8214,10 +6958,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000055",
@@ -8227,10 +6969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000056",
@@ -8240,10 +6980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000057",
@@ -8253,10 +6991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000058",
@@ -8266,10 +7002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000059",
@@ -8326,10 +7060,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000062",
@@ -8339,10 +7071,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000063",
@@ -8352,10 +7082,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000064",
@@ -8365,10 +7093,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000065",
@@ -8378,10 +7104,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000066",
@@ -8391,10 +7115,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000067",
@@ -8404,10 +7126,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000068",
@@ -8417,10 +7137,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000069",
@@ -8430,10 +7148,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000070",
@@ -8443,10 +7159,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000071",
@@ -8456,10 +7170,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000072",
@@ -8469,10 +7181,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000073",
@@ -8482,10 +7192,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000074",
@@ -8495,10 +7203,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000075",
@@ -8508,10 +7214,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000076",
@@ -8521,10 +7225,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000077",
@@ -8534,10 +7236,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000078",
@@ -8547,10 +7247,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000079",
@@ -8560,10 +7258,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000080",
@@ -8573,10 +7269,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000081",
@@ -8586,10 +7280,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000082",
@@ -8599,10 +7291,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000083",
@@ -8612,10 +7302,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000084",
@@ -8625,10 +7313,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000085",
@@ -8638,10 +7324,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000086",
@@ -8651,10 +7335,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000087",
@@ -8664,10 +7346,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000088",
@@ -8677,10 +7357,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000089",
@@ -8690,10 +7368,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000090",
@@ -8703,10 +7379,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000091",
@@ -8716,10 +7390,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000092",
@@ -8729,10 +7401,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000093",
@@ -8742,10 +7412,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000094",
@@ -8755,10 +7423,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000095",
@@ -8768,10 +7434,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000096",
@@ -8781,10 +7445,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000097",
@@ -8794,10 +7456,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000098",
@@ -8807,10 +7467,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000099",
@@ -8820,10 +7478,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000100",
@@ -8833,10 +7489,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000101",
@@ -8846,10 +7500,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000102",
@@ -8859,10 +7511,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000103",
@@ -8872,10 +7522,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000104",
@@ -8885,10 +7533,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000105",
@@ -8898,10 +7544,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000106",
@@ -8911,10 +7555,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000107",
@@ -8924,10 +7566,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000108",
@@ -8937,10 +7577,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000109",
@@ -8950,10 +7588,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000110",
@@ -8963,10 +7599,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000111",
@@ -8976,10 +7610,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000112",
@@ -8989,10 +7621,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000113",
@@ -9002,10 +7632,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000114",
@@ -9015,10 +7643,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000115",
@@ -9028,10 +7654,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000116",
@@ -9041,10 +7665,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000117",
@@ -9054,10 +7676,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000118",
@@ -9067,10 +7687,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000119",
@@ -9080,10 +7698,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000120",
@@ -9093,10 +7709,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000121",
@@ -9106,10 +7720,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000122",
@@ -9119,10 +7731,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000123",
@@ -9132,10 +7742,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000124",
@@ -9145,10 +7753,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000125",
@@ -9158,10 +7764,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000126",
@@ -9171,10 +7775,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000127",
@@ -9213,10 +7815,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000129",
@@ -9226,10 +7826,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000130",
@@ -9239,10 +7837,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000131",
@@ -9252,10 +7848,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000132",
@@ -9265,10 +7859,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000133",
@@ -9278,10 +7870,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000134",
@@ -9291,10 +7881,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000135",
@@ -9304,10 +7892,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000136",
@@ -9317,10 +7903,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000137",
@@ -9330,10 +7914,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000138",
@@ -9343,10 +7925,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000139",
@@ -9356,10 +7936,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000140",
@@ -9369,10 +7947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000141",
@@ -9382,10 +7958,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000142",
@@ -9395,10 +7969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000143",
@@ -9408,10 +7980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000144",
@@ -9421,10 +7991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000145",
@@ -9434,10 +8002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000146",
@@ -9447,10 +8013,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000147",
@@ -9460,10 +8024,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000148",
@@ -9473,10 +8035,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000149",
@@ -9486,10 +8046,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000150",
@@ -9499,10 +8057,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000151",
@@ -9512,10 +8068,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000152",
@@ -9525,10 +8079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000153",
@@ -9538,10 +8090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000154",
@@ -9551,10 +8101,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000155",
@@ -9564,10 +8112,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000156",
@@ -9577,10 +8123,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000157",
@@ -9590,10 +8134,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000158",
@@ -9603,10 +8145,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000159",
@@ -9616,10 +8156,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000160",
@@ -9629,10 +8167,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000161",
@@ -9642,10 +8178,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000162",
@@ -9655,10 +8189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000163",
@@ -9668,10 +8200,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000164",
@@ -9681,10 +8211,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000165",
@@ -9694,10 +8222,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000166",
@@ -9707,10 +8233,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000167",
@@ -9720,10 +8244,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000168",
@@ -9733,10 +8255,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000169",
@@ -9746,10 +8266,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000170",
@@ -9759,10 +8277,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000171",
@@ -9772,10 +8288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000172",
@@ -9785,10 +8299,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000173",
@@ -9798,10 +8310,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000174",
@@ -9811,10 +8321,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000175",
@@ -9824,10 +8332,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000176",
@@ -9837,10 +8343,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000177",
@@ -9850,10 +8354,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000178",
@@ -9863,10 +8365,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000179",
@@ -9876,10 +8376,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000180",
@@ -9889,10 +8387,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000181",
@@ -9902,10 +8398,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000182",
@@ -9915,10 +8409,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000183",
@@ -9928,10 +8420,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000184",
@@ -9941,10 +8431,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000185",
@@ -9954,10 +8442,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000186",
@@ -9986,10 +8472,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000188",
@@ -10008,10 +8492,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000190",
@@ -10021,10 +8503,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000191",
@@ -10034,10 +8514,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000192",
@@ -10047,10 +8525,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000193",
@@ -10060,10 +8536,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000194",
@@ -10073,10 +8547,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000195",
@@ -10086,10 +8558,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000196",
@@ -10099,10 +8569,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000197",
@@ -10112,10 +8580,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000198",
@@ -10125,10 +8591,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000199",
@@ -10138,10 +8602,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000200",
@@ -10151,10 +8613,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000201",
@@ -10164,10 +8624,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000202",
@@ -10177,10 +8635,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000203",
@@ -10190,10 +8646,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000204",
@@ -10203,10 +8657,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000205",
@@ -10216,10 +8668,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000206",
@@ -10229,10 +8679,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000207",
@@ -10242,10 +8690,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000208",
@@ -10255,10 +8701,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000209",
@@ -10268,10 +8712,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000210",
@@ -10281,10 +8723,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000211",
@@ -10294,10 +8734,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000212",
@@ -10307,10 +8745,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000213",
@@ -10320,10 +8756,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000214",
@@ -10333,10 +8767,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000215",
@@ -10346,10 +8778,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000216",
@@ -10359,10 +8789,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000217",
@@ -10372,10 +8800,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000218",
@@ -10385,10 +8811,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000219",
@@ -10398,10 +8822,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000220",
@@ -10411,10 +8833,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000221",
@@ -10424,10 +8844,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000222",
@@ -10437,10 +8855,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000223",
@@ -10450,10 +8866,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000224",
@@ -10463,10 +8877,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000225",
@@ -10476,10 +8888,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000226",
@@ -10489,10 +8899,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000227",
@@ -10502,10 +8910,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000228",
@@ -10515,10 +8921,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000229",
@@ -10528,10 +8932,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000230",
@@ -10541,10 +8943,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000231",
@@ -10554,10 +8954,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000232",
@@ -10571,10 +8969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000234",
@@ -10584,10 +8980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000235",
@@ -10597,10 +8991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000236",
@@ -10610,10 +9002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000237",
@@ -10623,10 +9013,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000238",
@@ -10636,10 +9024,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000239",
@@ -10649,10 +9035,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000240",
@@ -10662,10 +9046,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000241",
@@ -10675,10 +9057,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000242",
@@ -10688,10 +9068,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000243",
@@ -10701,10 +9079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000244",
@@ -10714,10 +9090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000245",
@@ -10727,10 +9101,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000246",
@@ -10740,10 +9112,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000247",
@@ -10753,10 +9123,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000248",
@@ -10766,10 +9134,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000249",
@@ -10779,10 +9145,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000250",
@@ -10792,10 +9156,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000251",
@@ -10805,10 +9167,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000252",
@@ -10818,10 +9178,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000253",
@@ -10831,10 +9189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000254",
@@ -10844,10 +9200,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000255",
@@ -10857,10 +9211,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000256",
@@ -10870,10 +9222,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000257",
@@ -10883,10 +9233,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000258",
@@ -10896,10 +9244,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000259",
@@ -10909,10 +9255,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000260",
@@ -10922,10 +9266,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000261",
@@ -10935,10 +9277,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000262",
@@ -10948,10 +9288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000263",
@@ -10961,10 +9299,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000264",
@@ -10974,10 +9310,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000265",
@@ -10987,10 +9321,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000266",
@@ -11000,10 +9332,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000267",
@@ -11013,10 +9343,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000268",
@@ -11026,10 +9354,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000269",
@@ -11039,10 +9365,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000270",
@@ -11052,10 +9376,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000271",
@@ -11065,10 +9387,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000272",
@@ -11078,10 +9398,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000273",
@@ -11091,10 +9409,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000274",
@@ -11104,10 +9420,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000275",
@@ -11117,10 +9431,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000276",
@@ -11130,10 +9442,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000277",
@@ -11143,10 +9453,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000278",
@@ -11156,10 +9464,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000279",
@@ -11169,10 +9475,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000280",
@@ -11182,10 +9486,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000281",
@@ -11195,10 +9497,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000282",
@@ -11208,10 +9508,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000283",
@@ -11221,10 +9519,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000284",
@@ -11234,10 +9530,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000285",
@@ -11247,10 +9541,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000286",
@@ -11260,10 +9552,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000287",
@@ -11273,10 +9563,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000288",
@@ -11286,10 +9574,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000289",
@@ -11299,10 +9585,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000290",
@@ -11312,10 +9596,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000291",
@@ -11325,10 +9607,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000292",
@@ -11338,10 +9618,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000293",
@@ -11351,10 +9629,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000294",
@@ -11364,10 +9640,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000295",
@@ -11377,10 +9651,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000296",
@@ -11390,10 +9662,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000297",
@@ -11403,10 +9673,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000298",
@@ -11416,10 +9684,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000299",
@@ -11429,10 +9695,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000300",
@@ -11442,10 +9706,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000301",
@@ -11455,10 +9717,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000302",
@@ -11468,10 +9728,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000303",
@@ -11504,10 +9762,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000306",
@@ -11521,10 +9777,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000308",
@@ -11534,10 +9788,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000309",
@@ -11547,10 +9799,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000310",
@@ -11560,10 +9810,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000311",
@@ -11573,10 +9821,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000312",
@@ -11586,10 +9832,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000313",
@@ -11599,10 +9843,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000314",
@@ -11612,10 +9854,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000315",
@@ -11625,10 +9865,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000316",
@@ -11638,10 +9876,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000317",
@@ -11651,10 +9887,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000318",
@@ -11664,10 +9898,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000319",
@@ -11677,10 +9909,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000320",
@@ -11690,10 +9920,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000321",
@@ -11703,10 +9931,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000322",
@@ -11716,10 +9942,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000323",
@@ -11729,10 +9953,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000324",
@@ -11742,10 +9964,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000325",
@@ -11755,10 +9975,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000326",
@@ -11768,10 +9986,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000327",
@@ -11781,10 +9997,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/OMO_0001000"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000328",
@@ -11794,10 +10008,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000329",
@@ -11807,10 +10019,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000330",
@@ -11820,10 +10030,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000331",
@@ -11885,10 +10093,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000337",
@@ -11898,10 +10104,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000338",
@@ -11911,10 +10115,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000339",
@@ -11924,10 +10126,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000340",
@@ -11937,10 +10137,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000341",
@@ -11950,10 +10148,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000342",
@@ -11963,10 +10159,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000343",
@@ -11976,10 +10170,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000344",
@@ -11989,10 +10181,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000345",
@@ -12002,10 +10192,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000346",
@@ -12015,10 +10203,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000347",
@@ -12028,10 +10214,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000348",
@@ -12041,10 +10225,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000349",
@@ -12054,10 +10236,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000350",
@@ -12067,10 +10247,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000351",
@@ -12080,10 +10258,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000352",
@@ -12093,10 +10269,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000353",
@@ -12106,10 +10280,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000354",
@@ -12119,10 +10291,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000355",
@@ -12132,10 +10302,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000356",
@@ -12145,10 +10313,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000357",
@@ -12158,10 +10324,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000358",
@@ -12171,10 +10335,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000359",
@@ -12184,10 +10346,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000360",
@@ -12197,10 +10357,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000361",
@@ -12210,10 +10368,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000362",
@@ -12223,10 +10379,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000363",
@@ -12236,10 +10390,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000364",
@@ -12249,10 +10401,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000365",
@@ -12262,10 +10412,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000366",
@@ -12275,10 +10423,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000367",
@@ -12288,10 +10434,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000368",
@@ -12301,10 +10445,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000369",
@@ -12314,10 +10456,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000370",
@@ -12327,10 +10467,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000371",
@@ -12340,10 +10478,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000372",
@@ -12353,10 +10489,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000373",
@@ -12366,10 +10500,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000374",
@@ -12379,10 +10511,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000375",
@@ -12392,10 +10522,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000376",
@@ -12405,10 +10533,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000377",
@@ -12418,10 +10544,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000378",
@@ -12431,10 +10555,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000379",
@@ -12444,10 +10566,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000380",
@@ -12457,10 +10577,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000381",
@@ -12470,10 +10588,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000382",
@@ -12483,10 +10599,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000383",
@@ -12496,10 +10610,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000384",
@@ -12509,10 +10621,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000385",
@@ -12522,10 +10632,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000386",
@@ -12535,10 +10643,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000387",
@@ -12548,10 +10654,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000388",
@@ -12561,10 +10665,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000389",
@@ -12574,10 +10676,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000390",
@@ -12587,10 +10687,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000391",
@@ -12600,10 +10698,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000392",
@@ -12613,10 +10709,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000393",
@@ -12626,10 +10720,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000394",
@@ -12639,10 +10731,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000395",
@@ -12652,10 +10742,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000396",
@@ -12665,10 +10753,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000397",
@@ -12678,10 +10764,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000398",
@@ -12691,10 +10775,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000399",
@@ -12704,10 +10786,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000400",
@@ -12717,10 +10797,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000401",
@@ -12730,10 +10808,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000402",
@@ -12743,10 +10819,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000403",
@@ -12756,10 +10830,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000404",
@@ -12769,10 +10841,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000405",
@@ -12782,10 +10852,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000406",
@@ -12795,10 +10863,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000407",
@@ -12808,10 +10874,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000408",
@@ -12821,10 +10885,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000409",
@@ -12834,10 +10896,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000410",
@@ -12847,10 +10907,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000411",
@@ -12860,10 +10918,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000412",
@@ -12873,10 +10929,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000413",
@@ -12886,10 +10940,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000414",
@@ -12899,10 +10951,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000415",
@@ -12912,10 +10962,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000416",
@@ -12925,10 +10973,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000417",
@@ -12938,10 +10984,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000418",
@@ -12951,10 +10995,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000419",
@@ -12964,10 +11006,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000420",
@@ -12977,10 +11017,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000421",
@@ -12990,10 +11028,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000422",
@@ -13003,10 +11039,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000423",
@@ -13016,10 +11050,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000424",
@@ -13029,10 +11061,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000425",
@@ -13042,10 +11072,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000426",
@@ -13055,10 +11083,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000427",
@@ -13068,10 +11094,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000428",
@@ -13081,10 +11105,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000429",
@@ -13180,10 +11202,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000434",
@@ -13193,10 +11213,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000435",
@@ -13206,10 +11224,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000436",
@@ -13219,10 +11235,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000437",
@@ -13232,10 +11246,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000438",
@@ -13245,10 +11257,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000439",
@@ -13258,10 +11268,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000440",
@@ -13271,10 +11279,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000441",
@@ -14620,10 +12626,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000489",
@@ -14633,10 +12637,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000490",
@@ -14646,10 +12648,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000491",
@@ -14659,10 +12659,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000492",
@@ -14672,10 +12670,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000493",
@@ -14685,10 +12681,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000494",
@@ -14698,10 +12692,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000495",
@@ -14711,10 +12703,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000496",
@@ -14724,10 +12714,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000497",
@@ -14737,10 +12725,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000498",
@@ -14750,10 +12736,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000499",
@@ -14763,10 +12747,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000500",
@@ -14776,10 +12758,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000501",
@@ -14789,10 +12769,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000502",
@@ -14802,10 +12780,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000503",
@@ -14815,10 +12791,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000504",
@@ -14828,10 +12802,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000505",
@@ -14841,10 +12813,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000506",
@@ -14854,10 +12824,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000507",
@@ -14867,10 +12835,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000508",
@@ -14880,10 +12846,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000509",
@@ -14893,10 +12857,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000510",
@@ -14906,10 +12868,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000511",
@@ -14919,10 +12879,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000512",
@@ -14932,10 +12890,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000513",
@@ -14945,10 +12901,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000514",
@@ -14958,10 +12912,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000515",
@@ -14971,10 +12923,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000516",
@@ -14984,10 +12934,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000517",
@@ -14997,10 +12945,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000518",
@@ -15010,10 +12956,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000519",
@@ -15023,10 +12967,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000520",
@@ -15036,10 +12978,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000521",
@@ -15049,10 +12989,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000522",
@@ -15062,10 +13000,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000523",
@@ -15075,10 +13011,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000524",
@@ -15088,10 +13022,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000525",
@@ -15147,10 +13079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000529",
@@ -15160,10 +13090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000531",
@@ -16707,10 +14635,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000644",
@@ -16772,10 +14698,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000646",
@@ -17002,10 +14926,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000654",
@@ -17327,10 +15249,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000662",
@@ -17340,10 +15260,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000663",
@@ -19007,10 +16925,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000808",
@@ -19020,10 +16936,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000809",
@@ -19033,10 +16947,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000810",
@@ -19046,10 +16958,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000811",
@@ -19059,10 +16969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000812",
@@ -19072,10 +16980,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000813",
@@ -19085,10 +16991,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000814",
@@ -19098,10 +17002,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000815",
@@ -19111,10 +17013,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000816",
@@ -19124,10 +17024,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000817",
@@ -19137,10 +17035,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000818",
@@ -19150,10 +17046,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000819",
@@ -19163,10 +17057,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000820",
@@ -19176,10 +17068,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000821",
@@ -19189,10 +17079,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000822",
@@ -19202,10 +17090,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000823",
@@ -19215,10 +17101,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000824",
@@ -19228,10 +17112,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000825",
@@ -19241,10 +17123,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000826",
@@ -19254,10 +17134,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000827",
@@ -19267,10 +17145,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000828",
@@ -19280,10 +17156,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000829",
@@ -19293,10 +17167,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000830",
@@ -19306,10 +17178,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000831",
@@ -19319,10 +17189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000832",
@@ -19332,10 +17200,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000833",
@@ -19345,10 +17211,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000834",
@@ -19358,10 +17222,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000835",
@@ -19371,10 +17233,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000836",
@@ -19384,10 +17244,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000837",
@@ -19397,10 +17255,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000838",
@@ -19410,10 +17266,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000839",
@@ -19423,10 +17277,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000840",
@@ -19436,10 +17288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000841",
@@ -19449,10 +17299,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000842",
@@ -19462,10 +17310,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000843",
@@ -19475,10 +17321,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000844",
@@ -19574,10 +17418,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000848",
@@ -19587,10 +17429,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000849",
@@ -19600,10 +17440,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000850",
@@ -19613,10 +17451,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000851",
@@ -19626,10 +17462,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000852",
@@ -19639,10 +17473,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000853",
@@ -19652,10 +17484,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000854",
@@ -19665,10 +17495,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000855",
@@ -19678,10 +17506,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000856",
@@ -19691,10 +17517,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000857",
@@ -19704,10 +17528,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000858",
@@ -19717,10 +17539,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000859",
@@ -19730,10 +17550,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000860",
@@ -19743,10 +17561,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000861",
@@ -19756,10 +17572,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000862",
@@ -19769,10 +17583,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000863",
@@ -19782,10 +17594,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000864",
@@ -19795,10 +17605,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000865",
@@ -19808,10 +17616,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000866",
@@ -19821,10 +17627,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000867",
@@ -19834,10 +17638,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000868",
@@ -19847,10 +17649,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000869",
@@ -19860,10 +17660,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1000870",
@@ -20275,10 +18073,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001001",
@@ -20288,10 +18084,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001002",
@@ -20301,10 +18095,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001003",
@@ -20314,10 +18106,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001004",
@@ -20327,10 +18117,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001005",
@@ -20340,10 +18128,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001006",
@@ -20353,10 +18139,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001007",
@@ -20366,10 +18150,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001008",
@@ -20379,10 +18161,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001009",
@@ -20392,10 +18172,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001010",
@@ -20405,10 +18183,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001011",
@@ -20418,10 +18194,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001012",
@@ -20431,10 +18205,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001013",
@@ -20444,10 +18216,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001014",
@@ -20457,10 +18227,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001015",
@@ -20470,10 +18238,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001016",
@@ -20483,10 +18249,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001017",
@@ -20496,10 +18260,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001018",
@@ -20509,10 +18271,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001019",
@@ -20522,10 +18282,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001020",
@@ -20535,10 +18293,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001021",
@@ -20548,10 +18304,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001022",
@@ -20561,10 +18315,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001023",
@@ -20574,10 +18326,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1001101",
@@ -20727,10 +18477,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002001",
@@ -20740,10 +18488,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002002",
@@ -20753,10 +18499,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002003",
@@ -20826,10 +18570,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002008",
@@ -20839,10 +18581,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002009",
@@ -20852,10 +18592,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002010",
@@ -20865,10 +18603,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002011",
@@ -20878,10 +18614,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002012",
@@ -20891,10 +18625,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002013",
@@ -20904,10 +18636,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002014",
@@ -20917,10 +18647,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002015",
@@ -20930,10 +18658,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002016",
@@ -20943,10 +18669,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002017",
@@ -20956,10 +18680,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002018",
@@ -20969,10 +18691,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002019",
@@ -20982,10 +18702,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002020",
@@ -20995,10 +18713,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002021",
@@ -21008,10 +18724,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002022",
@@ -21021,10 +18735,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002023",
@@ -21034,10 +18746,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002024",
@@ -21047,10 +18757,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002025",
@@ -21060,10 +18768,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002026",
@@ -21073,10 +18779,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002027",
@@ -21086,10 +18790,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002028",
@@ -21099,10 +18801,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002029",
@@ -21112,10 +18812,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002030",
@@ -21125,10 +18823,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002031",
@@ -21138,10 +18834,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002032",
@@ -21151,10 +18845,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002033",
@@ -21164,10 +18856,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002034",
@@ -21177,10 +18867,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002035",
@@ -21190,10 +18878,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002036",
@@ -21203,10 +18889,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002037",
@@ -21216,10 +18900,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002038",
@@ -21229,10 +18911,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002039",
@@ -21242,10 +18922,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1002040",
@@ -21255,10 +18933,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/1003000",
@@ -23097,10 +20773,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000000",
@@ -23111,10 +20785,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000001",
@@ -23998,10 +21670,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000053",
@@ -24012,10 +21682,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000054",
@@ -24026,10 +21694,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000055",
@@ -24040,10 +21706,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000056",
@@ -24054,10 +21718,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000057",
@@ -24068,10 +21730,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000064",
@@ -24166,10 +21826,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000202",
@@ -24197,10 +21855,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000204",
@@ -24211,10 +21867,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000205",
@@ -24225,10 +21879,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000206",
@@ -24239,10 +21891,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000207",
@@ -24283,10 +21933,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000214",
@@ -24297,10 +21945,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000215",
@@ -24311,10 +21957,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000216",
@@ -24325,10 +21969,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000217",
@@ -24339,10 +21981,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000218",
@@ -24353,10 +21993,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000219",
@@ -24367,10 +22005,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000220",
@@ -24398,10 +22034,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000222",
@@ -24429,10 +22063,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000224",
@@ -24443,10 +22075,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000225",
@@ -24457,10 +22087,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000226",
@@ -24471,10 +22099,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000227",
@@ -24515,10 +22141,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000234",
@@ -24529,10 +22153,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000235",
@@ -24543,10 +22165,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000236",
@@ -24557,10 +22177,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000237",
@@ -24571,10 +22189,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000238",
@@ -24585,10 +22201,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000239",
@@ -24599,10 +22213,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000301",
@@ -24664,10 +22276,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000502",
@@ -24678,10 +22288,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000503",
@@ -24692,10 +22300,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000504",
@@ -24706,10 +22312,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000505",
@@ -24720,10 +22324,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000506",
@@ -24734,10 +22336,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000507",
@@ -24748,10 +22348,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000508",
@@ -24762,10 +22360,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000509",
@@ -24776,10 +22372,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000510",
@@ -24790,10 +22384,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000511",
@@ -24804,10 +22396,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000512",
@@ -24818,10 +22408,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000513",
@@ -24832,10 +22420,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000514",
@@ -24846,10 +22432,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000515",
@@ -24860,10 +22444,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000516",
@@ -24874,10 +22456,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000517",
@@ -25010,10 +22590,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000059",
@@ -25024,10 +22602,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000060",
@@ -25038,10 +22614,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000061",
@@ -25052,10 +22626,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000062",
@@ -25066,10 +22638,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000063",
@@ -25080,10 +22650,8 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
           "val" : "http://purl.obolibrary.org/obo/IAO_0000226"
-        }, {
-          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
-          "val" : "true"
-        } ]
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "https://w3id.org/metpo/2000071",

--- a/metpo.owl
+++ b/metpo.owl
@@ -181,7 +181,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000000">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has susceptibility profile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1015,7 +1015,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000052">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1025,7 +1025,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000053">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1035,7 +1035,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000054">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1045,7 +1045,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000055">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1055,7 +1055,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000056">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has temperature delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1065,7 +1065,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000057">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has culture temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1168,7 +1168,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000201">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lyses</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1194,7 +1194,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000203">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete fixes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1204,7 +1204,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000204">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete catabolizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1214,7 +1214,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000205">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete mineralizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1224,7 +1224,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000206">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete conjugates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1296,7 +1296,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000213">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete binds</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1306,7 +1306,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000214">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chelates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1316,7 +1316,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000215">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete precipitates</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1326,7 +1326,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000216">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete solubilizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1336,7 +1336,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000217">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete volatilizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1346,7 +1346,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000218">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete crystallizes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1356,7 +1356,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000219">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete adsorbs</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1382,7 +1382,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000221">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not lyse</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1408,7 +1408,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000223">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not fix</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1418,7 +1418,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000224">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not catabolize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1428,7 +1428,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000225">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not mineralize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1438,7 +1438,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000226">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not conjugate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1510,7 +1510,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000233">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not bind</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1520,7 +1520,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000234">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not chelate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1530,7 +1530,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000235">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not precipitate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1540,7 +1540,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000236">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not solubilize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1550,7 +1550,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000237">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not volatilize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1560,7 +1560,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000238">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete does not crystallize</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1570,7 +1570,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000239">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1633,7 +1633,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000501">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1643,7 +1643,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000502">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1653,7 +1653,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000503">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1663,7 +1663,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000504">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has pH delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1673,7 +1673,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000505">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has culture pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1683,7 +1683,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000506">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1693,7 +1693,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000507">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1703,7 +1703,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000508">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1713,7 +1713,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000509">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1723,7 +1723,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000510">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has NaCl delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1733,7 +1733,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000511">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1743,7 +1743,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000512">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1753,7 +1753,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000513">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has optimum oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1763,7 +1763,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000514">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has growth oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1773,7 +1773,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000515">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has range oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1783,7 +1783,7 @@
     <owl:ObjectProperty rdf:about="https://w3id.org/metpo/2000516">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has oxygen delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -1922,7 +1922,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000058">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has observed spot value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1932,7 +1932,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000059">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has minimum observed value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1942,7 +1942,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000060">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has maximum observed value</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1952,7 +1952,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000061">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete has value comments</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1962,7 +1962,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000062">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete is negative data</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -1972,7 +1972,7 @@
     <owl:DatatypeProperty rdf:about="https://w3id.org/metpo/2000063">
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete observation data property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
@@ -2478,7 +2478,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2489,7 +2489,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2500,7 +2500,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2511,7 +2511,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2522,7 +2522,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2533,7 +2533,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2544,7 +2544,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2555,7 +2555,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2566,7 +2566,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2577,7 +2577,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2588,7 +2588,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2599,7 +2599,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2610,7 +2610,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2621,7 +2621,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2632,7 +2632,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2643,7 +2643,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2654,7 +2654,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2665,7 +2665,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2676,7 +2676,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2687,7 +2687,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2698,7 +2698,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2709,7 +2709,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2720,7 +2720,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete METPO Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2731,7 +2731,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2742,7 +2742,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2753,7 +2753,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mesophilie</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2764,7 +2764,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2775,7 +2775,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2786,7 +2786,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2797,7 +2797,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2808,7 +2808,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2819,7 +2819,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2830,7 +2830,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2841,7 +2841,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2852,7 +2852,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2863,7 +2863,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2874,7 +2874,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2885,7 +2885,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2896,7 +2896,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2907,7 +2907,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2918,7 +2918,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2929,7 +2929,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2940,7 +2940,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2951,7 +2951,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2962,7 +2962,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acid Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2973,7 +2973,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2984,7 +2984,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2995,7 +2995,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3006,7 +3006,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3017,7 +3017,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3028,7 +3028,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3039,7 +3039,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3050,7 +3050,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3061,7 +3061,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3072,7 +3072,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3083,7 +3083,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3094,7 +3094,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3105,7 +3105,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3116,7 +3116,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3127,7 +3127,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3138,7 +3138,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3149,7 +3149,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3160,7 +3160,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3171,7 +3171,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3182,7 +3182,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3193,7 +3193,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3204,7 +3204,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3215,7 +3215,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3226,7 +3226,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3237,7 +3237,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3248,7 +3248,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3259,7 +3259,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3270,7 +3270,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3281,7 +3281,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3292,7 +3292,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3303,7 +3303,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3314,7 +3314,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3325,7 +3325,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3336,7 +3336,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3347,7 +3347,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3358,7 +3358,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3369,7 +3369,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3380,7 +3380,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3391,7 +3391,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3402,7 +3402,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3413,7 +3413,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3424,7 +3424,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3435,7 +3435,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3446,7 +3446,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3457,7 +3457,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3468,7 +3468,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3479,7 +3479,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3490,7 +3490,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3501,7 +3501,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3512,7 +3512,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3523,7 +3523,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3534,7 +3534,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3545,7 +3545,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3556,7 +3556,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3567,7 +3567,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3578,7 +3578,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3589,7 +3589,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3600,7 +3600,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3611,7 +3611,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3622,7 +3622,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3633,7 +3633,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3644,7 +3644,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Endospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3655,7 +3655,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Exospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3666,7 +3666,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3677,7 +3677,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3688,7 +3688,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Arthrospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3699,7 +3699,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3710,7 +3710,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporangiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3721,7 +3721,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3732,7 +3732,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Akinetes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3743,7 +3743,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3754,7 +3754,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3765,7 +3765,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3776,7 +3776,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3787,7 +3787,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3798,7 +3798,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3809,7 +3809,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3820,7 +3820,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3831,7 +3831,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ascospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3842,7 +3842,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Basidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3853,7 +3853,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3864,7 +3864,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3875,7 +3875,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3886,7 +3886,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zoospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3897,7 +3897,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3908,7 +3908,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3919,7 +3919,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3930,7 +3930,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3941,7 +3941,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3952,7 +3952,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3963,7 +3963,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3974,7 +3974,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3985,7 +3985,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -3996,7 +3996,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4007,7 +4007,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4018,7 +4018,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4029,7 +4029,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4040,7 +4040,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4051,7 +4051,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4062,7 +4062,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4073,7 +4073,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4084,7 +4084,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4095,7 +4095,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4106,7 +4106,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4117,7 +4117,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4128,7 +4128,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4139,7 +4139,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4150,7 +4150,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4161,7 +4161,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4172,7 +4172,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4183,7 +4183,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4194,7 +4194,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4205,7 +4205,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4216,7 +4216,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4227,7 +4227,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4238,7 +4238,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4249,7 +4249,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4260,7 +4260,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4271,7 +4271,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4282,7 +4282,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4293,7 +4293,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4304,7 +4304,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4315,7 +4315,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4326,7 +4326,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4337,7 +4337,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4348,7 +4348,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4359,7 +4359,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4370,7 +4370,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4381,7 +4381,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4392,7 +4392,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4403,7 +4403,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4414,7 +4414,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4425,7 +4425,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4436,7 +4436,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4447,7 +4447,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4458,7 +4458,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4469,7 +4469,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4480,7 +4480,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4491,7 +4491,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum mid4</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4502,7 +4502,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4513,7 +4513,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4524,7 +4524,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4535,7 +4535,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4546,7 +4546,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4557,7 +4557,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4568,7 +4568,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4579,7 +4579,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range mid4</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4590,7 +4590,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4601,7 +4601,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4612,7 +4612,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4623,7 +4623,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4634,7 +4634,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4645,7 +4645,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4656,7 +4656,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4667,7 +4667,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4678,7 +4678,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4689,7 +4689,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4700,7 +4700,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4711,7 +4711,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4722,7 +4722,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4733,7 +4733,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4744,7 +4744,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4755,7 +4755,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4766,7 +4766,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Optimum high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4777,7 +4777,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4788,7 +4788,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4799,7 +4799,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4810,7 +4810,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Range high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4821,7 +4821,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4832,7 +4832,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4843,7 +4843,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4854,7 +4854,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4865,7 +4865,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta mid3</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4876,7 +4876,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4887,7 +4887,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4898,7 +4898,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4909,7 +4909,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4920,7 +4920,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4931,7 +4931,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete NaCl Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4942,7 +4942,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4953,7 +4953,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4964,7 +4964,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta mid1</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4975,7 +4975,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta mid2</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4986,7 +4986,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Delta high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4997,7 +4997,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5008,7 +5008,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5019,7 +5019,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Branced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5030,7 +5030,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5041,7 +5041,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5052,7 +5052,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5063,7 +5063,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5074,7 +5074,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Curved Spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5085,7 +5085,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5096,7 +5096,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Disc</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5107,7 +5107,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dumbbell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5118,7 +5118,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Other</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5129,7 +5129,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5140,7 +5140,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5151,7 +5151,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flask</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5162,7 +5162,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5173,7 +5173,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5184,7 +5184,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5195,7 +5195,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5206,7 +5206,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5217,7 +5217,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5228,7 +5228,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5239,7 +5239,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5250,7 +5250,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5261,7 +5261,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5272,7 +5272,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5283,7 +5283,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5294,7 +5294,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5305,7 +5305,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5316,7 +5316,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Square</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5327,7 +5327,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Star</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5338,7 +5338,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Star - Dumbbell - Pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5349,7 +5349,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5360,7 +5360,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5371,7 +5371,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Triangular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5382,7 +5382,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5393,7 +5393,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5404,7 +5404,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Condition</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5415,7 +5415,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physiological Trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5426,7 +5426,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Metabolic Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5437,7 +5437,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5448,7 +5448,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5459,7 +5459,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5470,7 +5470,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5481,7 +5481,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mesophilie</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5492,7 +5492,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Structural Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5503,7 +5503,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5514,7 +5514,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5525,7 +5525,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5536,7 +5536,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5547,7 +5547,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5558,7 +5558,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5569,7 +5569,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Electron Donor Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5580,7 +5580,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5591,7 +5591,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5602,7 +5602,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5613,7 +5613,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5624,7 +5624,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5635,7 +5635,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Reproductive Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5646,7 +5646,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dormancy Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5657,7 +5657,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5668,7 +5668,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5679,7 +5679,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Genomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5690,7 +5690,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Dimension</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5701,7 +5701,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5712,7 +5712,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5723,7 +5723,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5734,7 +5734,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5745,7 +5745,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5756,7 +5756,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5767,7 +5767,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Colony Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5778,7 +5778,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physical Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5789,7 +5789,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Context</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5800,7 +5800,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Biological Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5811,7 +5811,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Functional Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5822,7 +5822,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Classification Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5833,7 +5833,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete METPO Biological Process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5844,7 +5844,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5855,7 +5855,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Measurable Property</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5866,7 +5866,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-stain negative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5877,7 +5877,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-stain positive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5888,7 +5888,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5899,7 +5899,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5910,7 +5910,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5921,7 +5921,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5932,7 +5932,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5943,7 +5943,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5954,7 +5954,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5965,7 +5965,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5976,7 +5976,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5987,7 +5987,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -5998,7 +5998,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6009,7 +6009,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6020,7 +6020,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6031,7 +6031,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acid Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6042,7 +6042,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Alkali Tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6053,7 +6053,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme Alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6064,7 +6064,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6075,7 +6075,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6086,7 +6086,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6097,7 +6097,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6108,7 +6108,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6119,7 +6119,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6130,7 +6130,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6141,7 +6141,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6152,7 +6152,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6163,7 +6163,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6174,7 +6174,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6185,7 +6185,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6196,7 +6196,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6207,7 +6207,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6218,7 +6218,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6229,7 +6229,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6240,7 +6240,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6251,7 +6251,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6262,7 +6262,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6273,7 +6273,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6284,7 +6284,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6295,7 +6295,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6306,7 +6306,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6317,7 +6317,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6328,7 +6328,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6339,7 +6339,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6350,7 +6350,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6361,7 +6361,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6372,7 +6372,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6383,7 +6383,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6394,7 +6394,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6405,7 +6405,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6416,7 +6416,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6427,7 +6427,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6438,7 +6438,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6449,7 +6449,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6460,7 +6460,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6471,7 +6471,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6482,7 +6482,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6493,7 +6493,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6504,7 +6504,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6515,7 +6515,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6526,7 +6526,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6537,7 +6537,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6548,7 +6548,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6559,7 +6559,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6570,7 +6570,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6581,7 +6581,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6592,7 +6592,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6603,7 +6603,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6614,7 +6614,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6625,7 +6625,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6636,7 +6636,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6647,7 +6647,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6658,7 +6658,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Endospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6669,7 +6669,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Exospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6680,7 +6680,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6691,7 +6691,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6702,7 +6702,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;organismal quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6713,7 +6713,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;physicial object quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6724,7 +6724,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;quality&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6735,7 +6735,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6746,7 +6746,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete 1-D extent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6757,7 +6757,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6768,7 +6768,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6779,7 +6779,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6790,7 +6790,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete &apos;prokaryotic metabolically differentiated cell&apos;</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6801,7 +6801,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterotrophy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6812,7 +6812,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6823,7 +6823,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spore type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6834,7 +6834,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6845,7 +6845,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward NaCl</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6856,7 +6856,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward pH</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6867,7 +6867,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6878,7 +6878,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Arthrospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6889,7 +6889,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic constraints</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6900,7 +6900,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell by chemical produced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6911,7 +6911,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6922,7 +6922,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporangiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6933,7 +6933,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6944,7 +6944,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Akinetes</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6955,7 +6955,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6966,7 +6966,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6977,7 +6977,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6988,7 +6988,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6999,7 +6999,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7010,7 +7010,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7021,7 +7021,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7032,7 +7032,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Ascospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7043,7 +7043,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Basidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7054,7 +7054,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7065,7 +7065,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7076,7 +7076,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7087,7 +7087,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Zoospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7098,7 +7098,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7109,7 +7109,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7120,7 +7120,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7131,7 +7131,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7142,7 +7142,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7153,7 +7153,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7164,7 +7164,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7175,7 +7175,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7186,7 +7186,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7197,7 +7197,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7208,7 +7208,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7219,7 +7219,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7230,7 +7230,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7241,7 +7241,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7252,7 +7252,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7263,7 +7263,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7274,7 +7274,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7285,7 +7285,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7296,7 +7296,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7307,7 +7307,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7318,7 +7318,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7329,7 +7329,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7340,7 +7340,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7351,7 +7351,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7362,7 +7362,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7373,7 +7373,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7384,7 +7384,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7395,7 +7395,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7406,7 +7406,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7417,7 +7417,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7428,7 +7428,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7439,7 +7439,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7450,7 +7450,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% low ( &lt; 42.65)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7461,7 +7461,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% mid1 (42.65 - 57)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7472,7 +7472,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% mid2 (57 - 66.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7483,7 +7483,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GC% high ( &gt; 66.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7494,7 +7494,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM very low (&lt; 0.5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7505,7 +7505,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM low (0.5 - 0.65)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7516,7 +7516,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM mid (0.65 - 0.9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7527,7 +7527,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell width uM high (&gt; 0.9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7538,7 +7538,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM very low (&lt;= 1.3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7549,7 +7549,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM low (1.3 - 2)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7560,7 +7560,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM mid (2 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7571,7 +7571,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell length uM high (&gt; 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7582,7 +7582,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C very low (&lt;= 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7593,7 +7593,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C low (10 - 22)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7604,7 +7604,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid1 (22 - 27)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7615,7 +7615,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid2 (27 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7626,7 +7626,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid3 (30 - 34)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7637,7 +7637,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C mid4 (34 - 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7648,7 +7648,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Optimum C high (&gt; 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7659,7 +7659,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C very low (&lt;= 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7670,7 +7670,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C low (10 - 22)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7681,7 +7681,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid1 (22 - 27)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7692,7 +7692,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid2 (27 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7703,7 +7703,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid3 (30 - 34)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7714,7 +7714,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C mid4 (34 - 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7725,7 +7725,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Range C high (&gt; 40)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7736,7 +7736,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum low (0 - 6)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7747,7 +7747,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid1 (6 - 7)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7758,7 +7758,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum mid2 (7 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7769,7 +7769,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Optimum high (8 - 14)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7780,7 +7780,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range very low (0 - 4)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7791,7 +7791,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range low (4 - 6)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7802,7 +7802,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid1 (6 - 7)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7813,7 +7813,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid2 (7 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7824,7 +7824,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range mid3 (8 - 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7835,7 +7835,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Range high (10 - 14)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7846,7 +7846,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7857,7 +7857,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum mid1 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7868,7 +7868,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7879,7 +7879,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Optimum high (&gt; 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7890,7 +7890,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7901,7 +7901,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range mid1 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7912,7 +7912,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7923,7 +7923,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl Range high (&gt; 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7934,7 +7934,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta very low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7945,7 +7945,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta low (1 - 2)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7956,7 +7956,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid1 (2 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7967,7 +7967,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid2 (3 - 4)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7978,7 +7978,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta mid3 (4 - 5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7989,7 +7989,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH delta high (5 - 9)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8000,7 +8000,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta low (&lt;= 1)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8011,7 +8011,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta mid2 (1 - 3)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8022,7 +8022,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta mid2 (3 - 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8033,7 +8033,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete % NaCl delta high (&gt;= 8)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8044,7 +8044,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta very low (1 - 5)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8055,7 +8055,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta low (5 - 10)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8066,7 +8066,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta mid1 (10 - 20)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8077,7 +8077,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta mid2 (20 - 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8088,7 +8088,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature C delta high (&gt;= 30)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8099,7 +8099,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8110,7 +8110,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete branced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8121,7 +8121,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8132,7 +8132,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8143,7 +8143,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8154,7 +8154,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8165,7 +8165,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete curved spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8176,7 +8176,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8187,7 +8187,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete disc</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8198,7 +8198,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dumbbell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8209,7 +8209,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8220,7 +8220,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8231,7 +8231,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flask</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8242,7 +8242,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8253,7 +8253,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8264,7 +8264,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8275,7 +8275,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8286,7 +8286,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8297,7 +8297,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8308,7 +8308,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8319,7 +8319,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8330,7 +8330,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8341,7 +8341,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8352,7 +8352,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8363,7 +8363,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8374,7 +8374,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8385,7 +8385,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete square</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8396,7 +8396,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8407,7 +8407,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8418,7 +8418,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8429,7 +8429,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete triangular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8440,7 +8440,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8451,7 +8451,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Environmental Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8462,7 +8462,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Condition</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8473,7 +8473,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Physiological Trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8484,7 +8484,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Metabolic Classification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8495,7 +8495,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cellular Characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8506,7 +8506,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Taxonomic Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8517,7 +8517,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Microbial Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8528,7 +8528,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8539,7 +8539,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Structural Feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8550,7 +8550,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Temperature Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8561,7 +8561,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Salinity Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8572,7 +8572,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH Adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8583,7 +8583,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Oxygen Requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8594,7 +8594,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Carbon Source Utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8605,7 +8605,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Energy Acquisition Mode</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8616,7 +8616,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Electron Donor Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8627,7 +8627,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8638,7 +8638,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Motility Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8649,7 +8649,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Bacterial Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8660,7 +8660,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Fungal Spore Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8671,7 +8671,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Reproductive Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8682,7 +8682,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Dormancy Structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8693,7 +8693,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Adaptation Type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8704,7 +8704,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Pressure Tolerance Range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8715,7 +8715,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete GenomicFeature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8726,7 +8726,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Dimension</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8737,7 +8737,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Optimal Growth Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8748,7 +8748,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Range Parameter</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8759,7 +8759,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Growth Tolerance Metric</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8770,7 +8770,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8781,7 +8781,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Cell Arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8792,7 +8792,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Colony Morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8803,7 +8803,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete acid-fast</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8814,7 +8814,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8825,7 +8825,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete active transport</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8836,7 +8836,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8847,7 +8847,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adaptive trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8858,7 +8858,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adhesin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8869,7 +8869,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete adhesion structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8880,7 +8880,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8891,7 +8891,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerobic respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8902,7 +8902,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8913,7 +8913,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete aggregate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8924,7 +8924,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete akinete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8935,7 +8935,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8946,7 +8946,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ammonification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8957,7 +8957,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete amylolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8968,7 +8968,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8979,7 +8979,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anaerobic respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8990,7 +8990,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete anoxygenic photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9001,7 +9001,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antibiotic production</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9012,7 +9012,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antibiotic resistance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9023,7 +9023,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete antimicrobial resistance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9034,7 +9034,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete appendage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9045,7 +9045,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete arthrospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9056,7 +9056,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ascospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9067,7 +9067,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete autotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9078,7 +9078,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete autotrophic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9089,7 +9089,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete auxotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9100,7 +9100,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete axial filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9111,7 +9111,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9122,7 +9122,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9133,7 +9133,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete barotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9144,7 +9144,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete basidiospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9155,7 +9155,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete binary fission</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9166,7 +9166,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9177,7 +9177,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9188,7 +9188,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biofilm formation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9199,7 +9199,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete biogeochemical cycling</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9210,7 +9210,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete bioluminescence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9221,7 +9221,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete budding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9232,7 +9232,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete buoyancy structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9243,7 +9243,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete capnophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9254,7 +9254,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete capsule</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9265,7 +9265,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carbon fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9276,7 +9276,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carbon source</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9287,7 +9287,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete carboxydotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9298,7 +9298,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell arrangement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9309,7 +9309,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell envelope</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9320,7 +9320,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell length category</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9331,7 +9331,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9342,7 +9342,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9353,7 +9353,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell wall characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9364,7 +9364,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell wall component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9375,7 +9375,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cell width category</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9386,7 +9386,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9397,7 +9397,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9408,7 +9408,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9419,7 +9419,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellular product</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9430,7 +9430,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cellulolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9478,7 +9478,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9489,7 +9489,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chemotaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9500,7 +9500,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete chlamydospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9511,7 +9511,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete class</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9522,7 +9522,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete clinically relevant feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9533,7 +9533,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete coccus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9544,7 +9544,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cold shock protein</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9555,7 +9555,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cold shock response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9566,7 +9566,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colonization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9577,7 +9577,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony elevation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9588,7 +9588,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony margin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9599,7 +9599,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony morphology</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9610,7 +9610,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete colony texture</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9621,7 +9621,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete commensalism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9632,7 +9632,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete community behavior</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9643,7 +9643,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete community structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9654,7 +9654,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete compatible solute</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9665,7 +9665,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete competence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9676,7 +9676,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete component</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9687,7 +9687,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete conidium</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9698,7 +9698,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete conjugation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9709,7 +9709,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete CRISPR</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9720,7 +9720,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete culturability</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9731,7 +9731,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete cyst</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9742,7 +9742,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete death phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9753,7 +9753,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete denitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9764,7 +9764,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete developmental process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9775,7 +9775,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diagnostic enzyme</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9786,7 +9786,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diagnostic feature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9797,7 +9797,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete diazotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9808,7 +9808,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete differentiation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9819,7 +9819,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dimorphism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9830,7 +9830,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete disc-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9841,7 +9841,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete domain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9852,7 +9852,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dormancy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9863,7 +9863,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dormancy structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9874,7 +9874,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete dumbbell-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9885,7 +9885,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological niche</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9896,7 +9896,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9907,7 +9907,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ecological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9918,7 +9918,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ectosymbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9929,7 +9929,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete electron acceptor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9940,7 +9940,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete electron donor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9951,7 +9951,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete endospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9962,7 +9962,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete endosymbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9973,7 +9973,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete energy metabolism process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9984,7 +9984,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete enzyme activity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -9995,7 +9995,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete epigenetic modification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10006,7 +10006,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete evolutionary process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10017,7 +10017,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete exospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10028,7 +10028,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete exponential phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10039,7 +10039,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extracellular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10050,7 +10050,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extracellular polysaccharide</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10061,7 +10061,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extreme halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10072,7 +10072,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete extremophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10083,7 +10083,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete facultative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10094,7 +10094,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete facultative anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10105,7 +10105,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete family</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10116,7 +10116,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fastidious</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10127,7 +10127,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fermentation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10138,7 +10138,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete filamentous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10149,7 +10149,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fimbriae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10160,7 +10160,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flagellum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10171,7 +10171,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete flask-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10182,7 +10182,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete fungal spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10193,7 +10193,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete gas vesicle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10228,7 +10228,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete high GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10239,7 +10239,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete low GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10250,7 +10250,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lower-mid GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10261,7 +10261,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete upper-mid GC content</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10272,7 +10272,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete generation time</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10283,7 +10283,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10294,7 +10294,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic exchange</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10305,7 +10305,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genetic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10316,7 +10316,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genome size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10327,7 +10327,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10338,7 +10338,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic island</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10349,7 +10349,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genomic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10360,7 +10360,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete genus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10371,7 +10371,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete gliding motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10382,7 +10382,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete global regulator</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10393,7 +10393,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-negative</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10404,7 +10404,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram-positive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10415,7 +10415,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete Gram stain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10426,7 +10426,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10437,7 +10437,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth conditions constraints</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10448,7 +10448,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth pattern</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10459,7 +10459,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete growth rate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10470,7 +10470,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete habitat</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10481,7 +10481,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10492,7 +10492,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete halotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10503,7 +10503,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heat shock protein</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10514,7 +10514,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heat shock response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10525,7 +10525,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hemolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10536,7 +10536,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterocyst</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10547,7 +10547,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete heterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10558,7 +10558,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete holdfast</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10569,7 +10569,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete horizontal gene transfer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10580,7 +10580,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hydrolase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10591,7 +10591,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10602,7 +10602,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete inclusion body</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10613,7 +10613,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete infection</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10624,7 +10624,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10635,7 +10635,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with a phage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10646,7 +10646,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with an environment</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10657,7 +10657,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction with host</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10668,7 +10668,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete interaction within a community</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10679,7 +10679,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete intracellular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10690,7 +10690,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete invasion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10701,7 +10701,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete laboratory characteristic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10712,7 +10712,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lag phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10723,7 +10723,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete life cycle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10734,7 +10734,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete life cycle phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10745,7 +10745,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lipolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10756,7 +10756,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lipopolysaccharide</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10767,7 +10767,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete localization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10778,7 +10778,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete lysogeny</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10789,7 +10789,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete macroscopic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10800,7 +10800,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete magnetotaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10811,7 +10811,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mesophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10822,7 +10822,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic partner</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10833,7 +10833,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete metabolic trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10844,7 +10844,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10855,7 +10855,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete methylation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10882,7 +10882,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10902,7 +10902,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10913,7 +10913,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10924,7 +10924,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mobile genetic element</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10935,7 +10935,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete moderate halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10946,7 +10946,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete morphological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10957,7 +10957,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete motility process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10968,7 +10968,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete motility structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10979,7 +10979,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mutualism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10990,7 +10990,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mycolic acid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11001,7 +11001,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete mycorrhization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11012,7 +11012,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete neutrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11023,7 +11023,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11034,7 +11034,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nitrogen fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11045,7 +11045,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nodulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11056,7 +11056,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nucleoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11067,7 +11067,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete nutrient utilization</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11078,7 +11078,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11089,7 +11089,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11100,7 +11100,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11111,7 +11111,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11122,7 +11122,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete order</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11133,7 +11133,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by growth conditions</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11144,7 +11144,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by nutritional requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11155,7 +11155,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by product produced</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11166,7 +11166,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11177,7 +11177,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to ph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11188,7 +11188,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11199,7 +11199,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to salt concentration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11210,7 +11210,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by relation to temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11221,7 +11221,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by shape</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11232,7 +11232,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete microbe characterized by trophic type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11243,7 +11243,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete osmophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11254,7 +11254,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete osmoregulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11265,7 +11265,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxidative stress response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11276,7 +11276,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxidoreductase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11287,7 +11287,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxygen requirement</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11298,7 +11298,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete oxygenic photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11309,7 +11309,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pan-genome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11320,7 +11320,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete parasitism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11331,7 +11331,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete passive transport</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11342,7 +11342,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pathogenicity</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11353,7 +11353,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pathogenicity island</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11364,7 +11364,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete peptidoglycan</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11385,7 +11385,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH optimum (growth range)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11396,7 +11396,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11407,7 +11407,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH range (growth tolerance)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11418,7 +11418,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pH tolerance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11429,7 +11429,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phage defense</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11440,7 +11440,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11451,7 +11451,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11462,7 +11462,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete photosynthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11473,7 +11473,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phototaxis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11484,7 +11484,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete phylum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11495,7 +11495,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11506,7 +11506,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological state</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11517,7 +11517,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete physiological trait</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11528,7 +11528,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11539,7 +11539,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pigment</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11550,7 +11550,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pigmentation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11561,7 +11561,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pilus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11572,7 +11572,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete plant growth promotion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11583,7 +11583,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete plasmid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11594,7 +11594,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete pleomorphism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11605,7 +11605,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11616,7 +11616,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prophage</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11627,7 +11627,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prostheca</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11638,7 +11638,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete protein synthesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11649,7 +11649,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete proteolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11660,7 +11660,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete prototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11671,7 +11671,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11682,7 +11682,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete qualifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11693,7 +11693,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete quorum sensing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11704,7 +11704,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete regulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11715,7 +11715,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete regulatory mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11726,7 +11726,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete reproductive process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11737,7 +11737,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete reproductive structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11748,7 +11748,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete resistance mechanism</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11759,7 +11759,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11770,7 +11770,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete restriction-modification system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11781,7 +11781,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete ribosome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11792,7 +11792,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete S-layer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11803,7 +11803,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete salinity delta</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11814,7 +11814,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete salinity preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11825,7 +11825,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secondary metabolite</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11836,7 +11836,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secretion</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11847,7 +11847,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete secretion system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11858,7 +11858,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sheathed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11869,7 +11869,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete siderophore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11880,7 +11880,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sigma factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11891,7 +11891,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete signaling</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11902,7 +11902,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete slime layer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11913,7 +11913,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete specialized cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11924,7 +11924,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete species</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11935,7 +11935,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirillum</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11946,7 +11946,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete spirochete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11957,7 +11957,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sporangiospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11968,7 +11968,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sporulation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11979,7 +11979,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete square cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11990,7 +11990,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stalk</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12001,7 +12001,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete star-shaped cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12012,7 +12012,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stationary phase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12023,7 +12023,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete storage structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12034,7 +12034,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete strain</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12045,7 +12045,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete stress response</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12056,7 +12056,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete structure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12067,7 +12067,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete sulfate reducer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12078,7 +12078,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete swarming</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12089,7 +12089,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete symbiosis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12100,7 +12100,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete symbiotic process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12111,7 +12111,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete syntrophy</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12122,7 +12122,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete taxonomic identifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12133,7 +12133,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete taxonomic rank</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12144,7 +12144,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete teichoic acid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12183,7 +12183,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete temperature preference</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12204,7 +12204,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete thermal tolerance</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12215,7 +12215,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12226,7 +12226,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete toxin</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12237,7 +12237,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transcription factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12248,7 +12248,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12259,7 +12259,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transferase</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12270,7 +12270,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transformation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12281,7 +12281,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transport system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12292,7 +12292,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete transposon</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12303,7 +12303,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete triangular cell</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12314,7 +12314,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete trichome</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12325,7 +12325,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete twitching motility</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12336,7 +12336,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete two-component system</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12347,7 +12347,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete viable but non-culturable</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12358,7 +12358,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete vibrio</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12369,7 +12369,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12380,7 +12380,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence factor</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12391,7 +12391,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete virulence process</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12402,7 +12402,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete xylanolysis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12413,7 +12413,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete zoospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12424,7 +12424,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/OMO_0001000"/>
         <rdfs:label>obsolete zygospore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12435,7 +12435,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12446,7 +12446,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature optimum (metabolic activity)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12457,7 +12457,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature range (metabolic viability)</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12529,7 +12529,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete psychrotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12540,7 +12540,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete thermotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12551,7 +12551,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12562,7 +12562,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme hyperthermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12573,7 +12573,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete non-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12584,7 +12584,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete slight halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12595,7 +12595,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete haloalkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12606,7 +12606,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12617,7 +12617,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete acid tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12628,7 +12628,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete alkali tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12639,7 +12639,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12650,7 +12650,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12661,7 +12661,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligative acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12672,7 +12672,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12683,7 +12683,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete microaerophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12694,7 +12694,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete microaerotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12705,7 +12705,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aerotolerant anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12716,7 +12716,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate aerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12727,7 +12727,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate anaerobe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12738,7 +12738,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12749,7 +12749,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete anoxygenic phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12760,7 +12760,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12771,7 +12771,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12782,7 +12782,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12793,7 +12793,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete organotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12804,7 +12804,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete phototroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12815,7 +12815,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12826,7 +12826,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12837,7 +12837,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete copiotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12848,7 +12848,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12859,7 +12859,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete mixotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12870,7 +12870,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lithoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12881,7 +12881,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemoorganoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12892,7 +12892,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chemolithoautotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12903,7 +12903,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methylotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12914,7 +12914,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methanotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12925,7 +12925,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogenotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12936,7 +12936,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12947,7 +12947,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen producer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12958,7 +12958,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete nitrogen fixer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12969,7 +12969,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete methanogen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12980,7 +12980,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfur oxidizer</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12991,7 +12991,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete denitrifier</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13002,7 +13002,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13013,7 +13013,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete non-motile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13024,7 +13024,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete flagellated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13035,7 +13035,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete peritrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13046,7 +13046,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete lophotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13057,7 +13057,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete monotrichous</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13068,7 +13068,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ciliated</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13079,7 +13079,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete gliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13090,7 +13090,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete twitching</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13101,7 +13101,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sliding</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13112,7 +13112,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete myxospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13123,7 +13123,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete conidia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13134,7 +13134,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete chlamydospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13145,7 +13145,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sporocysts</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13156,7 +13156,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hypnospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13167,7 +13167,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete gemmae</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13178,7 +13178,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete azygospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13189,7 +13189,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aleuriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13200,7 +13200,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete stylospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13211,7 +13211,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sclerotia</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13222,7 +13222,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete teliospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13233,7 +13233,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete urediniospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13244,7 +13244,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pycnidiospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13255,7 +13255,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete acriospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13266,7 +13266,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete aplanospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13277,7 +13277,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete statismospores</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13288,7 +13288,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezotolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13299,7 +13299,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezosensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13310,7 +13310,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obligate barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13321,7 +13321,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative barophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13332,7 +13332,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hyperbarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13343,7 +13343,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hypobarophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13354,7 +13354,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete atmospheric pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13365,7 +13365,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete moderate piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13376,7 +13376,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete extreme piezophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13387,7 +13387,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete stenopiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13398,7 +13398,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete eurypiezic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13409,7 +13409,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-sensitive</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13420,7 +13420,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-resistant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13431,7 +13431,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure-adapted</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13442,7 +13442,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-acidophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13453,7 +13453,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-alkaliphile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13464,7 +13464,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-halophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13475,7 +13475,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13486,7 +13486,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-thermophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13497,7 +13497,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-lithoautotrophe</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13508,7 +13508,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-chemoheterotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13519,7 +13519,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-oligotroph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13530,7 +13530,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-endolithic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13541,7 +13541,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete piezo-tolerant</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13708,7 +13708,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13719,7 +13719,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13730,7 +13730,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13741,7 +13741,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell width high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13752,7 +13752,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length very low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13763,7 +13763,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length low</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13774,7 +13774,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length mid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13785,7 +13785,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete cell length high</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15772,7 +15772,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete branched</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15783,7 +15783,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete coccobacillus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15794,7 +15794,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete crescent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15805,7 +15805,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete curved</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15816,7 +15816,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete curved spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15827,7 +15827,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete diplococcus</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15838,7 +15838,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ellipsoidal</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15849,7 +15849,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete filament</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15860,7 +15860,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete fusiform</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15871,7 +15871,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete helical</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15882,7 +15882,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete irregular</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15893,7 +15893,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oval</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15904,7 +15904,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ovoid</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15915,7 +15915,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15926,7 +15926,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete ring</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15937,7 +15937,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete rod</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15948,7 +15948,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sphere</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15959,7 +15959,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete spindle</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15970,7 +15970,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete spiral</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15981,7 +15981,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete star - dumbbell - pleomorphic</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15992,7 +15992,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete tailed</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16003,7 +16003,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16014,7 +16014,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete salinity adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16025,7 +16025,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH adaptation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16036,7 +16036,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete bacterial spore</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16047,7 +16047,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure adaptation type</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16058,7 +16058,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pressure tolerance range</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16069,7 +16069,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity to oxygen</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16080,7 +16080,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16091,7 +16091,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete size</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16102,7 +16102,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete 1-D extent</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16113,7 +16113,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete width</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16124,7 +16124,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete length</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16135,7 +16135,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward pressure</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16146,7 +16146,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward nacl</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16157,7 +16157,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward ph</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16168,7 +16168,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sensitivity toward temperature</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16224,7 +16224,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete structured susceptibility detail</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16235,7 +16235,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete facultative psychrophile</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17513,7 +17513,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete denitrifying</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17568,7 +17568,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete hydrogen-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17749,7 +17749,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete nitrogen-fixing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -18005,7 +18005,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -18016,7 +18016,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete sulfur-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19377,7 +19377,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19388,7 +19388,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19399,7 +19399,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Denitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19410,7 +19410,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Dissimilatory nitrate reduction to ammonium</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19421,7 +19421,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19432,7 +19432,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic ammonium oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19443,7 +19443,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitric oxide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19454,7 +19454,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrous oxide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19465,7 +19465,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur and sulfoxide compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19476,7 +19476,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19487,7 +19487,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19498,7 +19498,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19509,7 +19509,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19520,7 +19520,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19531,7 +19531,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Dimethyl sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19542,7 +19542,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methionine sulfoxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19553,7 +19553,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19564,7 +19564,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19575,7 +19575,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19586,7 +19586,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Tetrathionate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19597,7 +19597,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Polysulfide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19608,7 +19608,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Metal and metalloid respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19619,7 +19619,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19630,7 +19630,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19641,7 +19641,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent Fe(II) oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19652,7 +19652,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19663,7 +19663,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19674,7 +19674,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Uranium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19685,7 +19685,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Vanadium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19696,7 +19696,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chromium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19707,7 +19707,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Technetium reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19718,7 +19718,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Cobalt reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19729,7 +19729,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19740,7 +19740,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19751,7 +19751,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19762,7 +19762,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenite reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19773,7 +19773,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon and organic compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19844,7 +19844,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Fumarate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19855,7 +19855,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Trimethylamine N-oxide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19866,7 +19866,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Humus respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19877,7 +19877,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Halogenated compound respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19888,7 +19888,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Organohalide respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19899,7 +19899,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete (Per)chlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19910,7 +19910,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Perchlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19921,7 +19921,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chlorate respiration</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19932,7 +19932,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Bromate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19943,7 +19943,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iodate reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19954,7 +19954,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19965,7 +19965,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19976,7 +19976,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogen oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19987,7 +19987,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19998,7 +19998,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrification</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20009,7 +20009,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Complete ammonia oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20020,7 +20020,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon monoxide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20031,7 +20031,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogenotrophic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20042,7 +20042,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Acetoclastic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20053,7 +20053,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methylotrophic methanogenesis</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20064,7 +20064,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20075,7 +20075,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Lanthanide reduction</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20086,7 +20086,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Lanthanide oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20584,7 +20584,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20595,7 +20595,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20606,7 +20606,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20617,7 +20617,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20628,7 +20628,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20639,7 +20639,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20650,7 +20650,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20661,7 +20661,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20672,7 +20672,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20683,7 +20683,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20694,7 +20694,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20705,7 +20705,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete culture pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20716,7 +20716,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20727,7 +20727,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20738,7 +20738,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20749,7 +20749,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20760,7 +20760,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete optimum oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20771,7 +20771,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete growth oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20782,7 +20782,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen range observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20793,7 +20793,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen delta observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20804,7 +20804,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete oxygen observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20815,7 +20815,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete temperature observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20826,7 +20826,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete NaCl observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20837,7 +20837,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete pH observation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20966,7 +20966,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20977,7 +20977,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Fe(III)-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20988,7 +20988,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Mn(IV)-dependent methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21050,7 +21050,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur disproportionation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21061,7 +21061,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen fixation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21072,7 +21072,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21083,7 +21083,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Anaerobic ammonium-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21094,7 +21094,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrous oxide-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21105,7 +21105,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21116,7 +21116,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21127,7 +21127,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21138,7 +21138,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21149,7 +21149,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-disproportionating</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21160,7 +21160,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfide-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21171,7 +21171,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Thiosulfate-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21182,7 +21182,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfite-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21193,7 +21193,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21204,7 +21204,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iron-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21215,7 +21215,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrate-dependent Fe(II)-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21226,7 +21226,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21237,7 +21237,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Manganese-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21248,7 +21248,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Uranium-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21259,7 +21259,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Arsenate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21270,7 +21270,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21281,7 +21281,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Selenite-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21292,7 +21292,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Perchlorate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21303,7 +21303,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Chlorate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21314,7 +21314,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Bromate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21325,7 +21325,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Iodate-reducing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21336,7 +21336,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Hydrogen-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21347,7 +21347,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Sulfur-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21358,7 +21358,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Ammonia oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21369,7 +21369,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrite oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21380,7 +21380,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Complete ammonia-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21391,7 +21391,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Methane oxidation</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21402,7 +21402,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Carbon monoxide-oxidizing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -21413,7 +21413,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete Nitrogen-fixing</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -22942,7 +22942,7 @@
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
         <rdfs:label>obsolete obsolete</rdfs:label>
-        <owl:deprecated>true</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
 </rdf:RDF>
 

--- a/src/ontology/components/metpo_sheet.owl
+++ b/src/ontology/components/metpo_sheet.owl
@@ -1662,7 +1662,7 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IAO_0000119> "def
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000000> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000000> "obsolete has susceptibility profile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000000> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000000> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000001> (organism interacts with chemical)
 
@@ -1976,37 +1976,37 @@ SubObjectPropertyOf(<https://w3id.org/metpo/2000051> <https://w3id.org/metpo/200
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000052> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000052> "obsolete has temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000052> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000052> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000053> (obsolete has optimum temperature observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000053> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000053> "obsolete has optimum temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000053> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000053> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000054> (obsolete has growth temperature observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000054> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000054> "obsolete has growth temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000054> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000054> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000055> (obsolete has range temperature observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000055> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000055> "obsolete has range temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000055> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000055> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000056> (obsolete has temperature delta observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000056> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000056> "obsolete has temperature delta observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000056> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000056> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000057> (obsolete has culture temperature observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000057> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000057> "obsolete has culture temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000057> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000057> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000064> (tolerates)
 
@@ -2067,7 +2067,7 @@ SubObjectPropertyOf(<https://w3id.org/metpo/2000200> <https://w3id.org/metpo/200
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000201> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000201> "obsolete lyses")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000201> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000201> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000202> (produces)
 
@@ -2079,25 +2079,25 @@ SubObjectPropertyOf(<https://w3id.org/metpo/2000202> <https://w3id.org/metpo/200
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000203> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000203> "obsolete fixes")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000203> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000203> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000204> (obsolete catabolizes)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000204> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000204> "obsolete catabolizes")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000204> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000204> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000205> (obsolete mineralizes)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000205> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000205> "obsolete mineralizes")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000205> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000205> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000206> (obsolete conjugates)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000206> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000206> "obsolete conjugates")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000206> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000206> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000207> (transports)
 
@@ -2141,43 +2141,43 @@ ObjectPropertyRange(<https://w3id.org/metpo/2000212> <https://w3id.org/metpo/100
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000213> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000213> "obsolete binds")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000213> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000213> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000214> (obsolete chelates)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000214> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000214> "obsolete chelates")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000214> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000214> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000215> (obsolete precipitates)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000215> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000215> "obsolete precipitates")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000215> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000215> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000216> (obsolete solubilizes)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000216> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000216> "obsolete solubilizes")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000216> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000216> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000217> (obsolete volatilizes)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000217> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000217> "obsolete volatilizes")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000217> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000217> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000218> (obsolete crystallizes)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000218> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000218> "obsolete crystallizes")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000218> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000218> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000219> (obsolete adsorbs)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000219> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000219> "obsolete adsorbs")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000219> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000219> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000220> (does not disproportionate)
 
@@ -2189,7 +2189,7 @@ SubObjectPropertyOf(<https://w3id.org/metpo/2000220> <https://w3id.org/metpo/200
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000221> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000221> "obsolete does not lyse")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000221> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000221> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000222> (does not produce)
 
@@ -2201,25 +2201,25 @@ SubObjectPropertyOf(<https://w3id.org/metpo/2000222> <https://w3id.org/metpo/200
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000223> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000223> "obsolete does not fix")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000223> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000223> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000224> (obsolete does not catabolize)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000224> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000224> "obsolete does not catabolize")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000224> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000224> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000225> (obsolete does not mineralize)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000225> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000225> "obsolete does not mineralize")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000225> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000225> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000226> (obsolete does not conjugate)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000226> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000226> "obsolete does not conjugate")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000226> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000226> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000227> (does not transport)
 
@@ -2263,43 +2263,43 @@ ObjectPropertyRange(<https://w3id.org/metpo/2000232> <https://w3id.org/metpo/100
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000233> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000233> "obsolete does not bind")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000233> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000233> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000234> (obsolete does not chelate)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000234> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000234> "obsolete does not chelate")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000234> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000234> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000235> (obsolete does not precipitate)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000235> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000235> "obsolete does not precipitate")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000235> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000235> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000236> (obsolete does not solubilize)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000236> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000236> "obsolete does not solubilize")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000236> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000236> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000237> (obsolete does not volatilize)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000237> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000237> "obsolete does not volatilize")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000237> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000237> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000238> (obsolete does not crystallize)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000238> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000238> "obsolete does not crystallize")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000238> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000238> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000239> (obsolete has pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000239> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000239> "obsolete has pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000239> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000239> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000301> (enzyme activity analyzed)
 
@@ -2328,97 +2328,97 @@ ObjectPropertyRange(<https://w3id.org/metpo/2000303> <https://w3id.org/metpo/100
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000501> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000501> "obsolete has optimum pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000501> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000501> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000502> (obsolete has growth pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000502> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000502> "obsolete has growth pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000502> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000502> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000503> (obsolete has range pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000503> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000503> "obsolete has range pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000503> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000503> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000504> (obsolete has pH delta observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000504> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000504> "obsolete has pH delta observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000504> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000504> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000505> (obsolete has culture pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000505> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000505> "obsolete has culture pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000505> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000505> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000506> (obsolete has NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000506> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000506> "obsolete has NaCl observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000506> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000506> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000507> (obsolete has optimum NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000507> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000507> "obsolete has optimum NaCl observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000507> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000507> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000508> (obsolete has growth NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000508> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000508> "obsolete has growth NaCl observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000508> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000508> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000509> (obsolete has range NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000509> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000509> "obsolete has range NaCl observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000509> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000509> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000510> (obsolete has NaCl delta observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000510> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000510> "obsolete has NaCl delta observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000510> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000510> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000511> (obsolete has observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000511> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000511> "obsolete has observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000511> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000511> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000512> (obsolete has oxygen observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000512> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000512> "obsolete has oxygen observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000512> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000512> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000513> (obsolete has optimum oxygen observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000513> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000513> "obsolete has optimum oxygen observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000513> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000513> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000514> (obsolete has growth oxygen observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000514> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000514> "obsolete has growth oxygen observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000514> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000514> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000515> (obsolete has range oxygen observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000515> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000515> "obsolete has range oxygen observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000515> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000515> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000516> (obsolete has oxygen delta observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000516> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000516> "obsolete has oxygen delta observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000516> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000516> "true"^^xsd:boolean)
 
 # Object Property: <https://w3id.org/metpo/2000517> (grows in)
 
@@ -2479,37 +2479,37 @@ SubObjectPropertyOf(<https://w3id.org/metpo/2000606> <https://w3id.org/metpo/200
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000058> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000058> "obsolete has observed spot value")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000058> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000058> "true"^^xsd:boolean)
 
 # Data Property: <https://w3id.org/metpo/2000059> (obsolete has minimum observed value)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000059> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000059> "obsolete has minimum observed value")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000059> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000059> "true"^^xsd:boolean)
 
 # Data Property: <https://w3id.org/metpo/2000060> (obsolete has maximum observed value)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000060> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000060> "obsolete has maximum observed value")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000060> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000060> "true"^^xsd:boolean)
 
 # Data Property: <https://w3id.org/metpo/2000061> (obsolete has value comments)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000061> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000061> "obsolete has value comments")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000061> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000061> "true"^^xsd:boolean)
 
 # Data Property: <https://w3id.org/metpo/2000062> (obsolete is negative data)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000062> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000062> "obsolete is negative data")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000062> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000062> "true"^^xsd:boolean)
 
 # Data Property: <https://w3id.org/metpo/2000063> (obsolete observation data property)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/2000063> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/2000063> "obsolete observation data property")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000063> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/2000063> "true"^^xsd:boolean)
 
 # Data Property: <https://w3id.org/metpo/2000071> (has value)
 
@@ -2743,4431 +2743,4431 @@ AnnotationAssertion(rdfs:label <http://www.geneontology.org/formats/oboInOwl#Obs
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000001> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000001> "obsolete Temperature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000001> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000001> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000001> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000002> (obsolete Salinity)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000002> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000002> "obsolete Salinity")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000002> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000002> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000002> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000003> (obsolete pH)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000003> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000003> "obsolete pH")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000003> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000003> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000003> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000004> (obsolete Oxygen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000004> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000004> "obsolete Oxygen")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000004> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000004> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000004> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000005> (obsolete Trophic type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000005> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000005> "obsolete Trophic type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000005> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000005> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000005> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000006> (obsolete Motility)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000006> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000006> "obsolete Motility")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000006> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000006> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000006> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000007> (obsolete Sporulation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000007> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000007> "obsolete Sporulation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000007> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000007> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000007> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000008> (obsolete Pressure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000008> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000008> "obsolete Pressure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000008> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000008> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000008> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000009> (obsolete GC content)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000009> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000009> "obsolete GC content")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000009> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000009> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000009> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000001> (obsolete Temperature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000001> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000001> "obsolete Temperature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000001> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000001> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000001> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000010> (obsolete Cell Width)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000010> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000010> "obsolete Cell Width")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000010> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000010> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000010> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000011> (obsolete Cell Length)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000011> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000011> "obsolete Cell Length")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000011> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000011> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000011> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000012> (obsolete Temperature Optimum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000012> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000012> "obsolete Temperature Optimum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000012> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000012> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000012> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000013> (obsolete Temperature Range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000013> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000013> "obsolete Temperature Range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000013> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000013> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000013> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000014> (obsolete pH Optimum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000014> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000014> "obsolete pH Optimum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000014> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000014> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000014> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000015> (obsolete pH Range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000015> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000015> "obsolete pH Range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000015> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000015> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000015> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000016> (obsolete NaCl Optimum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000016> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000016> "obsolete NaCl Optimum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000016> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000016> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000016> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000017> (obsolete NaCl Range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000017> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000017> "obsolete NaCl Range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000017> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000017> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000017> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000018> (obsolete pH delta)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000018> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000018> "obsolete pH delta")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000018> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000018> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000018> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000019> (obsolete NaCl delta)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000019> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000019> "obsolete NaCl delta")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000019> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000019> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000019> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000002> (obsolete Salinity)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000002> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000002> "obsolete Salinity")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000002> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000002> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000002> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000020> (obsolete Temperature Delta)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000020> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000020> "obsolete Temperature Delta")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000020> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000020> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000020> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000021> (obsolete METPO Morphology)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000021> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000021> "obsolete METPO Morphology")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000021> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000021> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000021> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000022> (obsolete Psychrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000022> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000022> "obsolete Psychrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000022> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000022> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000022> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000023> (obsolete Psychrotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000023> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000023> "obsolete Psychrotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000023> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000023> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000023> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000024> (obsolete Mesophilie)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000024> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000024> "obsolete Mesophilie")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000024> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000024> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000024> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000025> (obsolete Thermotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000025> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000025> "obsolete Thermotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000025> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000025> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000025> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000026> (obsolete Thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000026> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000026> "obsolete Thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000026> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000026> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000026> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000027> (obsolete Extreme thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000027> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000027> "obsolete Extreme thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000027> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000027> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000027> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000028> (obsolete Hyperthermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000028> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000028> "obsolete Hyperthermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000028> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000028> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000028> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000029> (obsolete Extreme hyperthermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000029> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000029> "obsolete Extreme hyperthermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000029> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000029> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000029> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000003> (obsolete pH)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000003> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000003> "obsolete pH")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000003> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000003> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000003> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000030> (obsolete Halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000030> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000030> "obsolete Halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000030> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000030> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000030> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000031> (obsolete Non-halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000031> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000031> "obsolete Non-halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000031> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000031> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000031> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000032> (obsolete Slight halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000032> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000032> "obsolete Slight halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000032> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000032> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000032> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000033> (obsolete Moderate halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000033> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000033> "obsolete Moderate halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000033> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000033> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000033> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000034> (obsolete Extreme halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000034> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000034> "obsolete Extreme halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000034> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000034> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000034> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000035> (obsolete Halotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000035> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000035> "obsolete Halotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000035> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000035> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000035> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000036> (obsolete Haloalkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000036> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000036> "obsolete Haloalkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000036> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000036> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000036> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000037> (obsolete Extreme Acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000037> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000037> "obsolete Extreme Acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000037> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000037> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000037> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000038> (obsolete Acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000038> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000038> "obsolete Acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000038> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000038> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000038> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000039> (obsolete Neutrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000039> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000039> "obsolete Neutrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000039> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000039> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000039> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000004> (obsolete Oxygen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000004> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000004> "obsolete Oxygen")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000004> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000004> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000004> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000040> (obsolete Alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000040> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000040> "obsolete Alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000040> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000040> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000040> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000041> (obsolete Acid Tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000041> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000041> "obsolete Acid Tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000041> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000041> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000041> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000042> (obsolete Alkali Tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000042> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000042> "obsolete Alkali Tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000042> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000042> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000042> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000043> (obsolete Extreme Alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000043> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000043> "obsolete Extreme Alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000043> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000043> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000043> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000044> (obsolete Facultative acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000044> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000044> "obsolete Facultative acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000044> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000044> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000044> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000045> (obsolete Obligative acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000045> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000045> "obsolete Obligative acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000045> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000045> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000045> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000046> (obsolete Aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000046> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000046> "obsolete Aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000046> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000046> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000046> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000047> (obsolete Anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000047> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000047> "obsolete Anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000047> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000047> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000047> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000048> (obsolete Facultative anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000048> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000048> "obsolete Facultative anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000048> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000048> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000048> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000049> (obsolete Facultative aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000049> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000049> "obsolete Facultative aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000049> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000049> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000049> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000005> (obsolete Trophic type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000005> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000005> "obsolete Trophic type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000005> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000005> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000005> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000050> (obsolete Microaerophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000050> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000050> "obsolete Microaerophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000050> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000050> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000050> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000051> (obsolete Aerotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000051> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000051> "obsolete Aerotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000051> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000051> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000051> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000052> (obsolete Microaerotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000052> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000052> "obsolete Microaerotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000052> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000052> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000052> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000053> (obsolete Aerotolerant anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000053> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000053> "obsolete Aerotolerant anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000053> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000053> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000053> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000054> (obsolete Obligate aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000054> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000054> "obsolete Obligate aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000054> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000054> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000054> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000055> (obsolete Obligate anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000055> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000055> "obsolete Obligate anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000055> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000055> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000055> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000056> (obsolete Oxygenic phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000056> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000056> "obsolete Oxygenic phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000056> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000056> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000056> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000057> (obsolete Anoxygenic phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000057> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000057> "obsolete Anoxygenic phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000057> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000057> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000057> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000058> (obsolete Autotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000058> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000058> "obsolete Autotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000058> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000058> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000058> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000059> (obsolete Photoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000059> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000059> "obsolete Photoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000059> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000059> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000059> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000006> (obsolete Motility)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000006> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000006> "obsolete Motility")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000006> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000006> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000006> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000060> (obsolete Chemoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000060> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000060> "obsolete Chemoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000060> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000060> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000060> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000061> (obsolete Heterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000061> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000061> "obsolete Heterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000061> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000061> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000061> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000062> (obsolete Photoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000062> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000062> "obsolete Photoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000062> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000062> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000062> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000063> (obsolete Chemoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000063> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000063> "obsolete Chemoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000063> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000063> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000063> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000064> (obsolete Lithotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000064> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000064> "obsolete Lithotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000064> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000064> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000064> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000065> (obsolete Organotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000065> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000065> "obsolete Organotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000065> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000065> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000065> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000066> (obsolete Phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000066> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000066> "obsolete Phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000066> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000066> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000066> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000067> (obsolete Chemotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000067> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000067> "obsolete Chemotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000067> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000067> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000067> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000068> (obsolete Oligotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000068> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000068> "obsolete Oligotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000068> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000068> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000068> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000069> (obsolete Copiotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000069> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000069> "obsolete Copiotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000069> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000069> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000069> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000007> (obsolete Sporulation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000007> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000007> "obsolete Sporulation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000007> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000007> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000007> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000070> (obsolete Lithoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000070> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000070> "obsolete Lithoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000070> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000070> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000070> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000071> (obsolete Mixotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000071> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000071> "obsolete Mixotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000071> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000071> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000071> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000072> (obsolete Lithoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000072> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000072> "obsolete Lithoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000072> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000072> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000072> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000073> (obsolete Chemoorganoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000073> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000073> "obsolete Chemoorganoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000073> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000073> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000073> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000074> (obsolete Chemolithoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000074> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000074> "obsolete Chemolithoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000074> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000074> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000074> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000075> (obsolete Methylotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000075> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000075> "obsolete Methylotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000075> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000075> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000075> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000076> (obsolete Methanotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000076> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000076> "obsolete Methanotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000076> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000076> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000076> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000077> (obsolete Carboxydotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000077> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000077> "obsolete Carboxydotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000077> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000077> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000077> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000078> (obsolete Hydrogenotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000078> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000078> "obsolete Hydrogenotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000078> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000078> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000078> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000079> (obsolete Hydrogen oxidizer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000079> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000079> "obsolete Hydrogen oxidizer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000079> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000079> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000079> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000008> (obsolete Pressure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000008> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000008> "obsolete Pressure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000008> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000008> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000008> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000080> (obsolete Hydrogen producer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000080> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000080> "obsolete Hydrogen producer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000080> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000080> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000080> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000081> (obsolete Nitrogen fixer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000081> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000081> "obsolete Nitrogen fixer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000081> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000081> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000081> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000082> (obsolete Methanogen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000082> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000082> "obsolete Methanogen")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000082> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000082> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000082> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000083> (obsolete Sulfate reducer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000083> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000083> "obsolete Sulfate reducer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000083> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000083> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000083> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000084> (obsolete Sulfur oxidizer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000084> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000084> "obsolete Sulfur oxidizer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000084> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000084> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000084> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000085> (obsolete Denitrifier)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000085> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000085> "obsolete Denitrifier")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000085> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000085> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000085> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000086> (obsolete Capnophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000086> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000086> "obsolete Capnophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000086> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000086> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000086> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000087> (obsolete Motile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000087> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000087> "obsolete Motile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000087> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000087> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000087> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000088> (obsolete Non-motile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000088> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000088> "obsolete Non-motile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000088> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000088> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000088> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000089> (obsolete Flagellated)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000089> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000089> "obsolete Flagellated")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000089> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000089> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000089> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000009> (obsolete GC content)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000009> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000009> "obsolete GC content")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000009> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000009> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000009> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000090> (obsolete Peritrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000090> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000090> "obsolete Peritrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000090> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000090> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000090> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000091> (obsolete Lophotrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000091> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000091> "obsolete Lophotrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000091> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000091> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000091> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000092> (obsolete Monotrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000092> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000092> "obsolete Monotrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000092> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000092> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000092> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000093> (obsolete Ciliated)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000093> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000093> "obsolete Ciliated")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000093> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000093> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000093> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000094> (obsolete Gliding)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000094> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000094> "obsolete Gliding")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000094> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000094> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000094> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000095> (obsolete Twitching)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000095> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000095> "obsolete Twitching")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000095> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000095> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000095> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000096> (obsolete Sliding)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000096> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000096> "obsolete Sliding")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000096> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000096> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000096> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000097> (obsolete Swarming)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000097> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000097> "obsolete Swarming")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000097> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000097> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000097> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000098> (obsolete Endospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000098> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000098> "obsolete Endospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000098> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000098> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000098> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000099> (obsolete Exospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000099> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000099> "obsolete Exospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000099> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000099> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000099> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000010> (obsolete Cell Width)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000010> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000010> "obsolete Cell Width")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000010> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000010> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000010> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000100> (obsolete Myxospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000100> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000100> "obsolete Myxospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000100> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000100> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000100> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000101> (obsolete Arthrospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000101> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000101> "obsolete Arthrospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000101> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000101> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000101> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000102> (obsolete Conidia)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000102> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000102> "obsolete Conidia")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000102> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000102> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000102> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000103> (obsolete Sporangiospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000103> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000103> "obsolete Sporangiospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000103> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000103> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000103> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000104> (obsolete Zygospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000104> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000104> "obsolete Zygospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000104> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000104> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000104> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000105> (obsolete Akinetes)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000105> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000105> "obsolete Akinetes")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000105> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000105> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000105> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000106> (obsolete Chlamydospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000106> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000106> "obsolete Chlamydospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000106> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000106> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000106> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000107> (obsolete Sporocysts)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000107> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000107> "obsolete Sporocysts")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000107> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000107> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000107> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000108> (obsolete Hypnospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000108> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000108> "obsolete Hypnospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000108> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000108> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000108> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000109> (obsolete Gemmae)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000109> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000109> "obsolete Gemmae")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000109> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000109> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000109> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000011> (obsolete Cell Length)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000011> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000011> "obsolete Cell Length")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000011> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000011> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000011> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000110> (obsolete Oospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000110> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000110> "obsolete Oospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000110> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000110> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000110> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000111> (obsolete Azygospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000111> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000111> "obsolete Azygospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000111> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000111> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000111> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000112> (obsolete Cysts)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000112> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000112> "obsolete Cysts")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000112> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000112> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000112> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000113> (obsolete Ascospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000113> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000113> "obsolete Ascospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000113> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000113> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000113> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000114> (obsolete Basidiospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000114> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000114> "obsolete Basidiospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000114> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000114> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000114> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000115> (obsolete Aleuriospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000115> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000115> "obsolete Aleuriospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000115> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000115> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000115> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000116> (obsolete Stylospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000116> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000116> "obsolete Stylospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000116> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000116> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000116> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000117> (obsolete Sclerotia)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000117> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000117> "obsolete Sclerotia")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000117> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000117> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000117> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000118> (obsolete Zoospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000118> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000118> "obsolete Zoospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000118> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000118> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000118> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000119> (obsolete Teliospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000119> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000119> "obsolete Teliospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000119> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000119> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000119> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000012> (obsolete Temperature Optimum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000012> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000012> "obsolete Temperature Optimum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000012> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000012> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000012> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000120> (obsolete Urediniospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000120> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000120> "obsolete Urediniospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000120> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000120> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000120> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000121> (obsolete Pycnidiospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000121> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000121> "obsolete Pycnidiospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000121> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000121> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000121> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000122> (obsolete Acriospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000122> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000122> "obsolete Acriospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000122> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000122> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000122> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000123> (obsolete Aplanospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000123> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000123> "obsolete Aplanospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000123> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000123> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000123> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000124> (obsolete Statismospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000124> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000124> "obsolete Statismospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000124> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000124> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000124> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000125> (obsolete Barotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000125> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000125> "obsolete Barotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000125> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000125> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000125> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000126> (obsolete Piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000126> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000126> "obsolete Piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000126> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000126> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000126> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000127> (obsolete Piezotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000127> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000127> "obsolete Piezotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000127> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000127> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000127> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000128> (obsolete Piezosensitive)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000128> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000128> "obsolete Piezosensitive")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000128> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000128> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000128> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000129> (obsolete Obligate barophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000129> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000129> "obsolete Obligate barophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000129> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000129> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000129> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000013> (obsolete Temperature Range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000013> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000013> "obsolete Temperature Range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000013> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000013> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000013> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000130> (obsolete Facultative barophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000130> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000130> "obsolete Facultative barophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000130> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000130> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000130> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000131> (obsolete Hyperbarophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000131> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000131> "obsolete Hyperbarophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000131> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000131> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000131> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000132> (obsolete Hypobarophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000132> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000132> "obsolete Hypobarophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000132> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000132> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000132> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000133> (obsolete Atmospheric pressure-adapted)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000133> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000133> "obsolete Atmospheric pressure-adapted")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000133> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000133> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000133> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000134> (obsolete Moderate piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000134> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000134> "obsolete Moderate piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000134> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000134> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000134> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000135> (obsolete Extreme piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000135> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000135> "obsolete Extreme piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000135> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000135> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000135> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000136> (obsolete Stenopiezic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000136> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000136> "obsolete Stenopiezic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000136> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000136> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000136> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000137> (obsolete Eurypiezic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000137> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000137> "obsolete Eurypiezic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000137> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000137> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000137> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000138> (obsolete Pressure-sensitive)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000138> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000138> "obsolete Pressure-sensitive")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000138> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000138> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000138> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000139> (obsolete Pressure-resistant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000139> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000139> "obsolete Pressure-resistant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000139> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000139> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000139> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000014> (obsolete pH Optimum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000014> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000014> "obsolete pH Optimum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000014> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000014> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000014> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000140> (obsolete Pressure-adapted)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000140> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000140> "obsolete Pressure-adapted")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000140> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000140> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000140> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000141> (obsolete Piezo-acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000141> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000141> "obsolete Piezo-acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000141> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000141> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000141> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000142> (obsolete Piezo-alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000142> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000142> "obsolete Piezo-alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000142> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000142> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000142> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000143> (obsolete Piezo-halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000143> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000143> "obsolete Piezo-halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000143> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000143> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000143> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000144> (obsolete Piezo-psychrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000144> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000144> "obsolete Piezo-psychrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000144> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000144> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000144> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000145> (obsolete Piezo-thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000145> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000145> "obsolete Piezo-thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000145> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000145> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000145> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000146> (obsolete Piezo-lithoautotrophe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000146> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000146> "obsolete Piezo-lithoautotrophe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000146> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000146> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000146> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000147> (obsolete Piezo-chemoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000147> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000147> "obsolete Piezo-chemoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000147> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000147> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000147> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000148> (obsolete Piezo-oligotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000148> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000148> "obsolete Piezo-oligotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000148> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000148> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000148> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000149> (obsolete Piezo-endolithic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000149> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000149> "obsolete Piezo-endolithic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000149> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000149> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000149> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000015> (obsolete pH Range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000015> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000015> "obsolete pH Range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000015> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000015> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000015> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000150> (obsolete Piezo-tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000150> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000150> "obsolete Piezo-tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000150> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000150> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000150> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000151> (obsolete GC low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000151> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000151> "obsolete GC low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000151> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000151> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000151> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000152> (obsolete GC mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000152> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000152> "obsolete GC mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000152> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000152> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000152> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000153> (obsolete GC mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000153> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000153> "obsolete GC mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000153> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000153> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000153> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000154> (obsolete GC high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000154> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000154> "obsolete GC high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000154> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000154> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000154> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000155> (obsolete Cell width very low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000155> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000155> "obsolete Cell width very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000155> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000155> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000155> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000156> (obsolete Cell width low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000156> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000156> "obsolete Cell width low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000156> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000156> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000156> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000157> (obsolete Cell width mid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000157> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000157> "obsolete Cell width mid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000157> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000157> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000157> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000158> (obsolete Cell width high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000158> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000158> "obsolete Cell width high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000158> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000158> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000158> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000159> (obsolete Cell length very low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000159> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000159> "obsolete Cell length very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000159> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000159> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000159> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000016> (obsolete NaCl Optimum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000016> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000016> "obsolete NaCl Optimum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000016> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000016> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000016> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000160> (obsolete Cell length low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000160> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000160> "obsolete Cell length low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000160> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000160> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000160> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000161> (obsolete Cell length mid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000161> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000161> "obsolete Cell length mid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000161> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000161> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000161> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000162> (obsolete Cell length high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000162> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000162> "obsolete Cell length high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000162> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000162> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000162> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000163> (obsolete Temperature Optimum very low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000163> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000163> "obsolete Temperature Optimum very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000163> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000163> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000163> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000164> (obsolete Temperature Optimum low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000164> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000164> "obsolete Temperature Optimum low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000164> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000164> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000164> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000165> (obsolete Temperature Optimum mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000165> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000165> "obsolete Temperature Optimum mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000165> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000165> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000165> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000166> (obsolete Temperature Optimum mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000166> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000166> "obsolete Temperature Optimum mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000166> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000166> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000166> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000167> (obsolete Temperature Optimum mid3)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000167> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000167> "obsolete Temperature Optimum mid3")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000167> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000167> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000167> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000168> (obsolete Temperature Optimum mid4)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000168> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000168> "obsolete Temperature Optimum mid4")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000168> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000168> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000168> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000169> (obsolete Temperature Optimum high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000169> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000169> "obsolete Temperature Optimum high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000169> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000169> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000169> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000017> (obsolete NaCl Range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000017> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000017> "obsolete NaCl Range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000017> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000017> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000017> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000170> (obsolete Temperature Range very low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000170> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000170> "obsolete Temperature Range very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000170> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000170> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000170> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000171> (obsolete Temperature Range low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000171> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000171> "obsolete Temperature Range low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000171> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000171> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000171> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000172> (obsolete Temperature Range mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000172> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000172> "obsolete Temperature Range mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000172> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000172> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000172> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000173> (obsolete Temperature Range mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000173> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000173> "obsolete Temperature Range mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000173> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000173> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000173> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000174> (obsolete Temperature Range mid3)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000174> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000174> "obsolete Temperature Range mid3")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000174> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000174> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000174> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000175> (obsolete Temperature Range mid4)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000175> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000175> "obsolete Temperature Range mid4")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000175> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000175> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000175> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000176> (obsolete Temperature Range high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000176> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000176> "obsolete Temperature Range high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000176> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000176> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000176> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000177> (obsolete pH Optimum low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000177> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000177> "obsolete pH Optimum low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000177> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000177> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000177> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000178> (obsolete pH Optimum mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000178> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000178> "obsolete pH Optimum mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000178> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000178> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000178> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000179> (obsolete pH Optimum mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000179> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000179> "obsolete pH Optimum mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000179> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000179> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000179> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000018> (obsolete pH delta)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000018> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000018> "obsolete pH delta")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000018> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000018> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000018> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000180> (obsolete pH Optimum high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000180> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000180> "obsolete pH Optimum high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000180> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000180> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000180> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000181> (obsolete pH Range very low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000181> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000181> "obsolete pH Range very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000181> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000181> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000181> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000182> (obsolete pH Range low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000182> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000182> "obsolete pH Range low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000182> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000182> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000182> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000183> (obsolete pH Range mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000183> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000183> "obsolete pH Range mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000183> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000183> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000183> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000184> (obsolete pH Range mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000184> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000184> "obsolete pH Range mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000184> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000184> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000184> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000185> (obsolete pH Range mid3)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000185> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000185> "obsolete pH Range mid3")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000185> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000185> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000185> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000186> (obsolete pH Range high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000186> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000186> "obsolete pH Range high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000186> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000186> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000186> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000187> (obsolete NaCl Optimum low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000187> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000187> "obsolete NaCl Optimum low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000187> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000187> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000187> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000188> (obsolete NaCl Optimum mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000188> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000188> "obsolete NaCl Optimum mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000188> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000188> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000188> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000189> (obsolete NaCl Optimum mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000189> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000189> "obsolete NaCl Optimum mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000189> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000189> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000189> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000019> (obsolete NaCl delta)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000019> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000019> "obsolete NaCl delta")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000019> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000019> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000019> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000190> (obsolete NaCl Optimum high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000190> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000190> "obsolete NaCl Optimum high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000190> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000190> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000190> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000191> (obsolete NaCl Range low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000191> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000191> "obsolete NaCl Range low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000191> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000191> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000191> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000192> (obsolete NaCl Range mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000192> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000192> "obsolete NaCl Range mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000192> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000192> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000192> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000193> (obsolete NaCl Range mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000193> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000193> "obsolete NaCl Range mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000193> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000193> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000193> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000194> (obsolete NaCl Range high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000194> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000194> "obsolete NaCl Range high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000194> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000194> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000194> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000195> (obsolete pH Delta very low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000195> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000195> "obsolete pH Delta very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000195> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000195> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000195> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000196> (obsolete pH Delta low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000196> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000196> "obsolete pH Delta low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000196> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000196> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000196> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000197> (obsolete pH Delta mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000197> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000197> "obsolete pH Delta mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000197> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000197> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000197> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000198> (obsolete pH Delta mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000198> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000198> "obsolete pH Delta mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000198> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000198> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000198> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000199> (obsolete pH Delta mid3)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000199> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000199> "obsolete pH Delta mid3")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000199> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000199> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000199> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000020> (obsolete Temperature Delta)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000020> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000020> "obsolete Temperature Delta")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000020> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000020> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000020> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000200> (obsolete pH Delta high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000200> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000200> "obsolete pH Delta high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000200> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000200> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000200> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000201> (obsolete NaCl Delta low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000201> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000201> "obsolete NaCl Delta low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000201> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000201> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000201> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000202> (obsolete NaCl Delta mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000202> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000202> "obsolete NaCl Delta mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000202> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000202> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000202> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000203> (obsolete NaCl Delta mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000203> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000203> "obsolete NaCl Delta mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000203> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000203> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000203> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000204> (obsolete NaCl Delta high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000204> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000204> "obsolete NaCl Delta high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000204> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000204> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000204> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000205> (obsolete Temperature Delta very low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000205> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000205> "obsolete Temperature Delta very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000205> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000205> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000205> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000206> (obsolete Temperature Delta low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000206> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000206> "obsolete Temperature Delta low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000206> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000206> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000206> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000207> (obsolete Temperature Delta mid1)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000207> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000207> "obsolete Temperature Delta mid1")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000207> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000207> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000207> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000208> (obsolete Temperature Delta mid2)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000208> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000208> "obsolete Temperature Delta mid2")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000208> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000208> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000208> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000209> (obsolete Temperature Delta high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000209> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000209> "obsolete Temperature Delta high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000209> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000209> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000209> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000021> (obsolete Morphology)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000021> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000021> "obsolete Morphology")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000021> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000021> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000021> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000210> (obsolete Bacillus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000210> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000210> "obsolete Bacillus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000210> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000210> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000210> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000211> (obsolete Branced)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000211> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000211> "obsolete Branced")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000211> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000211> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000211> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000212> (obsolete Coccobacillus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000212> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000212> "obsolete Coccobacillus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000212> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000212> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000212> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000213> (obsolete Coccus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000213> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000213> "obsolete Coccus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000213> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000213> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000213> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000214> (obsolete Crescent)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000214> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000214> "obsolete Crescent")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000214> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000214> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000214> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000215> (obsolete Curved)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000215> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000215> "obsolete Curved")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000215> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000215> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000215> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000216> (obsolete Curved Spiral)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000216> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000216> "obsolete Curved Spiral")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000216> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000216> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000216> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000217> (obsolete Diplococcus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000217> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000217> "obsolete Diplococcus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000217> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000217> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000217> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000218> (obsolete Disc)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000218> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000218> "obsolete Disc")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000218> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000218> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000218> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000219> (obsolete Dumbbell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000219> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000219> "obsolete Dumbbell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000219> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000219> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000219> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000022> (obsolete Other)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000022> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000022> "obsolete Other")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000022> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000022> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000022> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000220> (obsolete Ellipsoidal)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000220> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000220> "obsolete Ellipsoidal")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000220> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000220> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000220> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000221> (obsolete Filament)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000221> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000221> "obsolete Filament")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000221> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000221> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000221> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000222> (obsolete Flask)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000222> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000222> "obsolete Flask")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000222> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000222> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000222> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000223> (obsolete Fusiform)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000223> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000223> "obsolete Fusiform")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000223> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000223> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000223> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000224> (obsolete Helical)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000224> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000224> "obsolete Helical")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000224> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000224> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000224> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000225> (obsolete Irregular)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000225> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000225> "obsolete Irregular")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000225> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000225> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000225> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000226> (obsolete Oval)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000226> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000226> "obsolete Oval")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000226> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000226> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000226> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000227> (obsolete Ovoid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000227> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000227> "obsolete Ovoid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000227> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000227> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000227> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000228> (obsolete Pleomorphic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000228> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000228> "obsolete Pleomorphic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000228> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000228> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000228> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000229> (obsolete Ring)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000229> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000229> "obsolete Ring")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000229> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000229> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000229> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000023> (obsolete Psychrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000023> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000023> "obsolete Psychrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000023> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000023> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000023> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000230> (obsolete Rod)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000230> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000230> "obsolete Rod")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000230> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000230> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000230> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000231> (obsolete Sphere)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000231> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000231> "obsolete Sphere")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000231> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000231> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000231> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000232> (obsolete Spindle)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000232> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000232> "obsolete Spindle")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000232> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000232> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000232> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000233> (obsolete Spiral)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000233> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000233> "obsolete Spiral")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000233> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000233> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000233> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000234> (obsolete Spirochete)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000234> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000234> "obsolete Spirochete")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000234> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000234> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000234> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000235> (obsolete Spore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000235> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000235> "obsolete Spore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000235> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000235> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000235> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000236> (obsolete Square)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000236> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000236> "obsolete Square")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000236> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000236> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000236> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000237> (obsolete Star)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000237> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000237> "obsolete Star")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000237> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000237> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000237> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000238> (obsolete Star - Dumbbell - Pleomorphic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000238> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000238> "obsolete Star - Dumbbell - Pleomorphic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000238> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000238> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000238> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000239> (obsolete Tailed)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000239> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000239> "obsolete Tailed")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000239> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000239> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000239> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000024> (obsolete Psychrotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000024> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000024> "obsolete Psychrotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000024> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000024> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000024> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000240> (obsolete Triangular)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000240> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000240> "obsolete Triangular")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000240> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000240> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000240> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000241> (obsolete Vibrio)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000241> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000241> "obsolete Vibrio")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000241> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000241> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000241> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000242> (obsolete Environmental Parameter)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000242> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000242> "obsolete Environmental Parameter")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000242> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000242> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000242> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000243> (obsolete Growth Condition)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000243> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000243> "obsolete Growth Condition")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000243> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000243> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000243> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000244> (obsolete Physiological Trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000244> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000244> "obsolete Physiological Trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000244> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000244> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000244> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000245> (obsolete Metabolic Classification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000245> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000245> "obsolete Metabolic Classification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000245> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000245> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000245> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000246> (obsolete Cellular Characteristic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000246> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000246> "obsolete Cellular Characteristic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000246> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000246> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000246> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000247> (obsolete Taxonomic Feature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000247> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000247> "obsolete Taxonomic Feature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000247> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000247> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000247> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000248> (obsolete Microbial Adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000248> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000248> "obsolete Microbial Adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000248> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000248> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000248> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000249> (obsolete Growth Parameter)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000249> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000249> "obsolete Growth Parameter")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000249> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000249> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000249> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000025> (obsolete Mesophilie)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000025> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000025> "obsolete Mesophilie")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000025> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000025> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000025> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000250> (obsolete Structural Feature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000250> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000250> "obsolete Structural Feature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000250> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000250> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000250> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000251> (obsolete Temperature Adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000251> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000251> "obsolete Temperature Adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000251> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000251> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000251> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000252> (obsolete Salinity Adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000252> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000252> "obsolete Salinity Adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000252> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000252> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000252> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000253> (obsolete pH Adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000253> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000253> "obsolete pH Adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000253> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000253> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000253> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000254> (obsolete Oxygen Requirement)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000254> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000254> "obsolete Oxygen Requirement")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000254> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000254> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000254> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000255> (obsolete Carbon Source Utilization)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000255> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000255> "obsolete Carbon Source Utilization")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000255> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000255> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000255> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000256> (obsolete Energy Acquisition Mode)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000256> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000256> "obsolete Energy Acquisition Mode")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000256> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000256> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000256> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000257> (obsolete Electron Donor Type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000257> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000257> "obsolete Electron Donor Type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000257> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000257> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000257> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000258> (obsolete Motility Mechanism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000258> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000258> "obsolete Motility Mechanism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000258> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000258> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000258> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000259> (obsolete Motility Structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000259> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000259> "obsolete Motility Structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000259> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000259> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000259> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000026> (obsolete Thermotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000026> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000026> "obsolete Thermotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000026> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000026> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000026> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000260> (obsolete Bacterial Spore Type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000260> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000260> "obsolete Bacterial Spore Type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000260> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000260> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000260> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000261> (obsolete Fungal Spore Type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000261> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000261> "obsolete Fungal Spore Type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000261> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000261> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000261> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000262> (obsolete Reproductive Structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000262> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000262> "obsolete Reproductive Structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000262> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000262> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000262> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000263> (obsolete Dormancy Structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000263> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000263> "obsolete Dormancy Structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000263> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000263> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000263> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000264> (obsolete Pressure Adaptation Type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000264> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000264> "obsolete Pressure Adaptation Type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000264> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000264> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000264> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000265> (obsolete Pressure Tolerance Range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000265> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000265> "obsolete Pressure Tolerance Range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000265> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000265> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000265> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000266> (obsolete Genomic Feature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000266> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000266> "obsolete Genomic Feature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000266> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000266> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000266> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000267> (obsolete Cell Dimension)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000267> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000267> "obsolete Cell Dimension")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000267> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000267> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000267> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000268> (obsolete Optimal Growth Parameter)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000268> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000268> "obsolete Optimal Growth Parameter")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000268> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000268> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000268> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000269> (obsolete Growth Range Parameter)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000269> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000269> "obsolete Growth Range Parameter")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000269> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000269> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000269> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000027> (obsolete Thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000027> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000027> "obsolete Thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000027> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000027> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000027> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000270> (obsolete Growth Tolerance Metric)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000270> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000270> "obsolete Growth Tolerance Metric")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000270> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000270> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000270> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000271> (obsolete Cell Shape)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000271> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000271> "obsolete Cell Shape")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000271> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000271> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000271> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000272> (obsolete Cell Arrangement)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000272> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000272> "obsolete Cell Arrangement")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000272> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000272> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000272> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000273> (obsolete Colony Morphology)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000273> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000273> "obsolete Colony Morphology")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000273> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000273> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000273> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000274> (obsolete Physical Property)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000274> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000274> "obsolete Physical Property")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000274> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000274> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000274> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000275> (obsolete Environmental Context)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000275> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000275> "obsolete Environmental Context")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000275> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000275> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000275> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000276> (obsolete Biological Property)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000276> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000276> "obsolete Biological Property")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000276> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000276> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000276> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000277> (obsolete Functional Classification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000277> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000277> "obsolete Functional Classification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000277> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000277> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000277> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000278> (obsolete Classification Property)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000278> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000278> "obsolete Classification Property")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000278> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000278> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000278> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000279> (obsolete METPO Biological Process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000279> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000279> "obsolete METPO Biological Process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000279> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000279> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000279> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000028> (obsolete Extreme thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000028> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000028> "obsolete Extreme thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000028> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000028> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000028> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000280> (obsolete Measurable Property)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000280> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000280> "obsolete Measurable Property")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000280> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000280> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000280> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000281> (obsolete Gram-stain negative)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000281> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000281> "obsolete Gram-stain negative")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000281> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000281> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000281> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0000282> (obsolete Gram-stain positive)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0000282> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0000282> "obsolete Gram-stain positive")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000282> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0000282> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0000282> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000029> (obsolete Hyperthermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000029> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000029> "obsolete Hyperthermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000029> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000029> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000029> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000030> (obsolete Extreme hyperthermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000030> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000030> "obsolete Extreme hyperthermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000030> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000030> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000030> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000031> (obsolete Halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000031> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000031> "obsolete Halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000031> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000031> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000031> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000032> (obsolete Non-halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000032> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000032> "obsolete Non-halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000032> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000032> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000032> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000033> (obsolete Slight halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000033> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000033> "obsolete Slight halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000033> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000033> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000033> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000034> (obsolete Moderate halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000034> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000034> "obsolete Moderate halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000034> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000034> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000034> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000035> (obsolete Extreme halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000035> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000035> "obsolete Extreme halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000035> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000035> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000035> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000036> (obsolete Halotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000036> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000036> "obsolete Halotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000036> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000036> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000036> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000037> (obsolete Haloalkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000037> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000037> "obsolete Haloalkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000037> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000037> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000037> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000038> (obsolete Extreme Acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000038> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000038> "obsolete Extreme Acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000038> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000038> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000038> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000039> (obsolete Acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000039> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000039> "obsolete Acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000039> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000039> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000039> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000040> (obsolete Neutrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000040> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000040> "obsolete Neutrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000040> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000040> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000040> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000041> (obsolete Alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000041> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000041> "obsolete Alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000041> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000041> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000041> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000042> (obsolete Acid Tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000042> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000042> "obsolete Acid Tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000042> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000042> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000042> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000043> (obsolete Alkali Tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000043> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000043> "obsolete Alkali Tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000043> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000043> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000043> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000044> (obsolete Extreme Alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000044> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000044> "obsolete Extreme Alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000044> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000044> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000044> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000045> (obsolete Facultative acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000045> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000045> "obsolete Facultative acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000045> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000045> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000045> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000046> (obsolete Obligative acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000046> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000046> "obsolete Obligative acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000046> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000046> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000046> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000047> (obsolete Aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000047> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000047> "obsolete Aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000047> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000047> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000047> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000048> (obsolete Anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000048> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000048> "obsolete Anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000048> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000048> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000048> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000049> (obsolete Facultative anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000049> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000049> "obsolete Facultative anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000049> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000049> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000049> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000050> (obsolete Facultative aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000050> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000050> "obsolete Facultative aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000050> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000050> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000050> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000051> (obsolete Microaerophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000051> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000051> "obsolete Microaerophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000051> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000051> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000051> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000052> (obsolete Aerotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000052> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000052> "obsolete Aerotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000052> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000052> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000052> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000053> (obsolete Microaerotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000053> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000053> "obsolete Microaerotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000053> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000053> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000053> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000054> (obsolete Aerotolerant anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000054> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000054> "obsolete Aerotolerant anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000054> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000054> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000054> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000055> (obsolete Obligate aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000055> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000055> "obsolete Obligate aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000055> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000055> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000055> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000056> (obsolete Obligate anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000056> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000056> "obsolete Obligate anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000056> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000056> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000056> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000057> (obsolete Oxygenic phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000057> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000057> "obsolete Oxygenic phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000057> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000057> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000057> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000058> (obsolete Anoxygenic phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000058> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000058> "obsolete Anoxygenic phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000058> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000058> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000058> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000059> (obsolete Autotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000059> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000059> "obsolete Autotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000059> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000059> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000059> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000060> (obsolete Photoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000060> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000060> "obsolete Photoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000060> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000060> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000060> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000061> (obsolete Chemoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000061> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000061> "obsolete Chemoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000061> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000061> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000061> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000062> (obsolete Heterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000062> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000062> "obsolete Heterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000062> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000062> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000062> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000063> (obsolete Photoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000063> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000063> "obsolete Photoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000063> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000063> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000063> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000064> (obsolete Chemoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000064> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000064> "obsolete Chemoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000064> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000064> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000064> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000065> (obsolete Lithotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000065> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000065> "obsolete Lithotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000065> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000065> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000065> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000066> (obsolete Organotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000066> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000066> "obsolete Organotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000066> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000066> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000066> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000067> (obsolete Phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000067> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000067> "obsolete Phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000067> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000067> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000067> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000068> (obsolete Chemotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000068> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000068> "obsolete Chemotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000068> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000068> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000068> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000069> (obsolete Oligotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000069> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000069> "obsolete Oligotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000069> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000069> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000069> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000070> (obsolete Copiotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000070> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000070> "obsolete Copiotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000070> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000070> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000070> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000071> (obsolete Lithoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000071> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000071> "obsolete Lithoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000071> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000071> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000071> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000072> (obsolete Mixotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000072> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000072> "obsolete Mixotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000072> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000072> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000072> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000073> (obsolete Lithoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000073> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000073> "obsolete Lithoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000073> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000073> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000073> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000074> (obsolete Chemoorganoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000074> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000074> "obsolete Chemoorganoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000074> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000074> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000074> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000075> (obsolete Chemolithoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000075> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000075> "obsolete Chemolithoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000075> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000075> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000075> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000076> (obsolete Methylotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000076> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000076> "obsolete Methylotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000076> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000076> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000076> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000077> (obsolete Methanotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000077> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000077> "obsolete Methanotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000077> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000077> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000077> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000078> (obsolete Carboxydotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000078> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000078> "obsolete Carboxydotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000078> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000078> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000078> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000079> (obsolete Hydrogenotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000079> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000079> "obsolete Hydrogenotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000079> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000079> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000079> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000080> (obsolete Hydrogen oxidizer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000080> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000080> "obsolete Hydrogen oxidizer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000080> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000080> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000080> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000081> (obsolete Hydrogen producer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000081> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000081> "obsolete Hydrogen producer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000081> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000081> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000081> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000082> (obsolete Nitrogen fixer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000082> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000082> "obsolete Nitrogen fixer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000082> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000082> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000082> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000083> (obsolete Methanogen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000083> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000083> "obsolete Methanogen")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000083> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000083> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000083> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000084> (obsolete Sulfate reducer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000084> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000084> "obsolete Sulfate reducer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000084> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000084> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000084> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000085> (obsolete Sulfur oxidizer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000085> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000085> "obsolete Sulfur oxidizer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000085> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000085> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000085> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000086> (obsolete Denitrifier)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000086> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000086> "obsolete Denitrifier")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000086> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000086> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000086> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000087> (obsolete Capnophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000087> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000087> "obsolete Capnophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000087> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000087> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000087> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000088> (obsolete Motile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000088> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000088> "obsolete Motile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000088> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000088> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000088> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000089> (obsolete Non-motile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000089> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000089> "obsolete Non-motile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000089> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000089> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000089> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000090> (obsolete Flagellated)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000090> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000090> "obsolete Flagellated")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000090> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000090> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000090> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000091> (obsolete Peritrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000091> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000091> "obsolete Peritrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000091> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000091> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000091> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000092> (obsolete Lophotrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000092> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000092> "obsolete Lophotrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000092> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000092> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000092> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000093> (obsolete Monotrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000093> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000093> "obsolete Monotrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000093> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000093> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000093> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000094> (obsolete Ciliated)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000094> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000094> "obsolete Ciliated")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000094> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000094> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000094> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000095> (obsolete Gliding)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000095> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000095> "obsolete Gliding")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000095> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000095> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000095> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000096> (obsolete Twitching)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000096> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000096> "obsolete Twitching")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000096> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000096> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000096> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000097> (obsolete Sliding)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000097> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000097> "obsolete Sliding")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000097> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000097> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000097> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000098> (obsolete Swarming)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000098> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000098> "obsolete Swarming")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000098> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000098> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000098> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000099> (obsolete Endospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000099> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000099> "obsolete Endospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000099> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000099> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000099> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000100> (obsolete Exospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000100> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000100> "obsolete Exospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000100> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000100> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000100> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001000> (obsolete sensitivity to oxygen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001000> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001000> "obsolete sensitivity to oxygen")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001000> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001000> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001000> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001001> (obsolete sensitivity toward)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001001> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001001> "obsolete sensitivity toward")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001001> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001001> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001001> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001002> (obsolete 'organismal quality')
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001002> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001002> "obsolete 'organismal quality'")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001002> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001002> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001002> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001003> (obsolete 'physicial object quality')
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001003> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001003> "obsolete 'physicial object quality'")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001003> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001003> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001003> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001004> (obsolete 'quality')
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001004> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001004> "obsolete 'quality'")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001004> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001004> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001004> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001006> (obsolete size)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001006> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001006> "obsolete size")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001006> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001006> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001006> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001007> (obsolete 1-D extent)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001007> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001007> "obsolete 1-D extent")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001007> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001007> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001007> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001008> (obsolete width)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001008> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001008> "obsolete width")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001008> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001008> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001008> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001009> (obsolete length)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001009> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001009> "obsolete length")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001009> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001009> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001009> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000101> (obsolete Myxospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000101> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000101> "obsolete Myxospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000101> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000101> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000101> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001010> (obsolete 'prokaryotic metabolically differentiated cell')
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001010> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001010> "obsolete 'prokaryotic metabolically differentiated cell'")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001010> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001010> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001010> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001012> (obsolete heterotrophy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001012> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001012> "obsolete heterotrophy")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001012> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001012> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001012> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001013> (obsolete structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001013> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001013> "obsolete structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001013> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001013> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001013> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001014> (obsolete spore type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001014> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001014> "obsolete spore type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001014> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001014> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001014> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001016> (obsolete sensitivity toward pressure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001016> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001016> "obsolete sensitivity toward pressure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001016> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001016> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001016> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001017> (obsolete sensitivity toward NaCl)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001017> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001017> "obsolete sensitivity toward NaCl")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001017> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001017> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001017> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001018> (obsolete sensitivity toward pH)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001018> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001018> "obsolete sensitivity toward pH")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001018> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001018> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001018> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001019> (obsolete sensitivity toward temperature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001019> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001019> "obsolete sensitivity toward temperature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001019> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001019> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001019> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000102> (obsolete Arthrospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000102> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000102> "obsolete Arthrospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000102> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000102> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000102> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001020> (obsolete metabolic constraints)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001020> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001020> "obsolete metabolic constraints")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001020> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001020> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001020> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/0001021> (obsolete cell by chemical produced)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/0001021> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/0001021> "obsolete cell by chemical produced")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001021> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/0001021> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/0001021> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000103> (obsolete Conidia)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000103> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000103> "obsolete Conidia")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000103> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000103> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000103> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000104> (obsolete Sporangiospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000104> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000104> "obsolete Sporangiospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000104> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000104> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000104> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000105> (obsolete Zygospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000105> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000105> "obsolete Zygospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000105> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000105> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000105> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000106> (obsolete Akinetes)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000106> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000106> "obsolete Akinetes")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000106> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000106> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000106> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000107> (obsolete Chlamydospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000107> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000107> "obsolete Chlamydospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000107> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000107> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000107> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000108> (obsolete Sporocysts)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000108> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000108> "obsolete Sporocysts")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000108> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000108> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000108> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000109> (obsolete Hypnospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000109> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000109> "obsolete Hypnospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000109> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000109> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000109> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000110> (obsolete Gemmae)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000110> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000110> "obsolete Gemmae")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000110> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000110> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000110> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000111> (obsolete Oospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000111> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000111> "obsolete Oospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000111> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000111> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000111> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000112> (obsolete Azygospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000112> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000112> "obsolete Azygospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000112> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000112> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000112> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000113> (obsolete Cysts)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000113> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000113> "obsolete Cysts")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000113> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000113> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000113> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000114> (obsolete Ascospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000114> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000114> "obsolete Ascospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000114> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000114> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000114> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000115> (obsolete Basidiospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000115> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000115> "obsolete Basidiospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000115> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000115> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000115> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000116> (obsolete Aleuriospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000116> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000116> "obsolete Aleuriospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000116> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000116> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000116> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000117> (obsolete Stylospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000117> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000117> "obsolete Stylospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000117> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000117> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000117> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000118> (obsolete Sclerotia)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000118> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000118> "obsolete Sclerotia")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000118> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000118> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000118> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000119> (obsolete Zoospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000119> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000119> "obsolete Zoospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000119> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000119> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000119> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000120> (obsolete Teliospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000120> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000120> "obsolete Teliospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000120> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000120> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000120> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000121> (obsolete Urediniospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000121> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000121> "obsolete Urediniospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000121> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000121> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000121> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000122> (obsolete Pycnidiospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000122> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000122> "obsolete Pycnidiospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000122> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000122> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000122> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000123> (obsolete Acriospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000123> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000123> "obsolete Acriospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000123> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000123> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000123> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000124> (obsolete Aplanospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000124> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000124> "obsolete Aplanospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000124> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000124> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000124> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000125> (obsolete Statismospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000125> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000125> "obsolete Statismospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000125> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000125> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000125> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000126> (obsolete Barotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000126> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000126> "obsolete Barotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000126> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000126> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000126> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000127> (obsolete Piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000127> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000127> "obsolete Piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000127> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000127> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000127> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000128> (obsolete Piezotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000128> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000128> "obsolete Piezotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000128> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000128> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000128> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000129> (obsolete Piezosensitive)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000129> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000129> "obsolete Piezosensitive")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000129> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000129> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000129> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000130> (obsolete Obligate barophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000130> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000130> "obsolete Obligate barophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000130> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000130> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000130> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000131> (obsolete Facultative barophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000131> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000131> "obsolete Facultative barophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000131> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000131> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000131> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000132> (obsolete Hyperbarophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000132> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000132> "obsolete Hyperbarophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000132> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000132> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000132> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000133> (obsolete Hypobarophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000133> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000133> "obsolete Hypobarophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000133> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000133> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000133> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000134> (obsolete Atmospheric pressure-adapted)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000134> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000134> "obsolete Atmospheric pressure-adapted")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000134> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000134> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000134> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000135> (obsolete Moderate piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000135> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000135> "obsolete Moderate piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000135> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000135> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000135> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000136> (obsolete Extreme piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000136> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000136> "obsolete Extreme piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000136> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000136> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000136> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000137> (obsolete Stenopiezic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000137> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000137> "obsolete Stenopiezic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000137> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000137> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000137> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000138> (obsolete Eurypiezic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000138> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000138> "obsolete Eurypiezic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000138> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000138> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000138> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000139> (obsolete Pressure-sensitive)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000139> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000139> "obsolete Pressure-sensitive")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000139> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000139> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000139> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000140> (obsolete Pressure-resistant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000140> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000140> "obsolete Pressure-resistant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000140> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000140> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000140> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000141> (obsolete Pressure-adapted)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000141> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000141> "obsolete Pressure-adapted")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000141> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000141> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000141> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000142> (obsolete Piezo-acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000142> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000142> "obsolete Piezo-acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000142> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000142> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000142> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000143> (obsolete Piezo-alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000143> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000143> "obsolete Piezo-alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000143> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000143> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000143> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000144> (obsolete Piezo-halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000144> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000144> "obsolete Piezo-halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000144> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000144> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000144> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000145> (obsolete Piezo-psychrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000145> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000145> "obsolete Piezo-psychrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000145> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000145> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000145> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000146> (obsolete Piezo-thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000146> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000146> "obsolete Piezo-thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000146> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000146> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000146> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000147> (obsolete Piezo-lithoautotrophe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000147> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000147> "obsolete Piezo-lithoautotrophe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000147> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000147> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000147> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000148> (obsolete Piezo-chemoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000148> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000148> "obsolete Piezo-chemoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000148> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000148> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000148> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000149> (obsolete Piezo-oligotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000149> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000149> "obsolete Piezo-oligotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000149> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000149> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000149> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000150> (obsolete Piezo-endolithic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000150> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000150> "obsolete Piezo-endolithic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000150> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000150> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000150> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000151> (obsolete Piezo-tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000151> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000151> "obsolete Piezo-tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000151> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000151> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000151> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000152> (obsolete GC% low ( < 42.65))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000152> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000152> "obsolete GC% low ( < 42.65)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000152> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000152> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000152> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000153> (obsolete GC% mid1 (42.65 - 57))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000153> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000153> "obsolete GC% mid1 (42.65 - 57)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000153> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000153> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000153> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000154> (obsolete GC% mid2 (57 - 66.3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000154> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000154> "obsolete GC% mid2 (57 - 66.3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000154> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000154> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000154> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000155> (obsolete GC% high ( > 66.3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000155> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000155> "obsolete GC% high ( > 66.3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000155> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000155> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000155> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000156> (obsolete Cell width uM very low (< 0.5))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000156> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000156> "obsolete Cell width uM very low (< 0.5)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000156> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000156> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000156> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000157> (obsolete Cell width uM low (0.5 - 0.65))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000157> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000157> "obsolete Cell width uM low (0.5 - 0.65)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000157> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000157> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000157> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000158> (obsolete Cell width uM mid (0.65 - 0.9))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000158> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000158> "obsolete Cell width uM mid (0.65 - 0.9)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000158> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000158> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000158> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000159> (obsolete Cell width uM high (> 0.9))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000159> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000159> "obsolete Cell width uM high (> 0.9)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000159> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000159> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000159> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000160> (obsolete Cell length uM very low (<= 1.3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000160> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000160> "obsolete Cell length uM very low (<= 1.3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000160> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000160> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000160> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000161> (obsolete Cell length uM low (1.3 - 2))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000161> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000161> "obsolete Cell length uM low (1.3 - 2)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000161> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000161> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000161> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000162> (obsolete Cell length uM mid (2 - 3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000162> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000162> "obsolete Cell length uM mid (2 - 3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000162> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000162> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000162> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000163> (obsolete Cell length uM high (> 3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000163> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000163> "obsolete Cell length uM high (> 3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000163> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000163> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000163> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000164> (obsolete Temperature Optimum C very low (<= 10))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000164> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000164> "obsolete Temperature Optimum C very low (<= 10)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000164> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000164> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000164> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000165> (obsolete Temperature Optimum C low (10 - 22))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000165> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000165> "obsolete Temperature Optimum C low (10 - 22)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000165> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000165> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000165> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000166> (obsolete Temperature Optimum C mid1 (22 - 27))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000166> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000166> "obsolete Temperature Optimum C mid1 (22 - 27)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000166> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000166> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000166> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000167> (obsolete Temperature Optimum C mid2 (27 - 30))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000167> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000167> "obsolete Temperature Optimum C mid2 (27 - 30)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000167> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000167> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000167> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000168> (obsolete Temperature Optimum C mid3 (30 - 34))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000168> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000168> "obsolete Temperature Optimum C mid3 (30 - 34)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000168> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000168> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000168> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000169> (obsolete Temperature Optimum C mid4 (34 - 40))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000169> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000169> "obsolete Temperature Optimum C mid4 (34 - 40)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000169> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000169> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000169> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000170> (obsolete Temperature Optimum C high (> 40))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000170> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000170> "obsolete Temperature Optimum C high (> 40)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000170> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000170> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000170> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000171> (obsolete Temperature Range C very low (<= 10))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000171> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000171> "obsolete Temperature Range C very low (<= 10)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000171> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000171> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000171> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000172> (obsolete Temperature Range C low (10 - 22))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000172> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000172> "obsolete Temperature Range C low (10 - 22)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000172> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000172> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000172> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000173> (obsolete Temperature Range C mid1 (22 - 27))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000173> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000173> "obsolete Temperature Range C mid1 (22 - 27)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000173> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000173> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000173> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000174> (obsolete Temperature Range C mid2 (27 - 30))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000174> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000174> "obsolete Temperature Range C mid2 (27 - 30)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000174> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000174> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000174> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000175> (obsolete Temperature Range C mid3 (30 - 34))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000175> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000175> "obsolete Temperature Range C mid3 (30 - 34)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000175> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000175> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000175> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000176> (obsolete Temperature Range C mid4 (34 - 40))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000176> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000176> "obsolete Temperature Range C mid4 (34 - 40)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000176> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000176> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000176> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000177> (obsolete Temperature Range C high (> 40))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000177> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000177> "obsolete Temperature Range C high (> 40)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000177> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000177> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000177> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000178> (obsolete pH Optimum low (0 - 6))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000178> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000178> "obsolete pH Optimum low (0 - 6)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000178> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000178> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000178> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000179> (obsolete pH Optimum mid1 (6 - 7))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000179> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000179> "obsolete pH Optimum mid1 (6 - 7)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000179> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000179> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000179> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000180> (obsolete pH Optimum mid2 (7 - 8))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000180> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000180> "obsolete pH Optimum mid2 (7 - 8)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000180> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000180> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000180> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000181> (obsolete pH Optimum high (8 - 14))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000181> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000181> "obsolete pH Optimum high (8 - 14)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000181> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000181> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000181> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000182> (obsolete pH Range very low (0 - 4))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000182> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000182> "obsolete pH Range very low (0 - 4)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000182> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000182> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000182> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000183> (obsolete pH Range low (4 - 6))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000183> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000183> "obsolete pH Range low (4 - 6)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000183> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000183> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000183> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000184> (obsolete pH Range mid1 (6 - 7))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000184> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000184> "obsolete pH Range mid1 (6 - 7)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000184> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000184> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000184> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000185> (obsolete pH Range mid2 (7 - 8))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000185> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000185> "obsolete pH Range mid2 (7 - 8)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000185> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000185> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000185> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000186> (obsolete pH Range mid3 (8 - 10))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000186> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000186> "obsolete pH Range mid3 (8 - 10)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000186> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000186> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000186> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000187> (obsolete pH Range high (10 - 14))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000187> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000187> "obsolete pH Range high (10 - 14)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000187> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000187> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000187> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000188> (obsolete % NaCl Optimum low (<= 1))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000188> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000188> "obsolete % NaCl Optimum low (<= 1)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000188> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000188> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000188> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000189> (obsolete % NaCl Optimum mid1 (1 - 3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000189> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000189> "obsolete % NaCl Optimum mid1 (1 - 3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000189> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000189> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000189> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000190> (obsolete % NaCl Optimum mid2 (3 - 8))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000190> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000190> "obsolete % NaCl Optimum mid2 (3 - 8)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000190> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000190> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000190> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000191> (obsolete % NaCl Optimum high (> 8))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000191> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000191> "obsolete % NaCl Optimum high (> 8)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000191> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000191> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000191> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000192> (obsolete % NaCl Range low (<= 1))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000192> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000192> "obsolete % NaCl Range low (<= 1)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000192> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000192> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000192> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000193> (obsolete % NaCl Range mid1 (1 - 3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000193> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000193> "obsolete % NaCl Range mid1 (1 - 3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000193> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000193> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000193> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000194> (obsolete % NaCl Range mid2 (3 - 8))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000194> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000194> "obsolete % NaCl Range mid2 (3 - 8)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000194> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000194> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000194> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000195> (obsolete % NaCl Range high (> 8))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000195> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000195> "obsolete % NaCl Range high (> 8)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000195> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000195> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000195> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000196> (obsolete pH delta very low (<= 1))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000196> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000196> "obsolete pH delta very low (<= 1)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000196> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000196> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000196> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000197> (obsolete pH delta low (1 - 2))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000197> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000197> "obsolete pH delta low (1 - 2)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000197> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000197> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000197> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000198> (obsolete pH delta mid1 (2 - 3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000198> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000198> "obsolete pH delta mid1 (2 - 3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000198> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000198> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000198> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000199> (obsolete pH delta mid2 (3 - 4))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000199> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000199> "obsolete pH delta mid2 (3 - 4)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000199> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000199> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000199> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000200> (obsolete pH delta mid3 (4 - 5))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000200> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000200> "obsolete pH delta mid3 (4 - 5)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000200> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000200> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000200> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000201> (obsolete pH delta high (5 - 9))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000201> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000201> "obsolete pH delta high (5 - 9)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000201> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000201> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000201> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000202> (obsolete % NaCl delta low (<= 1))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000202> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000202> "obsolete % NaCl delta low (<= 1)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000202> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000202> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000202> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000203> (obsolete % NaCl delta mid2 (1 - 3))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000203> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000203> "obsolete % NaCl delta mid2 (1 - 3)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000203> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000203> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000203> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000204> (obsolete % NaCl delta mid2 (3 - 8))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000204> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000204> "obsolete % NaCl delta mid2 (3 - 8)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000204> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000204> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000204> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000205> (obsolete % NaCl delta high (>= 8))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000205> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000205> "obsolete % NaCl delta high (>= 8)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000205> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000205> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000205> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000206> (obsolete Temperature C delta very low (1 - 5))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000206> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000206> "obsolete Temperature C delta very low (1 - 5)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000206> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000206> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000206> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000207> (obsolete Temperature C delta low (5 - 10))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000207> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000207> "obsolete Temperature C delta low (5 - 10)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000207> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000207> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000207> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000208> (obsolete Temperature C delta mid1 (10 - 20))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000208> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000208> "obsolete Temperature C delta mid1 (10 - 20)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000208> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000208> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000208> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000209> (obsolete Temperature C delta mid2 (20 - 30))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000209> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000209> "obsolete Temperature C delta mid2 (20 - 30)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000209> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000209> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000209> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000210> (obsolete Temperature C delta high (>= 30))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000210> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000210> "obsolete Temperature C delta high (>= 30)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000210> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000210> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000210> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000211> (obsolete bacillus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000211> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000211> "obsolete bacillus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000211> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000211> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000211> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000212> (obsolete branced)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000212> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000212> "obsolete branced")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000212> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000212> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000212> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000213> (obsolete coccobacillus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000213> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000213> "obsolete coccobacillus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000213> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000213> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000213> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000214> (obsolete coccus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000214> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000214> "obsolete coccus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000214> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000214> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000214> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000215> (obsolete crescent)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000215> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000215> "obsolete crescent")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000215> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000215> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000215> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000216> (obsolete curved)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000216> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000216> "obsolete curved")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000216> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000216> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000216> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000217> (obsolete curved spiral)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000217> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000217> "obsolete curved spiral")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000217> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000217> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000217> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000218> (obsolete diplococcus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000218> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000218> "obsolete diplococcus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000218> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000218> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000218> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000219> (obsolete disc)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000219> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000219> "obsolete disc")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000219> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000219> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000219> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000220> (obsolete dumbbell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000220> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000220> "obsolete dumbbell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000220> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000220> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000220> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000221> (obsolete ellipsoidal)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000221> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000221> "obsolete ellipsoidal")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000221> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000221> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000221> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000222> (obsolete filament)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000222> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000222> "obsolete filament")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000222> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000222> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000222> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000223> (obsolete flask)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000223> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000223> "obsolete flask")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000223> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000223> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000223> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000224> (obsolete fusiform)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000224> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000224> "obsolete fusiform")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000224> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000224> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000224> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000225> (obsolete helical)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000225> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000225> "obsolete helical")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000225> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000225> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000225> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000226> (obsolete irregular)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000226> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000226> "obsolete irregular")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000226> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000226> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000226> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000227> (obsolete oval)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000227> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000227> "obsolete oval")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000227> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000227> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000227> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000228> (obsolete ovoid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000228> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000228> "obsolete ovoid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000228> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000228> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000228> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000229> (obsolete pleomorphic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000229> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000229> "obsolete pleomorphic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000229> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000229> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000229> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000230> (obsolete ring)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000230> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000230> "obsolete ring")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000230> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000230> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000230> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000231> (obsolete rod)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000231> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000231> "obsolete rod")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000231> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000231> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000231> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000232> (obsolete sphere)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000232> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000232> "obsolete sphere")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000232> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000232> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000232> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000233> (obsolete spindle)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000233> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000233> "obsolete spindle")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000233> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000233> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000233> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000234> (obsolete spiral)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000234> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000234> "obsolete spiral")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000234> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000234> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000234> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000235> (obsolete spirochete)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000235> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000235> "obsolete spirochete")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000235> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000235> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000235> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000236> (obsolete spore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000236> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000236> "obsolete spore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000236> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000236> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000236> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000237> (obsolete square)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000237> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000237> "obsolete square")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000237> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000237> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000237> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000238> (obsolete star)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000238> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000238> "obsolete star")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000238> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000238> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000238> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000239> (obsolete star - dumbbell - pleomorphic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000239> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000239> "obsolete star - dumbbell - pleomorphic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000239> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000239> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000239> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000240> (obsolete tailed)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000240> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000240> "obsolete tailed")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000240> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000240> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000240> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000241> (obsolete triangular)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000241> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000241> "obsolete triangular")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000241> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000241> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000241> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000242> (obsolete vibrio)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000242> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000242> "obsolete vibrio")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000242> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000242> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000242> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000243> (obsolete Environmental Parameter)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000243> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000243> "obsolete Environmental Parameter")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000243> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000243> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000243> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000244> (obsolete Growth Condition)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000244> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000244> "obsolete Growth Condition")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000244> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000244> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000244> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000245> (obsolete Physiological Trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000245> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000245> "obsolete Physiological Trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000245> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000245> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000245> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000246> (obsolete Metabolic Classification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000246> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000246> "obsolete Metabolic Classification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000246> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000246> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000246> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000247> (obsolete Cellular Characteristic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000247> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000247> "obsolete Cellular Characteristic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000247> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000247> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000247> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000248> (obsolete Taxonomic Feature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000248> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000248> "obsolete Taxonomic Feature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000248> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000248> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000248> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000249> (obsolete Microbial Adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000249> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000249> "obsolete Microbial Adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000249> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000249> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000249> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000250> (obsolete Growth Parameter)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000250> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000250> "obsolete Growth Parameter")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000250> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000250> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000250> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000251> (obsolete Structural Feature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000251> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000251> "obsolete Structural Feature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000251> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000251> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000251> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000252> (obsolete Temperature Adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000252> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000252> "obsolete Temperature Adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000252> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000252> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000252> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000253> (obsolete Salinity Adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000253> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000253> "obsolete Salinity Adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000253> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000253> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000253> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000254> (obsolete pH Adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000254> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000254> "obsolete pH Adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000254> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000254> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000254> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000255> (obsolete Oxygen Requirement)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000255> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000255> "obsolete Oxygen Requirement")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000255> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000255> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000255> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000256> (obsolete Carbon Source Utilization)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000256> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000256> "obsolete Carbon Source Utilization")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000256> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000256> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000256> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000257> (obsolete Energy Acquisition Mode)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000257> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000257> "obsolete Energy Acquisition Mode")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000257> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000257> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000257> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000258> (obsolete Electron Donor Type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000258> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000258> "obsolete Electron Donor Type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000258> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000258> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000258> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000259> (obsolete Motility Mechanism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000259> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000259> "obsolete Motility Mechanism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000259> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000259> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000259> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000260> (obsolete Motility Structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000260> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000260> "obsolete Motility Structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000260> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000260> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000260> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000261> (obsolete Bacterial Spore Type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000261> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000261> "obsolete Bacterial Spore Type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000261> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000261> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000261> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000262> (obsolete Fungal Spore Type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000262> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000262> "obsolete Fungal Spore Type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000262> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000262> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000262> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000263> (obsolete Reproductive Structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000263> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000263> "obsolete Reproductive Structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000263> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000263> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000263> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000264> (obsolete Dormancy Structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000264> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000264> "obsolete Dormancy Structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000264> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000264> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000264> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000265> (obsolete Pressure Adaptation Type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000265> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000265> "obsolete Pressure Adaptation Type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000265> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000265> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000265> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000266> (obsolete Pressure Tolerance Range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000266> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000266> "obsolete Pressure Tolerance Range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000266> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000266> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000266> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000267> (obsolete GenomicFeature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000267> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000267> "obsolete GenomicFeature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000267> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000267> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000267> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000268> (obsolete Cell Dimension)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000268> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000268> "obsolete Cell Dimension")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000268> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000268> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000268> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000269> (obsolete Optimal Growth Parameter)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000269> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000269> "obsolete Optimal Growth Parameter")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000269> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000269> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000269> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000270> (obsolete Growth Range Parameter)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000270> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000270> "obsolete Growth Range Parameter")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000270> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000270> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000270> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000271> (obsolete Growth Tolerance Metric)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000271> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000271> "obsolete Growth Tolerance Metric")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000271> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000271> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000271> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000272> (obsolete Cell Shape)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000272> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000272> "obsolete Cell Shape")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000272> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000272> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000272> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000273> (obsolete Cell Arrangement)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000273> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000273> "obsolete Cell Arrangement")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000273> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000273> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000273> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/000274> (obsolete Colony Morphology)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/000274> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/000274> "obsolete Colony Morphology")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000274> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/000274> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/000274> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000001> (obsolete acid-fast)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000001> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000001> "obsolete acid-fast")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000001> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000001> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000001> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000002> (obsolete acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000002> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000002> "obsolete acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000002> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000002> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000002> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000003> (obsolete active transport)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000003> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000003> "obsolete active transport")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000003> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000003> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000003> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000004> (obsolete adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000004> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000004> "obsolete adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000004> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000004> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000004> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000005> (obsolete adaptive trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000005> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000005> "obsolete adaptive trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000005> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000005> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000005> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000006> (obsolete adhesin)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000006> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000006> "obsolete adhesin")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000006> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000006> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000006> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000007> (obsolete adhesion structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000007> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000007> "obsolete adhesion structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000007> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000007> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000007> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000008> (obsolete aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000008> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000008> "obsolete aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000008> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000008> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000008> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000009> (obsolete aerobic respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000009> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000009> "obsolete aerobic respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000009> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000009> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000009> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000010> (obsolete aerotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000010> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000010> "obsolete aerotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000010> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000010> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000010> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000011> (obsolete aggregate)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000011> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000011> "obsolete aggregate")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000011> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000011> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000011> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000012> (obsolete akinete)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000012> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000012> "obsolete akinete")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000012> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000012> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000012> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000013> (obsolete alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000013> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000013> "obsolete alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000013> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000013> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000013> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000014> (obsolete ammonification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000014> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000014> "obsolete ammonification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000014> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000014> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000014> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000015> (obsolete amylolysis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000015> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000015> "obsolete amylolysis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000015> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000015> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000015> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000016> (obsolete anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000016> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000016> "obsolete anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000016> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000016> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000016> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000017> (obsolete anaerobic respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000017> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000017> "obsolete anaerobic respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000017> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000017> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000017> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000018> (obsolete anoxygenic photosynthesis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000018> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000018> "obsolete anoxygenic photosynthesis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000018> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000018> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000018> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000019> (obsolete antibiotic production)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000019> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000019> "obsolete antibiotic production")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000019> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000019> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000019> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000020> (obsolete antibiotic resistance)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000020> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000020> "obsolete antibiotic resistance")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000020> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000020> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000020> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000021> (obsolete antimicrobial resistance)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000021> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000021> "obsolete antimicrobial resistance")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000021> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000021> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000021> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000022> (obsolete appendage)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000022> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000022> "obsolete appendage")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000022> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000022> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000022> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000023> (obsolete arthrospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000023> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000023> "obsolete arthrospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000023> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000023> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000023> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000024> (obsolete ascospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000024> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000024> "obsolete ascospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000024> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000024> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000024> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000025> (obsolete autotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000025> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000025> "obsolete autotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000025> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000025> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000025> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000026> (obsolete autotrophic process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000026> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000026> "obsolete autotrophic process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000026> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000026> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000026> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000027> (obsolete auxotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000027> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000027> "obsolete auxotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000027> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000027> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000027> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000028> (obsolete axial filament)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000028> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000028> "obsolete axial filament")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000028> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000028> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000028> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000029> (obsolete bacillus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000029> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000029> "obsolete bacillus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000029> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000029> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000029> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000030> (obsolete barophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000030> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000030> "obsolete barophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000030> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000030> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000030> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000031> (obsolete barotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000031> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000031> "obsolete barotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000031> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000031> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000031> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000032> (obsolete basidiospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000032> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000032> "obsolete basidiospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000032> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000032> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000032> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000033> (obsolete binary fission)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000033> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000033> "obsolete binary fission")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000033> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000033> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000033> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000034> (obsolete biofilm)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000034> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000034> "obsolete biofilm")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000034> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000034> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000034> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000035> (obsolete biofilm component)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000035> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000035> "obsolete biofilm component")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000035> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000035> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000035> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000036> (obsolete biofilm formation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000036> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000036> "obsolete biofilm formation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000036> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000036> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000036> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000037> (obsolete biogeochemical cycling)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000037> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000037> "obsolete biogeochemical cycling")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000037> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000037> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000037> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000038> (obsolete bioluminescence)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000038> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000038> "obsolete bioluminescence")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000038> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000038> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000038> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000039> (obsolete budding)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000039> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000039> "obsolete budding")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000039> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000039> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000039> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000040> (obsolete buoyancy structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000040> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000040> "obsolete buoyancy structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000040> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000040> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000040> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000041> (obsolete capnophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000041> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000041> "obsolete capnophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000041> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000041> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000041> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000042> (obsolete capsule)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000042> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000042> "obsolete capsule")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000042> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000042> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000042> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000043> (obsolete carbon fixation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000043> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000043> "obsolete carbon fixation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000043> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000043> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000043> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000044> (obsolete carbon source)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000044> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000044> "obsolete carbon source")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000044> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000044> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000044> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000045> (obsolete carboxydotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000045> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000045> "obsolete carboxydotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000045> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000045> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000045> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000046> (obsolete cell arrangement)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000046> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000046> "obsolete cell arrangement")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000046> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000046> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000046> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000047> (obsolete cell envelope)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000047> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000047> "obsolete cell envelope")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000047> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000047> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000047> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000048> (obsolete cell length category)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000048> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000048> "obsolete cell length category")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000048> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000048> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000048> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000049> (obsolete cell shape)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000049> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000049> "obsolete cell shape")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000049> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000049> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000049> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000050> (obsolete cell size)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000050> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000050> "obsolete cell size")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000050> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000050> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000050> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000051> (obsolete cell wall characteristic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000051> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000051> "obsolete cell wall characteristic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000051> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000051> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000051> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000052> (obsolete cell wall component)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000052> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000052> "obsolete cell wall component")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000052> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000052> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000052> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000053> (obsolete cell width category)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000053> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000053> "obsolete cell width category")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000053> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000053> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000053> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000054> (obsolete cellular characteristic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000054> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000054> "obsolete cellular characteristic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000054> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000054> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000054> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000055> (obsolete cellular component)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000055> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000055> "obsolete cellular component")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000055> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000055> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000055> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000056> (obsolete cellular process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000056> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000056> "obsolete cellular process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000056> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000056> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000056> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000057> (obsolete cellular product)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000057> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000057> "obsolete cellular product")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000057> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000057> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000057> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000058> (obsolete cellulolysis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000058> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000058> "obsolete cellulolysis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000058> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000058> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000058> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000059> (phenotype)
@@ -7190,462 +7190,462 @@ SubClassOf(<https://w3id.org/metpo/1000060> <https://w3id.org/metpo/1000630>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000061> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000061> "obsolete chemoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000061> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000061> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000061> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000062> (obsolete chemotaxis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000062> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000062> "obsolete chemotaxis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000062> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000062> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000062> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000063> (obsolete chlamydospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000063> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000063> "obsolete chlamydospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000063> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000063> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000063> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000064> (obsolete class)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000064> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000064> "obsolete class")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000064> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000064> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000064> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000065> (obsolete clinically relevant feature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000065> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000065> "obsolete clinically relevant feature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000065> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000065> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000065> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000066> (obsolete coccus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000066> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000066> "obsolete coccus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000066> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000066> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000066> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000067> (obsolete cold shock protein)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000067> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000067> "obsolete cold shock protein")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000067> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000067> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000067> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000068> (obsolete cold shock response)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000068> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000068> "obsolete cold shock response")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000068> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000068> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000068> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000069> (obsolete colonization)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000069> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000069> "obsolete colonization")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000069> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000069> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000069> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000070> (obsolete colony elevation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000070> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000070> "obsolete colony elevation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000070> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000070> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000070> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000071> (obsolete colony margin)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000071> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000071> "obsolete colony margin")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000071> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000071> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000071> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000072> (obsolete colony morphology)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000072> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000072> "obsolete colony morphology")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000072> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000072> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000072> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000073> (obsolete colony texture)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000073> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000073> "obsolete colony texture")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000073> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000073> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000073> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000074> (obsolete commensalism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000074> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000074> "obsolete commensalism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000074> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000074> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000074> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000075> (obsolete community behavior)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000075> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000075> "obsolete community behavior")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000075> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000075> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000075> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000076> (obsolete community structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000076> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000076> "obsolete community structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000076> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000076> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000076> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000077> (obsolete compatible solute)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000077> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000077> "obsolete compatible solute")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000077> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000077> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000077> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000078> (obsolete competence)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000078> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000078> "obsolete competence")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000078> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000078> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000078> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000079> (obsolete component)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000079> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000079> "obsolete component")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000079> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000079> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000079> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000080> (obsolete conidium)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000080> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000080> "obsolete conidium")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000080> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000080> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000080> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000081> (obsolete conjugation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000081> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000081> "obsolete conjugation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000081> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000081> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000081> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000082> (obsolete CRISPR)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000082> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000082> "obsolete CRISPR")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000082> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000082> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000082> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000083> (obsolete culturability)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000083> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000083> "obsolete culturability")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000083> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000083> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000083> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000084> (obsolete cyst)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000084> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000084> "obsolete cyst")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000084> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000084> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000084> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000085> (obsolete death phase)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000085> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000085> "obsolete death phase")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000085> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000085> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000085> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000086> (obsolete denitrification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000086> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000086> "obsolete denitrification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000086> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000086> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000086> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000087> (obsolete developmental process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000087> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000087> "obsolete developmental process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000087> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000087> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000087> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000088> (obsolete diagnostic enzyme)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000088> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000088> "obsolete diagnostic enzyme")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000088> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000088> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000088> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000089> (obsolete diagnostic feature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000089> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000089> "obsolete diagnostic feature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000089> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000089> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000089> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000090> (obsolete diazotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000090> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000090> "obsolete diazotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000090> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000090> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000090> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000091> (obsolete differentiation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000091> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000091> "obsolete differentiation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000091> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000091> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000091> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000092> (obsolete dimorphism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000092> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000092> "obsolete dimorphism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000092> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000092> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000092> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000093> (obsolete disc-shaped cell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000093> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000093> "obsolete disc-shaped cell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000093> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000093> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000093> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000094> (obsolete domain)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000094> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000094> "obsolete domain")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000094> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000094> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000094> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000095> (obsolete dormancy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000095> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000095> "obsolete dormancy")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000095> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000095> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000095> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000096> (obsolete dormancy structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000096> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000096> "obsolete dormancy structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000096> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000096> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000096> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000097> (obsolete dumbbell-shaped cell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000097> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000097> "obsolete dumbbell-shaped cell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000097> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000097> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000097> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000098> (obsolete ecological niche)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000098> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000098> "obsolete ecological niche")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000098> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000098> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000098> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000099> (obsolete ecological process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000099> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000099> "obsolete ecological process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000099> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000099> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000099> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000100> (obsolete ecological trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000100> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000100> "obsolete ecological trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000100> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000100> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000100> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000101> (obsolete ectosymbiosis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000101> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000101> "obsolete ectosymbiosis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000101> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000101> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000101> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000102> (obsolete electron acceptor)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000102> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000102> "obsolete electron acceptor")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000102> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000102> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000102> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000103> (obsolete electron donor)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000103> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000103> "obsolete electron donor")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000103> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000103> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000103> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000104> (obsolete endospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000104> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000104> "obsolete endospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000104> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000104> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000104> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000105> (obsolete endosymbiosis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000105> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000105> "obsolete endosymbiosis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000105> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000105> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000105> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000106> (obsolete energy metabolism process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000106> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000106> "obsolete energy metabolism process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000106> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000106> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000106> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000107> (obsolete enzyme activity)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000107> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000107> "obsolete enzyme activity")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000107> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000107> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000107> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000108> (obsolete epigenetic modification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000108> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000108> "obsolete epigenetic modification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000108> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000108> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000108> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000109> (obsolete evolutionary process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000109> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000109> "obsolete evolutionary process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000109> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000109> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000109> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000110> (obsolete exospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000110> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000110> "obsolete exospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000110> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000110> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000110> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000111> (obsolete exponential phase)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000111> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000111> "obsolete exponential phase")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000111> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000111> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000111> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000112> (obsolete extracellular)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000112> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000112> "obsolete extracellular")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000112> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000112> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000112> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000113> (obsolete extracellular polysaccharide)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000113> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000113> "obsolete extracellular polysaccharide")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000113> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000113> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000113> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000114> (obsolete extreme halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000114> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000114> "obsolete extreme halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000114> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000114> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000114> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000115> (obsolete extremophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000115> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000115> "obsolete extremophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000115> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000115> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000115> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000116> (obsolete facultative)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000116> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000116> "obsolete facultative")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000116> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000116> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000116> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000117> (obsolete facultative anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000117> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000117> "obsolete facultative anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000117> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000117> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000117> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000118> (obsolete family)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000118> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000118> "obsolete family")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000118> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000118> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000118> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000119> (obsolete fastidious)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000119> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000119> "obsolete fastidious")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000119> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000119> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000119> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000120> (obsolete fermentation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000120> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000120> "obsolete fermentation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000120> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000120> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000120> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000121> (obsolete filamentous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000121> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000121> "obsolete filamentous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000121> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000121> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000121> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000122> (obsolete fimbriae)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000122> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000122> "obsolete fimbriae")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000122> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000122> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000122> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000123> (obsolete flagellum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000123> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000123> "obsolete flagellum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000123> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000123> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000123> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000124> (obsolete flask-shaped cell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000124> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000124> "obsolete flask-shaped cell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000124> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000124> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000124> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000125> (obsolete fungal spore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000125> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000125> "obsolete fungal spore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000125> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000125> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000125> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000126> (obsolete gas vesicle)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000126> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000126> "obsolete gas vesicle")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000126> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000126> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000126> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000127> (GC content)
@@ -7660,406 +7660,406 @@ SubClassOf(<https://w3id.org/metpo/1000127> <https://w3id.org/metpo/1000188>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000128> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000128> "obsolete high GC content")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000128> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000128> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000128> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000129> (obsolete low GC content)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000129> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000129> "obsolete low GC content")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000129> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000129> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000129> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000130> (obsolete lower-mid GC content)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000130> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000130> "obsolete lower-mid GC content")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000130> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000130> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000130> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000131> (obsolete upper-mid GC content)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000131> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000131> "obsolete upper-mid GC content")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000131> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000131> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000131> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000132> (obsolete generation time)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000132> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000132> "obsolete generation time")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000132> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000132> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000132> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000133> (obsolete genetic element)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000133> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000133> "obsolete genetic element")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000133> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000133> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000133> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000134> (obsolete genetic exchange)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000134> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000134> "obsolete genetic exchange")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000134> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000134> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000134> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000135> (obsolete genetic process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000135> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000135> "obsolete genetic process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000135> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000135> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000135> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000136> (obsolete genome size)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000136> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000136> "obsolete genome size")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000136> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000136> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000136> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000137> (obsolete genomic element)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000137> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000137> "obsolete genomic element")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000137> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000137> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000137> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000138> (obsolete genomic island)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000138> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000138> "obsolete genomic island")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000138> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000138> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000138> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000139> (obsolete genomic trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000139> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000139> "obsolete genomic trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000139> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000139> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000139> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000140> (obsolete genus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000140> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000140> "obsolete genus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000140> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000140> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000140> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000141> (obsolete gliding motility)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000141> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000141> "obsolete gliding motility")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000141> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000141> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000141> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000142> (obsolete global regulator)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000142> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000142> "obsolete global regulator")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000142> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000142> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000142> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000143> (obsolete Gram-negative)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000143> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000143> "obsolete Gram-negative")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000143> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000143> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000143> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000144> (obsolete Gram-positive)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000144> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000144> "obsolete Gram-positive")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000144> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000144> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000144> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000145> (obsolete Gram stain)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000145> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000145> "obsolete Gram stain")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000145> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000145> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000145> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000146> (obsolete growth characteristic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000146> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000146> "obsolete growth characteristic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000146> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000146> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000146> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000147> (obsolete growth conditions constraints)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000147> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000147> "obsolete growth conditions constraints")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000147> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000147> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000147> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000148> (obsolete growth pattern)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000148> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000148> "obsolete growth pattern")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000148> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000148> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000148> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000149> (obsolete growth rate)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000149> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000149> "obsolete growth rate")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000149> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000149> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000149> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000150> (obsolete habitat)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000150> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000150> "obsolete habitat")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000150> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000150> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000150> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000151> (obsolete halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000151> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000151> "obsolete halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000151> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000151> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000151> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000152> (obsolete halotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000152> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000152> "obsolete halotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000152> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000152> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000152> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000153> (obsolete heat shock protein)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000153> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000153> "obsolete heat shock protein")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000153> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000153> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000153> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000154> (obsolete heat shock response)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000154> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000154> "obsolete heat shock response")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000154> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000154> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000154> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000155> (obsolete hemolysis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000155> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000155> "obsolete hemolysis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000155> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000155> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000155> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000156> (obsolete heterocyst)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000156> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000156> "obsolete heterocyst")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000156> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000156> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000156> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000157> (obsolete heterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000157> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000157> "obsolete heterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000157> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000157> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000157> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000158> (obsolete holdfast)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000158> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000158> "obsolete holdfast")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000158> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000158> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000158> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000159> (obsolete horizontal gene transfer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000159> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000159> "obsolete horizontal gene transfer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000159> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000159> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000159> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000160> (obsolete hydrolase)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000160> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000160> "obsolete hydrolase")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000160> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000160> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000160> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000161> (obsolete hyperthermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000161> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000161> "obsolete hyperthermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000161> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000161> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000161> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000162> (obsolete inclusion body)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000162> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000162> "obsolete inclusion body")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000162> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000162> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000162> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000163> (obsolete infection)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000163> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000163> "obsolete infection")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000163> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000163> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000163> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000164> (obsolete interaction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000164> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000164> "obsolete interaction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000164> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000164> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000164> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000165> (obsolete interaction with a phage)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000165> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000165> "obsolete interaction with a phage")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000165> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000165> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000165> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000166> (obsolete interaction with an environment)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000166> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000166> "obsolete interaction with an environment")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000166> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000166> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000166> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000167> (obsolete interaction with host)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000167> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000167> "obsolete interaction with host")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000167> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000167> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000167> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000168> (obsolete interaction within a community)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000168> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000168> "obsolete interaction within a community")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000168> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000168> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000168> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000169> (obsolete intracellular)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000169> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000169> "obsolete intracellular")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000169> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000169> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000169> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000170> (obsolete invasion)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000170> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000170> "obsolete invasion")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000170> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000170> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000170> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000171> (obsolete laboratory characteristic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000171> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000171> "obsolete laboratory characteristic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000171> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000171> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000171> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000172> (obsolete lag phase)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000172> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000172> "obsolete lag phase")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000172> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000172> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000172> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000173> (obsolete life cycle)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000173> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000173> "obsolete life cycle")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000173> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000173> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000173> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000174> (obsolete life cycle phase)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000174> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000174> "obsolete life cycle phase")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000174> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000174> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000174> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000175> (obsolete lipolysis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000175> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000175> "obsolete lipolysis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000175> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000175> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000175> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000176> (obsolete lipopolysaccharide)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000176> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000176> "obsolete lipopolysaccharide")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000176> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000176> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000176> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000177> (obsolete localization)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000177> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000177> "obsolete localization")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000177> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000177> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000177> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000178> (obsolete lysogeny)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000178> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000178> "obsolete lysogeny")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000178> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000178> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000178> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000179> (obsolete macroscopic trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000179> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000179> "obsolete macroscopic trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000179> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000179> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000179> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000180> (obsolete magnetotaxis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000180> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000180> "obsolete magnetotaxis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000180> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000180> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000180> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000181> (obsolete mesophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000181> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000181> "obsolete mesophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000181> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000181> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000181> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000182> (obsolete metabolic partner)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000182> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000182> "obsolete metabolic partner")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000182> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000182> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000182> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000183> (obsolete metabolic trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000183> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000183> "obsolete metabolic trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000183> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000183> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000183> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000184> (obsolete methanogenesis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000184> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000184> "obsolete methanogenesis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000184> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000184> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000184> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000185> (obsolete methylation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000185> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000185> "obsolete methylation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000185> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000185> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000185> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000186> (material entity)
@@ -8072,7 +8072,7 @@ AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000186> "material entity
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000187> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000187> "obsolete process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000187> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000187> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000187> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000188> (quality)
@@ -8084,301 +8084,301 @@ AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000188> "quality")
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000189> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000189> "obsolete system")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000189> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000189> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000189> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000190> (obsolete microaerophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000190> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000190> "obsolete microaerophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000190> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000190> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000190> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000191> (obsolete mobile genetic element)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000191> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000191> "obsolete mobile genetic element")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000191> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000191> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000191> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000192> (obsolete moderate halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000192> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000192> "obsolete moderate halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000192> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000192> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000192> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000193> (obsolete morphological trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000193> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000193> "obsolete morphological trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000193> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000193> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000193> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000194> (obsolete motility process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000194> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000194> "obsolete motility process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000194> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000194> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000194> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000195> (obsolete motility structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000195> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000195> "obsolete motility structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000195> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000195> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000195> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000196> (obsolete mutualism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000196> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000196> "obsolete mutualism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000196> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000196> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000196> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000197> (obsolete mycolic acid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000197> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000197> "obsolete mycolic acid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000197> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000197> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000197> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000198> (obsolete mycorrhization)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000198> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000198> "obsolete mycorrhization")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000198> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000198> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000198> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000199> (obsolete neutrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000199> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000199> "obsolete neutrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000199> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000199> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000199> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000200> (obsolete nitrification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000200> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000200> "obsolete nitrification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000200> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000200> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000200> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000201> (obsolete nitrogen fixation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000201> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000201> "obsolete nitrogen fixation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000201> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000201> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000201> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000202> (obsolete nodulation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000202> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000202> "obsolete nodulation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000202> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000202> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000202> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000203> (obsolete nucleoid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000203> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000203> "obsolete nucleoid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000203> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000203> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000203> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000204> (obsolete nutrient utilization)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000204> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000204> "obsolete nutrient utilization")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000204> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000204> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000204> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000205> (obsolete obligate)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000205> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000205> "obsolete obligate")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000205> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000205> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000205> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000206> (obsolete obligate aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000206> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000206> "obsolete obligate aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000206> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000206> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000206> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000207> (obsolete obligate anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000207> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000207> "obsolete obligate anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000207> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000207> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000207> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000208> (obsolete oospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000208> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000208> "obsolete oospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000208> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000208> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000208> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000209> (obsolete order)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000209> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000209> "obsolete order")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000209> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000209> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000209> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000210> (obsolete microbe characterized by growth conditions)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000210> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000210> "obsolete microbe characterized by growth conditions")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000210> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000210> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000210> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000211> (obsolete microbe characterized by nutritional requirement)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000211> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000211> "obsolete microbe characterized by nutritional requirement")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000211> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000211> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000211> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000212> (obsolete microbe characterized by product produced)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000212> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000212> "obsolete microbe characterized by product produced")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000212> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000212> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000212> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000213> (obsolete microbe characterized by relation to oxygen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000213> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000213> "obsolete microbe characterized by relation to oxygen")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000213> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000213> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000213> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000214> (obsolete microbe characterized by relation to ph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000214> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000214> "obsolete microbe characterized by relation to ph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000214> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000214> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000214> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000215> (obsolete microbe characterized by relation to pressure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000215> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000215> "obsolete microbe characterized by relation to pressure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000215> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000215> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000215> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000216> (obsolete microbe characterized by relation to salt concentration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000216> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000216> "obsolete microbe characterized by relation to salt concentration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000216> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000216> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000216> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000217> (obsolete microbe characterized by relation to temperature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000217> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000217> "obsolete microbe characterized by relation to temperature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000217> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000217> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000217> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000218> (obsolete microbe characterized by shape)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000218> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000218> "obsolete microbe characterized by shape")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000218> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000218> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000218> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000219> (obsolete microbe characterized by trophic type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000219> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000219> "obsolete microbe characterized by trophic type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000219> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000219> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000219> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000220> (obsolete osmophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000220> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000220> "obsolete osmophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000220> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000220> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000220> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000221> (obsolete osmoregulation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000221> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000221> "obsolete osmoregulation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000221> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000221> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000221> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000222> (obsolete oxidative stress response)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000222> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000222> "obsolete oxidative stress response")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000222> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000222> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000222> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000223> (obsolete oxidoreductase)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000223> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000223> "obsolete oxidoreductase")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000223> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000223> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000223> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000224> (obsolete oxygen requirement)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000224> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000224> "obsolete oxygen requirement")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000224> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000224> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000224> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000225> (obsolete oxygenic photosynthesis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000225> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000225> "obsolete oxygenic photosynthesis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000225> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000225> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000225> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000226> (obsolete pan-genome)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000226> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000226> "obsolete pan-genome")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000226> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000226> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000226> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000227> (obsolete parasitism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000227> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000227> "obsolete parasitism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000227> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000227> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000227> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000228> (obsolete passive transport)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000228> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000228> "obsolete passive transport")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000228> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000228> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000228> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000229> (obsolete pathogenicity)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000229> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000229> "obsolete pathogenicity")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000229> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000229> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000229> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000230> (obsolete pathogenicity island)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000230> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000230> "obsolete pathogenicity island")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000230> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000230> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000230> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000231> (obsolete peptidoglycan)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000231> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000231> "obsolete peptidoglycan")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000231> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000231> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000231> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000232> (pH delta)
@@ -8391,490 +8391,490 @@ SubClassOf(<https://w3id.org/metpo/1000232> <https://w3id.org/metpo/1000534>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000233> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000233> "obsolete pH optimum (growth range)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000233> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000233> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000233> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000234> (obsolete pH preference)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000234> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000234> "obsolete pH preference")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000234> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000234> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000234> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000235> (obsolete pH range (growth tolerance))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000235> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000235> "obsolete pH range (growth tolerance)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000235> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000235> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000235> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000236> (obsolete pH tolerance)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000236> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000236> "obsolete pH tolerance")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000236> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000236> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000236> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000237> (obsolete phage defense)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000237> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000237> "obsolete phage defense")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000237> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000237> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000237> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000238> (obsolete photoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000238> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000238> "obsolete photoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000238> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000238> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000238> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000239> (obsolete photoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000239> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000239> "obsolete photoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000239> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000239> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000239> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000240> (obsolete photosynthesis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000240> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000240> "obsolete photosynthesis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000240> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000240> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000240> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000241> (obsolete phototaxis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000241> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000241> "obsolete phototaxis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000241> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000241> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000241> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000242> (obsolete phylum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000242> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000242> "obsolete phylum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000242> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000242> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000242> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000243> (obsolete physiological process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000243> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000243> "obsolete physiological process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000243> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000243> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000243> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000244> (obsolete physiological state)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000244> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000244> "obsolete physiological state")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000244> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000244> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000244> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000245> (obsolete physiological trait)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000245> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000245> "obsolete physiological trait")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000245> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000245> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000245> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000246> (obsolete piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000246> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000246> "obsolete piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000246> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000246> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000246> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000247> (obsolete pigment)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000247> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000247> "obsolete pigment")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000247> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000247> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000247> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000248> (obsolete pigmentation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000248> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000248> "obsolete pigmentation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000248> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000248> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000248> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000249> (obsolete pilus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000249> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000249> "obsolete pilus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000249> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000249> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000249> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000250> (obsolete plant growth promotion)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000250> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000250> "obsolete plant growth promotion")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000250> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000250> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000250> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000251> (obsolete plasmid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000251> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000251> "obsolete plasmid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000251> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000251> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000251> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000252> (obsolete pleomorphism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000252> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000252> "obsolete pleomorphism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000252> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000252> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000252> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000253> (obsolete process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000253> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000253> "obsolete process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000253> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000253> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000253> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000254> (obsolete prophage)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000254> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000254> "obsolete prophage")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000254> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000254> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000254> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000255> (obsolete prostheca)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000255> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000255> "obsolete prostheca")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000255> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000255> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000255> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000256> (obsolete protein synthesis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000256> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000256> "obsolete protein synthesis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000256> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000256> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000256> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000257> (obsolete proteolysis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000257> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000257> "obsolete proteolysis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000257> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000257> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000257> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000258> (obsolete prototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000258> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000258> "obsolete prototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000258> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000258> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000258> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000259> (obsolete psychrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000259> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000259> "obsolete psychrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000259> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000259> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000259> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000260> (obsolete qualifier)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000260> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000260> "obsolete qualifier")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000260> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000260> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000260> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000261> (obsolete quorum sensing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000261> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000261> "obsolete quorum sensing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000261> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000261> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000261> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000262> (obsolete regulation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000262> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000262> "obsolete regulation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000262> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000262> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000262> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000263> (obsolete regulatory mechanism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000263> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000263> "obsolete regulatory mechanism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000263> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000263> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000263> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000264> (obsolete reproductive process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000264> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000264> "obsolete reproductive process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000264> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000264> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000264> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000265> (obsolete reproductive structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000265> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000265> "obsolete reproductive structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000265> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000265> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000265> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000266> (obsolete resistance mechanism)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000266> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000266> "obsolete resistance mechanism")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000266> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000266> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000266> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000267> (obsolete respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000267> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000267> "obsolete respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000267> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000267> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000267> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000268> (obsolete restriction-modification system)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000268> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000268> "obsolete restriction-modification system")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000268> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000268> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000268> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000269> (obsolete ribosome)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000269> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000269> "obsolete ribosome")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000269> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000269> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000269> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000270> (obsolete S-layer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000270> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000270> "obsolete S-layer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000270> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000270> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000270> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000271> (obsolete salinity delta)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000271> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000271> "obsolete salinity delta")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000271> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000271> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000271> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000272> (obsolete salinity preference)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000272> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000272> "obsolete salinity preference")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000272> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000272> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000272> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000273> (obsolete secondary metabolite)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000273> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000273> "obsolete secondary metabolite")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000273> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000273> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000273> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000274> (obsolete secretion)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000274> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000274> "obsolete secretion")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000274> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000274> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000274> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000275> (obsolete secretion system)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000275> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000275> "obsolete secretion system")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000275> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000275> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000275> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000276> (obsolete sheathed)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000276> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000276> "obsolete sheathed")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000276> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000276> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000276> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000277> (obsolete siderophore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000277> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000277> "obsolete siderophore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000277> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000277> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000277> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000278> (obsolete sigma factor)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000278> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000278> "obsolete sigma factor")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000278> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000278> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000278> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000279> (obsolete signaling)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000279> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000279> "obsolete signaling")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000279> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000279> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000279> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000280> (obsolete slime layer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000280> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000280> "obsolete slime layer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000280> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000280> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000280> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000281> (obsolete specialized cell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000281> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000281> "obsolete specialized cell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000281> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000281> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000281> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000282> (obsolete species)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000282> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000282> "obsolete species")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000282> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000282> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000282> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000283> (obsolete spirillum)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000283> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000283> "obsolete spirillum")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000283> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000283> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000283> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000284> (obsolete spirochete)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000284> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000284> "obsolete spirochete")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000284> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000284> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000284> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000285> (obsolete sporangiospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000285> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000285> "obsolete sporangiospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000285> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000285> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000285> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000286> (obsolete sporulation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000286> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000286> "obsolete sporulation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000286> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000286> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000286> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000287> (obsolete square cell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000287> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000287> "obsolete square cell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000287> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000287> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000287> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000288> (obsolete stalk)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000288> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000288> "obsolete stalk")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000288> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000288> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000288> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000289> (obsolete star-shaped cell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000289> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000289> "obsolete star-shaped cell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000289> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000289> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000289> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000290> (obsolete stationary phase)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000290> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000290> "obsolete stationary phase")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000290> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000290> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000290> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000291> (obsolete storage structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000291> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000291> "obsolete storage structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000291> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000291> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000291> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000292> (obsolete strain)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000292> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000292> "obsolete strain")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000292> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000292> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000292> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000293> (obsolete stress response)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000293> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000293> "obsolete stress response")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000293> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000293> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000293> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000294> (obsolete structure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000294> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000294> "obsolete structure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000294> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000294> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000294> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000295> (obsolete sulfate reducer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000295> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000295> "obsolete sulfate reducer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000295> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000295> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000295> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000296> (obsolete swarming)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000296> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000296> "obsolete swarming")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000296> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000296> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000296> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000297> (obsolete symbiosis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000297> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000297> "obsolete symbiosis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000297> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000297> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000297> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000298> (obsolete symbiotic process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000298> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000298> "obsolete symbiotic process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000298> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000298> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000298> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000299> (obsolete syntrophy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000299> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000299> "obsolete syntrophy")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000299> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000299> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000299> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000300> (obsolete taxonomic identifier)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000300> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000300> "obsolete taxonomic identifier")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000300> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000300> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000300> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000301> (obsolete taxonomic rank)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000301> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000301> "obsolete taxonomic rank")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000301> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000301> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000301> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000302> (obsolete teichoic acid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000302> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000302> "obsolete teichoic acid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000302> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000302> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000302> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000303> (temperature delta)
@@ -8895,7 +8895,7 @@ SubClassOf(<https://w3id.org/metpo/1000304> <https://w3id.org/metpo/1000536>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000305> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000305> "obsolete temperature preference")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000305> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000305> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000305> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000306> (temperature range)
@@ -8908,168 +8908,168 @@ SubClassOf(<https://w3id.org/metpo/1000306> <https://w3id.org/metpo/1000535>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000307> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000307> "obsolete thermal tolerance")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000307> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000307> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000307> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000308> (obsolete thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000308> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000308> "obsolete thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000308> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000308> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000308> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000309> (obsolete toxin)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000309> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000309> "obsolete toxin")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000309> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000309> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000309> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000310> (obsolete transcription factor)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000310> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000310> "obsolete transcription factor")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000310> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000310> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000310> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000311> (obsolete transduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000311> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000311> "obsolete transduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000311> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000311> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000311> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000312> (obsolete transferase)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000312> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000312> "obsolete transferase")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000312> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000312> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000312> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000313> (obsolete transformation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000313> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000313> "obsolete transformation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000313> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000313> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000313> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000314> (obsolete transport system)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000314> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000314> "obsolete transport system")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000314> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000314> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000314> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000315> (obsolete transposon)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000315> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000315> "obsolete transposon")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000315> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000315> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000315> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000316> (obsolete triangular cell)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000316> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000316> "obsolete triangular cell")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000316> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000316> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000316> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000317> (obsolete trichome)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000317> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000317> "obsolete trichome")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000317> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000317> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000317> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000318> (obsolete twitching motility)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000318> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000318> "obsolete twitching motility")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000318> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000318> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000318> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000319> (obsolete two-component system)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000319> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000319> "obsolete two-component system")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000319> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000319> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000319> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000320> (obsolete viable but non-culturable)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000320> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000320> "obsolete viable but non-culturable")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000320> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000320> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000320> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000321> (obsolete vibrio)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000321> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000321> "obsolete vibrio")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000321> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000321> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000321> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000322> (obsolete virulence)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000322> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000322> "obsolete virulence")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000322> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000322> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000322> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000323> (obsolete virulence factor)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000323> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000323> "obsolete virulence factor")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000323> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000323> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000323> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000324> (obsolete virulence process)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000324> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000324> "obsolete virulence process")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000324> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000324> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000324> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000325> (obsolete xylanolysis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000325> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000325> "obsolete xylanolysis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000325> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000325> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000325> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000326> (obsolete zoospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000326> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000326> "obsolete zoospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000326> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000326> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000326> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000327> (obsolete zygospore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000327> <http://purl.obolibrary.org/obo/OMO_0001000>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000327> "obsolete zygospore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000327> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000327> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000327> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000328> (obsolete pressure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000328> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000328> "obsolete pressure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000328> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000328> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000328> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000329> (obsolete temperature optimum (metabolic activity))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000329> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000329> "obsolete temperature optimum (metabolic activity)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000329> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000329> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000329> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000330> (obsolete temperature range (metabolic viability))
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000330> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000330> "obsolete temperature range (metabolic viability)")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000330> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000330> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000330> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000331> (pH optimum)
@@ -9111,651 +9111,651 @@ SubClassOf(<https://w3id.org/metpo/1000335> <https://w3id.org/metpo/1000534>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000336> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000336> "obsolete psychrotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000336> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000336> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000336> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000337> (obsolete thermotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000337> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000337> "obsolete thermotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000337> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000337> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000337> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000338> (obsolete extreme thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000338> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000338> "obsolete extreme thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000338> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000338> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000338> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000339> (obsolete extreme hyperthermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000339> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000339> "obsolete extreme hyperthermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000339> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000339> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000339> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000340> (obsolete non-halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000340> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000340> "obsolete non-halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000340> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000340> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000340> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000341> (obsolete slight halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000341> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000341> "obsolete slight halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000341> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000341> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000341> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000342> (obsolete haloalkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000342> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000342> "obsolete haloalkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000342> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000342> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000342> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000343> (obsolete extreme acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000343> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000343> "obsolete extreme acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000343> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000343> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000343> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000344> (obsolete acid tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000344> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000344> "obsolete acid tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000344> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000344> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000344> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000345> (obsolete alkali tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000345> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000345> "obsolete alkali tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000345> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000345> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000345> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000346> (obsolete extreme alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000346> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000346> "obsolete extreme alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000346> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000346> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000346> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000347> (obsolete facultative acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000347> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000347> "obsolete facultative acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000347> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000347> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000347> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000348> (obsolete obligative acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000348> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000348> "obsolete obligative acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000348> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000348> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000348> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000349> (obsolete facultative aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000349> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000349> "obsolete facultative aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000349> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000349> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000349> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000350> (obsolete microaerophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000350> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000350> "obsolete microaerophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000350> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000350> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000350> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000351> (obsolete microaerotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000351> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000351> "obsolete microaerotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000351> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000351> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000351> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000352> (obsolete aerotolerant anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000352> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000352> "obsolete aerotolerant anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000352> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000352> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000352> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000353> (obsolete obligate aerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000353> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000353> "obsolete obligate aerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000353> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000353> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000353> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000354> (obsolete obligate anaerobe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000354> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000354> "obsolete obligate anaerobe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000354> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000354> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000354> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000355> (obsolete oxygenic phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000355> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000355> "obsolete oxygenic phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000355> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000355> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000355> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000356> (obsolete anoxygenic phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000356> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000356> "obsolete anoxygenic phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000356> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000356> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000356> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000357> (obsolete chemoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000357> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000357> "obsolete chemoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000357> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000357> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000357> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000358> (obsolete chemoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000358> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000358> "obsolete chemoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000358> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000358> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000358> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000359> (obsolete lithotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000359> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000359> "obsolete lithotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000359> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000359> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000359> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000360> (obsolete organotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000360> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000360> "obsolete organotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000360> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000360> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000360> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000361> (obsolete phototroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000361> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000361> "obsolete phototroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000361> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000361> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000361> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000362> (obsolete chemotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000362> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000362> "obsolete chemotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000362> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000362> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000362> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000363> (obsolete oligotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000363> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000363> "obsolete oligotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000363> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000363> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000363> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000364> (obsolete copiotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000364> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000364> "obsolete copiotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000364> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000364> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000364> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000365> (obsolete lithoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000365> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000365> "obsolete lithoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000365> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000365> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000365> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000366> (obsolete mixotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000366> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000366> "obsolete mixotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000366> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000366> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000366> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000367> (obsolete lithoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000367> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000367> "obsolete lithoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000367> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000367> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000367> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000368> (obsolete chemoorganoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000368> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000368> "obsolete chemoorganoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000368> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000368> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000368> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000369> (obsolete chemolithoautotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000369> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000369> "obsolete chemolithoautotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000369> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000369> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000369> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000370> (obsolete methylotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000370> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000370> "obsolete methylotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000370> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000370> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000370> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000371> (obsolete methanotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000371> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000371> "obsolete methanotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000371> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000371> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000371> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000372> (obsolete hydrogenotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000372> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000372> "obsolete hydrogenotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000372> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000372> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000372> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000373> (obsolete hydrogen oxidizer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000373> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000373> "obsolete hydrogen oxidizer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000373> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000373> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000373> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000374> (obsolete hydrogen producer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000374> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000374> "obsolete hydrogen producer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000374> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000374> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000374> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000375> (obsolete nitrogen fixer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000375> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000375> "obsolete nitrogen fixer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000375> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000375> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000375> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000376> (obsolete methanogen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000376> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000376> "obsolete methanogen")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000376> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000376> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000376> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000377> (obsolete sulfur oxidizer)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000377> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000377> "obsolete sulfur oxidizer")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000377> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000377> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000377> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000378> (obsolete denitrifier)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000378> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000378> "obsolete denitrifier")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000378> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000378> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000378> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000379> (obsolete motile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000379> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000379> "obsolete motile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000379> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000379> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000379> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000380> (obsolete non-motile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000380> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000380> "obsolete non-motile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000380> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000380> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000380> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000381> (obsolete flagellated)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000381> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000381> "obsolete flagellated")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000381> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000381> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000381> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000382> (obsolete peritrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000382> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000382> "obsolete peritrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000382> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000382> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000382> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000383> (obsolete lophotrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000383> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000383> "obsolete lophotrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000383> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000383> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000383> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000384> (obsolete monotrichous)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000384> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000384> "obsolete monotrichous")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000384> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000384> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000384> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000385> (obsolete ciliated)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000385> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000385> "obsolete ciliated")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000385> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000385> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000385> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000386> (obsolete gliding)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000386> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000386> "obsolete gliding")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000386> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000386> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000386> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000387> (obsolete twitching)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000387> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000387> "obsolete twitching")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000387> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000387> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000387> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000388> (obsolete sliding)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000388> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000388> "obsolete sliding")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000388> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000388> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000388> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000389> (obsolete myxospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000389> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000389> "obsolete myxospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000389> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000389> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000389> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000390> (obsolete conidia)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000390> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000390> "obsolete conidia")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000390> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000390> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000390> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000391> (obsolete chlamydospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000391> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000391> "obsolete chlamydospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000391> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000391> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000391> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000392> (obsolete sporocysts)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000392> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000392> "obsolete sporocysts")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000392> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000392> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000392> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000393> (obsolete hypnospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000393> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000393> "obsolete hypnospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000393> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000393> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000393> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000394> (obsolete gemmae)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000394> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000394> "obsolete gemmae")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000394> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000394> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000394> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000395> (obsolete azygospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000395> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000395> "obsolete azygospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000395> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000395> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000395> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000396> (obsolete aleuriospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000396> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000396> "obsolete aleuriospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000396> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000396> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000396> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000397> (obsolete stylospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000397> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000397> "obsolete stylospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000397> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000397> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000397> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000398> (obsolete sclerotia)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000398> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000398> "obsolete sclerotia")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000398> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000398> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000398> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000399> (obsolete teliospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000399> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000399> "obsolete teliospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000399> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000399> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000399> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000400> (obsolete urediniospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000400> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000400> "obsolete urediniospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000400> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000400> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000400> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000401> (obsolete pycnidiospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000401> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000401> "obsolete pycnidiospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000401> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000401> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000401> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000402> (obsolete acriospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000402> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000402> "obsolete acriospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000402> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000402> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000402> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000403> (obsolete aplanospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000403> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000403> "obsolete aplanospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000403> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000403> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000403> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000404> (obsolete statismospores)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000404> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000404> "obsolete statismospores")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000404> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000404> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000404> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000405> (obsolete piezotolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000405> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000405> "obsolete piezotolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000405> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000405> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000405> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000406> (obsolete piezosensitive)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000406> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000406> "obsolete piezosensitive")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000406> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000406> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000406> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000407> (obsolete obligate barophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000407> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000407> "obsolete obligate barophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000407> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000407> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000407> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000408> (obsolete facultative barophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000408> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000408> "obsolete facultative barophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000408> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000408> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000408> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000409> (obsolete hyperbarophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000409> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000409> "obsolete hyperbarophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000409> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000409> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000409> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000410> (obsolete hypobarophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000410> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000410> "obsolete hypobarophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000410> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000410> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000410> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000411> (obsolete atmospheric pressure-adapted)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000411> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000411> "obsolete atmospheric pressure-adapted")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000411> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000411> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000411> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000412> (obsolete moderate piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000412> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000412> "obsolete moderate piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000412> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000412> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000412> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000413> (obsolete extreme piezophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000413> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000413> "obsolete extreme piezophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000413> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000413> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000413> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000414> (obsolete stenopiezic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000414> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000414> "obsolete stenopiezic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000414> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000414> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000414> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000415> (obsolete eurypiezic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000415> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000415> "obsolete eurypiezic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000415> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000415> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000415> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000416> (obsolete pressure-sensitive)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000416> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000416> "obsolete pressure-sensitive")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000416> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000416> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000416> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000417> (obsolete pressure-resistant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000417> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000417> "obsolete pressure-resistant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000417> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000417> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000417> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000418> (obsolete pressure-adapted)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000418> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000418> "obsolete pressure-adapted")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000418> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000418> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000418> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000419> (obsolete piezo-acidophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000419> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000419> "obsolete piezo-acidophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000419> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000419> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000419> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000420> (obsolete piezo-alkaliphile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000420> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000420> "obsolete piezo-alkaliphile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000420> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000420> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000420> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000421> (obsolete piezo-halophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000421> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000421> "obsolete piezo-halophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000421> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000421> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000421> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000422> (obsolete piezo-psychrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000422> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000422> "obsolete piezo-psychrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000422> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000422> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000422> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000423> (obsolete piezo-thermophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000423> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000423> "obsolete piezo-thermophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000423> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000423> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000423> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000424> (obsolete piezo-lithoautotrophe)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000424> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000424> "obsolete piezo-lithoautotrophe")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000424> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000424> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000424> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000425> (obsolete piezo-chemoheterotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000425> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000425> "obsolete piezo-chemoheterotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000425> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000425> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000425> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000426> (obsolete piezo-oligotroph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000426> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000426> "obsolete piezo-oligotroph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000426> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000426> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000426> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000427> (obsolete piezo-endolithic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000427> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000427> "obsolete piezo-endolithic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000427> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000427> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000427> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000428> (obsolete piezo-tolerant)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000428> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000428> "obsolete piezo-tolerant")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000428> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000428> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000428> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000429> (GC low)
@@ -9796,56 +9796,56 @@ SubClassOf(<https://w3id.org/metpo/1000432> <https://w3id.org/metpo/1000127>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000433> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000433> "obsolete cell width very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000433> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000433> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000433> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000434> (obsolete cell width low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000434> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000434> "obsolete cell width low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000434> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000434> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000434> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000435> (obsolete cell width mid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000435> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000435> "obsolete cell width mid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000435> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000435> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000435> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000436> (obsolete cell width high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000436> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000436> "obsolete cell width high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000436> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000436> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000436> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000437> (obsolete cell length very low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000437> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000437> "obsolete cell length very low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000437> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000437> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000437> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000438> (obsolete cell length low)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000438> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000438> "obsolete cell length low")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000438> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000438> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000438> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000439> (obsolete cell length mid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000439> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000439> "obsolete cell length mid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000439> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000439> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000439> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000440> (obsolete cell length high)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000440> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000440> "obsolete cell length high")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000440> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000440> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000440> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000441> (temperature optimum very low)
@@ -10360,259 +10360,259 @@ SubClassOf(<https://w3id.org/metpo/1000487> <https://w3id.org/metpo/1000303>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000488> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000488> "obsolete branched")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000488> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000488> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000488> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000489> (obsolete coccobacillus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000489> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000489> "obsolete coccobacillus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000489> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000489> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000489> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000490> (obsolete crescent)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000490> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000490> "obsolete crescent")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000490> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000490> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000490> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000491> (obsolete curved)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000491> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000491> "obsolete curved")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000491> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000491> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000491> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000492> (obsolete curved spiral)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000492> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000492> "obsolete curved spiral")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000492> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000492> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000492> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000493> (obsolete diplococcus)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000493> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000493> "obsolete diplococcus")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000493> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000493> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000493> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000494> (obsolete ellipsoidal)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000494> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000494> "obsolete ellipsoidal")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000494> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000494> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000494> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000495> (obsolete filament)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000495> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000495> "obsolete filament")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000495> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000495> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000495> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000496> (obsolete fusiform)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000496> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000496> "obsolete fusiform")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000496> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000496> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000496> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000497> (obsolete helical)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000497> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000497> "obsolete helical")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000497> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000497> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000497> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000498> (obsolete irregular)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000498> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000498> "obsolete irregular")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000498> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000498> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000498> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000499> (obsolete oval)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000499> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000499> "obsolete oval")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000499> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000499> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000499> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000500> (obsolete ovoid)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000500> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000500> "obsolete ovoid")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000500> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000500> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000500> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000501> (obsolete pleomorphic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000501> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000501> "obsolete pleomorphic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000501> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000501> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000501> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000502> (obsolete ring)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000502> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000502> "obsolete ring")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000502> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000502> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000502> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000503> (obsolete rod)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000503> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000503> "obsolete rod")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000503> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000503> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000503> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000504> (obsolete sphere)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000504> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000504> "obsolete sphere")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000504> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000504> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000504> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000505> (obsolete spindle)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000505> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000505> "obsolete spindle")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000505> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000505> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000505> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000506> (obsolete spiral)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000506> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000506> "obsolete spiral")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000506> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000506> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000506> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000507> (obsolete star - dumbbell - pleomorphic)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000507> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000507> "obsolete star - dumbbell - pleomorphic")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000507> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000507> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000507> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000508> (obsolete tailed)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000508> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000508> "obsolete tailed")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000508> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000508> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000508> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000509> (obsolete temperature adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000509> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000509> "obsolete temperature adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000509> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000509> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000509> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000510> (obsolete salinity adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000510> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000510> "obsolete salinity adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000510> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000510> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000510> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000511> (obsolete pH adaptation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000511> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000511> "obsolete pH adaptation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000511> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000511> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000511> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000512> (obsolete bacterial spore)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000512> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000512> "obsolete bacterial spore")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000512> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000512> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000512> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000513> (obsolete pressure adaptation type)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000513> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000513> "obsolete pressure adaptation type")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000513> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000513> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000513> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000514> (obsolete pressure tolerance range)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000514> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000514> "obsolete pressure tolerance range")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000514> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000514> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000514> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000515> (obsolete sensitivity to oxygen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000515> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000515> "obsolete sensitivity to oxygen")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000515> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000515> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000515> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000516> (obsolete sensitivity toward)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000516> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000516> "obsolete sensitivity toward")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000516> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000516> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000516> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000517> (obsolete size)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000517> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000517> "obsolete size")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000517> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000517> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000517> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000518> (obsolete 1-D extent)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000518> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000518> "obsolete 1-D extent")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000518> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000518> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000518> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000519> (obsolete width)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000519> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000519> "obsolete width")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000519> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000519> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000519> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000520> (obsolete length)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000520> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000520> "obsolete length")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000520> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000520> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000520> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000521> (obsolete sensitivity toward pressure)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000521> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000521> "obsolete sensitivity toward pressure")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000521> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000521> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000521> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000522> (obsolete sensitivity toward nacl)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000522> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000522> "obsolete sensitivity toward nacl")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000522> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000522> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000522> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000523> (obsolete sensitivity toward ph)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000523> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000523> "obsolete sensitivity toward ph")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000523> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000523> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000523> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000524> (obsolete sensitivity toward temperature)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000524> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000524> "obsolete sensitivity toward temperature")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000524> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000524> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000524> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000525> (microbe)
@@ -10640,14 +10640,14 @@ SubClassOf(<https://w3id.org/metpo/1000527> <https://w3id.org/metpo/1000186>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000528> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000528> "obsolete structured susceptibility detail")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000528> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000528> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000528> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000529> (obsolete facultative psychrophile)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000529> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000529> "obsolete facultative psychrophile")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000529> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000529> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000529> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000531> (pH phenotype with numerical limits)
@@ -11028,7 +11028,7 @@ SubClassOf(<https://w3id.org/metpo/1000642> <https://w3id.org/metpo/1000731>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000643> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000643> "obsolete denitrifying")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000643> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000643> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000643> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000644> (heterotrophic)
@@ -11045,7 +11045,7 @@ SubClassOf(<https://w3id.org/metpo/1000644> <https://w3id.org/metpo/1000631>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000645> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000645> "obsolete hydrogen-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000645> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000645> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000645> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000646> (hydrogenotrophic)
@@ -11108,7 +11108,7 @@ SubClassOf(<https://w3id.org/metpo/1000652> <https://w3id.org/metpo/1000631>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000653> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000653> "obsolete nitrogen-fixing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000653> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000653> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000653> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000654> (oligotrophic)
@@ -11181,14 +11181,14 @@ SubClassOf(<https://w3id.org/metpo/1000660> <https://w3id.org/metpo/1000631>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000661> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000661> "obsolete sulfate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000661> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000661> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000661> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000662> (obsolete sulfur-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000662> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000662> "obsolete sulfur-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000662> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000662> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000662> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000663> (chemoorganotrophic)
@@ -11627,259 +11627,259 @@ SubClassOf(<https://w3id.org/metpo/1000806> <https://w3id.org/metpo/1000060>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000807> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000807> "obsolete Nitrogen compound respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000807> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000807> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000807> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000808> (obsolete Nitrate reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000808> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000808> "obsolete Nitrate reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000808> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000808> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000808> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000809> (obsolete Denitrification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000809> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000809> "obsolete Denitrification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000809> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000809> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000809> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000810> (obsolete Dissimilatory nitrate reduction to ammonium)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000810> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000810> "obsolete Dissimilatory nitrate reduction to ammonium")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000810> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000810> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000810> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000811> (obsolete Nitrite reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000811> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000811> "obsolete Nitrite reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000811> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000811> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000811> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000812> (obsolete Anaerobic ammonium oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000812> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000812> "obsolete Anaerobic ammonium oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000812> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000812> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000812> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000813> (obsolete Nitric oxide reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000813> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000813> "obsolete Nitric oxide reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000813> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000813> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000813> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000814> (obsolete Nitrous oxide reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000814> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000814> "obsolete Nitrous oxide reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000814> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000814> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000814> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000815> (obsolete Sulfur and sulfoxide compound respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000815> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000815> "obsolete Sulfur and sulfoxide compound respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000815> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000815> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000815> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000816> (obsolete Sulfate reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000816> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000816> "obsolete Sulfate reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000816> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000816> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000816> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000817> (obsolete Sulfur reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000817> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000817> "obsolete Sulfur reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000817> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000817> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000817> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000818> (obsolete Sulfite reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000818> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000818> "obsolete Sulfite reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000818> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000818> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000818> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000819> (obsolete Thiosulfate reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000819> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000819> "obsolete Thiosulfate reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000819> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000819> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000819> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000820> (obsolete Sulfoxide respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000820> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000820> "obsolete Sulfoxide respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000820> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000820> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000820> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000821> (obsolete Dimethyl sulfoxide respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000821> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000821> "obsolete Dimethyl sulfoxide respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000821> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000821> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000821> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000822> (obsolete Methionine sulfoxide respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000822> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000822> "obsolete Methionine sulfoxide respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000822> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000822> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000822> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000823> (obsolete Sulfide oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000823> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000823> "obsolete Sulfide oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000823> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000823> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000823> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000824> (obsolete Thiosulfate oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000824> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000824> "obsolete Thiosulfate oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000824> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000824> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000824> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000825> (obsolete Sulfite oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000825> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000825> "obsolete Sulfite oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000825> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000825> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000825> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000826> (obsolete Tetrathionate reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000826> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000826> "obsolete Tetrathionate reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000826> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000826> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000826> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000827> (obsolete Polysulfide reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000827> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000827> "obsolete Polysulfide reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000827> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000827> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000827> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000828> (obsolete Metal and metalloid respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000828> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000828> "obsolete Metal and metalloid respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000828> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000828> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000828> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000829> (obsolete Iron reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000829> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000829> "obsolete Iron reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000829> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000829> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000829> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000830> (obsolete Iron oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000830> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000830> "obsolete Iron oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000830> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000830> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000830> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000831> (obsolete Nitrate-dependent Fe(II) oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000831> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000831> "obsolete Nitrate-dependent Fe(II) oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000831> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000831> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000831> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000832> (obsolete Manganese reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000832> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000832> "obsolete Manganese reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000832> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000832> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000832> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000833> (obsolete Manganese oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000833> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000833> "obsolete Manganese oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000833> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000833> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000833> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000834> (obsolete Uranium reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000834> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000834> "obsolete Uranium reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000834> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000834> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000834> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000835> (obsolete Vanadium reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000835> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000835> "obsolete Vanadium reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000835> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000835> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000835> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000836> (obsolete Chromium reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000836> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000836> "obsolete Chromium reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000836> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000836> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000836> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000837> (obsolete Technetium reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000837> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000837> "obsolete Technetium reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000837> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000837> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000837> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000838> (obsolete Cobalt reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000838> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000838> "obsolete Cobalt reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000838> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000838> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000838> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000839> (obsolete Arsenate reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000839> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000839> "obsolete Arsenate reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000839> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000839> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000839> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000840> (obsolete Arsenite oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000840> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000840> "obsolete Arsenite oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000840> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000840> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000840> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000841> (obsolete Selenate reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000841> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000841> "obsolete Selenate reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000841> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000841> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000841> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000842> (obsolete Selenite reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000842> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000842> "obsolete Selenite reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000842> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000842> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000842> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000843> (obsolete Carbon and organic compound respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000843> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000843> "obsolete Carbon and organic compound respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000843> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000843> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000843> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000844> (Methanogenesis)
@@ -11916,161 +11916,161 @@ SubClassOf(<https://w3id.org/metpo/1000846> <https://w3id.org/metpo/1000060>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000847> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000847> "obsolete Fumarate respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000847> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000847> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000847> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000848> (obsolete Trimethylamine N-oxide respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000848> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000848> "obsolete Trimethylamine N-oxide respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000848> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000848> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000848> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000849> (obsolete Humus respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000849> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000849> "obsolete Humus respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000849> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000849> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000849> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000850> (obsolete Halogenated compound respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000850> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000850> "obsolete Halogenated compound respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000850> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000850> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000850> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000851> (obsolete Organohalide respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000851> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000851> "obsolete Organohalide respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000851> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000851> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000851> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000852> (obsolete (Per)chlorate respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000852> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000852> "obsolete (Per)chlorate respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000852> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000852> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000852> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000853> (obsolete Perchlorate respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000853> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000853> "obsolete Perchlorate respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000853> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000853> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000853> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000854> (obsolete Chlorate respiration)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000854> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000854> "obsolete Chlorate respiration")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000854> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000854> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000854> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000855> (obsolete Bromate reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000855> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000855> "obsolete Bromate reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000855> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000855> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000855> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000856> (obsolete Iodate reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000856> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000856> "obsolete Iodate reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000856> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000856> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000856> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000857> (obsolete Nitrite-dependent methane oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000857> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000857> "obsolete Nitrite-dependent methane oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000857> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000857> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000857> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000858> (obsolete Nitrate-dependent methane oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000858> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000858> "obsolete Nitrate-dependent methane oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000858> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000858> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000858> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000859> (obsolete Hydrogen oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000859> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000859> "obsolete Hydrogen oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000859> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000859> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000859> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000860> (obsolete Sulfur oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000860> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000860> "obsolete Sulfur oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000860> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000860> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000860> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000861> (obsolete Nitrification)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000861> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000861> "obsolete Nitrification")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000861> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000861> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000861> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000862> (obsolete Complete ammonia oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000862> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000862> "obsolete Complete ammonia oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000862> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000862> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000862> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000863> (obsolete Carbon monoxide oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000863> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000863> "obsolete Carbon monoxide oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000863> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000863> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000863> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000864> (obsolete Hydrogenotrophic methanogenesis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000864> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000864> "obsolete Hydrogenotrophic methanogenesis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000864> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000864> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000864> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000865> (obsolete Acetoclastic methanogenesis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000865> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000865> "obsolete Acetoclastic methanogenesis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000865> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000865> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000865> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000866> (obsolete Methylotrophic methanogenesis)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000866> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000866> "obsolete Methylotrophic methanogenesis")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000866> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000866> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000866> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000867> (obsolete Anaerobic methane oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000867> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000867> "obsolete Anaerobic methane oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000867> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000867> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000867> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000868> (obsolete Lanthanide reduction)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000868> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000868> "obsolete Lanthanide reduction")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000868> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000868> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000868> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000869> (obsolete Lanthanide oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1000869> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1000869> "obsolete Lanthanide oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000869> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1000869> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1000869> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1000870> (sporulation)
@@ -12195,168 +12195,168 @@ SubClassOf(<https://w3id.org/metpo/1000890> <https://w3id.org/metpo/1000882>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001000> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001000> "obsolete observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001000> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001000> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001000> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001001> (obsolete optimum temperature observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001001> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001001> "obsolete optimum temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001001> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001001> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001001> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001002> (obsolete growth temperature observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001002> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001002> "obsolete growth temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001002> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001002> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001002> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001003> (obsolete temperature range observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001003> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001003> "obsolete temperature range observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001003> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001003> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001003> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001004> (obsolete temperature delta observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001004> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001004> "obsolete temperature delta observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001004> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001004> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001004> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001005> (obsolete culture temperature observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001005> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001005> "obsolete culture temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001005> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001005> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001005> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001006> (obsolete culture NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001006> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001006> "obsolete culture NaCl observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001006> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001006> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001006> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001007> (obsolete growth NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001007> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001007> "obsolete growth NaCl observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001007> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001007> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001007> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001008> (obsolete NaCl delta observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001008> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001008> "obsolete NaCl delta observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001008> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001008> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001008> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001009> (obsolete NaCl range observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001009> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001009> "obsolete NaCl range observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001009> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001009> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001009> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001010> (obsolete optimum NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001010> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001010> "obsolete optimum NaCl observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001010> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001010> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001010> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001011> (obsolete culture pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001011> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001011> "obsolete culture pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001011> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001011> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001011> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001012> (obsolete growth pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001012> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001012> "obsolete growth pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001012> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001012> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001012> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001013> (obsolete optimum pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001013> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001013> "obsolete optimum pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001013> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001013> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001013> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001014> (obsolete pH delta observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001014> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001014> "obsolete pH delta observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001014> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001014> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001014> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001015> (obsolete pH range observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001015> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001015> "obsolete pH range observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001015> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001015> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001015> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001016> (obsolete optimum oxygen observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001016> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001016> "obsolete optimum oxygen observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001016> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001016> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001016> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001017> (obsolete growth oxygen observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001017> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001017> "obsolete growth oxygen observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001017> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001017> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001017> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001018> (obsolete oxygen range observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001018> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001018> "obsolete oxygen range observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001018> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001018> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001018> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001019> (obsolete oxygen delta observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001019> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001019> "obsolete oxygen delta observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001019> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001019> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001019> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001020> (obsolete oxygen observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001020> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001020> "obsolete oxygen observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001020> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001020> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001020> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001021> (obsolete temperature observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001021> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001021> "obsolete temperature observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001021> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001021> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001021> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001022> (obsolete NaCl observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001022> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001022> "obsolete NaCl observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001022> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001022> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001022> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001023> (obsolete pH observation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1001023> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1001023> "obsolete pH observation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001023> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1001023> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1001023> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1001101> (biosafety level)
@@ -12409,21 +12409,21 @@ SubClassOf(<https://w3id.org/metpo/1001106> <https://w3id.org/metpo/1001101>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002000> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002000> "obsolete Sulfate-dependent methane oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002000> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002000> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002000> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002001> (obsolete Fe(III)-dependent methane oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002001> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002001> "obsolete Fe(III)-dependent methane oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002001> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002001> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002001> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002002> (obsolete Mn(IV)-dependent methane oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002002> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002002> "obsolete Mn(IV)-dependent methane oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002002> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002002> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002002> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002003> (Cable bacteria metabolism)
@@ -12452,238 +12452,238 @@ SubClassOf(<https://w3id.org/metpo/1002006> <https://w3id.org/metpo/1000060>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002007> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002007> "obsolete Sulfur disproportionation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002007> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002007> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002007> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002008> (obsolete Nitrogen fixation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002008> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002008> "obsolete Nitrogen fixation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002008> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002008> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002008> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002009> (obsolete Nitrate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002009> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002009> "obsolete Nitrate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002009> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002009> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002009> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002010> (obsolete Anaerobic ammonium-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002010> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002010> "obsolete Anaerobic ammonium-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002010> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002010> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002010> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002011> (obsolete Nitrous oxide-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002011> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002011> "obsolete Nitrous oxide-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002011> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002011> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002011> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002012> (obsolete Sulfate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002012> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002012> "obsolete Sulfate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002012> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002012> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002012> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002013> (obsolete Sulfur-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002013> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002013> "obsolete Sulfur-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002013> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002013> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002013> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002014> (obsolete Sulfite-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002014> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002014> "obsolete Sulfite-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002014> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002014> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002014> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002015> (obsolete Thiosulfate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002015> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002015> "obsolete Thiosulfate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002015> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002015> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002015> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002016> (obsolete Sulfur-disproportionating)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002016> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002016> "obsolete Sulfur-disproportionating")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002016> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002016> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002016> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002017> (obsolete Sulfide-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002017> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002017> "obsolete Sulfide-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002017> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002017> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002017> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002018> (obsolete Thiosulfate-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002018> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002018> "obsolete Thiosulfate-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002018> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002018> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002018> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002019> (obsolete Sulfite-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002019> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002019> "obsolete Sulfite-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002019> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002019> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002019> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002020> (obsolete Iron-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002020> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002020> "obsolete Iron-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002020> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002020> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002020> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002021> (obsolete Iron-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002021> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002021> "obsolete Iron-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002021> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002021> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002021> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002022> (obsolete Nitrate-dependent Fe(II)-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002022> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002022> "obsolete Nitrate-dependent Fe(II)-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002022> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002022> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002022> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002023> (obsolete Manganese-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002023> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002023> "obsolete Manganese-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002023> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002023> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002023> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002024> (obsolete Manganese-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002024> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002024> "obsolete Manganese-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002024> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002024> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002024> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002025> (obsolete Uranium-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002025> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002025> "obsolete Uranium-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002025> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002025> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002025> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002026> (obsolete Arsenate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002026> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002026> "obsolete Arsenate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002026> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002026> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002026> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002027> (obsolete Selenate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002027> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002027> "obsolete Selenate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002027> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002027> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002027> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002028> (obsolete Selenite-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002028> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002028> "obsolete Selenite-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002028> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002028> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002028> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002029> (obsolete Perchlorate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002029> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002029> "obsolete Perchlorate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002029> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002029> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002029> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002030> (obsolete Chlorate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002030> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002030> "obsolete Chlorate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002030> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002030> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002030> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002031> (obsolete Bromate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002031> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002031> "obsolete Bromate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002031> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002031> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002031> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002032> (obsolete Iodate-reducing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002032> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002032> "obsolete Iodate-reducing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002032> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002032> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002032> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002033> (obsolete Hydrogen-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002033> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002033> "obsolete Hydrogen-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002033> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002033> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002033> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002034> (obsolete Sulfur-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002034> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002034> "obsolete Sulfur-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002034> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002034> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002034> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002035> (obsolete Ammonia oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002035> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002035> "obsolete Ammonia oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002035> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002035> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002035> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002036> (obsolete Nitrite oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002036> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002036> "obsolete Nitrite oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002036> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002036> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002036> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002037> (obsolete Complete ammonia-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002037> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002037> "obsolete Complete ammonia-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002037> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002037> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002037> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002038> (obsolete Methane oxidation)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002038> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002038> "obsolete Methane oxidation")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002038> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002038> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002038> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002039> (obsolete Carbon monoxide-oxidizing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002039> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002039> "obsolete Carbon monoxide-oxidizing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002039> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002039> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002039> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1002040> (obsolete Nitrogen-fixing)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/1002040> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/1002040> "obsolete Nitrogen-fixing")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002040> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/1002040> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/1002040> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: <https://w3id.org/metpo/1003000> (pH growth preference)
@@ -13329,7 +13329,7 @@ SubClassOf(<https://w3id.org/metpo/1007093> <https://w3id.org/metpo/1000059>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <https://w3id.org/metpo/9999999> <http://purl.obolibrary.org/obo/IAO_0000226>)
 AnnotationAssertion(rdfs:label <https://w3id.org/metpo/9999999> "obsolete obsolete")
-AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/9999999> "true")
+AnnotationAssertion(owl:deprecated <https://w3id.org/metpo/9999999> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/metpo/9999999> <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 

--- a/src/templates/deprecated.tsv
+++ b/src/templates/deprecated.tsv
@@ -1,5 +1,5 @@
 ID	label	TYPE	deprecated	obsolescence reason	obsolete parent class
-ID	LABEL	TYPE	A owl:deprecated	AI IAO:0000231	SC %
+ID	LABEL	TYPE	AT owl:deprecated^^xsd:boolean	AI IAO:0000231	SC %
 METPO:0000001	obsolete Temperature	owl:Class	true	OMO:0001000	oboInOwl:ObsoleteClass
 METPO:000001	obsolete Temperature	owl:Class	true	OMO:0001000	oboInOwl:ObsoleteClass
 METPO:0000002	obsolete Salinity	owl:Class	true	OMO:0001000	oboInOwl:ObsoleteClass


### PR DESCRIPTION
Low-hanging, high-impact release-quality fix found while running the default-profile ROBOT report.

**Problem.** `src/templates/deprecated.tsv` used `A owl:deprecated`, emitting an **untyped** literal `<owl:deprecated>true</owl:deprecated>` instead of `"true"^^xsd:boolean`. ROBOT/OWL API therefore did not recognize the 1217 deprecated terms as deprecated, cascading into the default-profile report:

| rule | before | after |
|---|---:|---:|
| deprecated_boolean_datatype (ERROR) | 1216 | 0 |
| misused_obsolete_label (ERROR) | 1216 | 0 |
| duplicate_label (ERROR) | 438 | 0 |
| missing_definition (WARN) | 1395 | 179 |
| **total** | **4342** | **256** |

**Fix.** `A owl:deprecated` -> `AT owl:deprecated^^xsd:boolean`. `owl:deprecated` now serializes as `"true"^^xsd:boolean`; the deprecated terms are recognized, so the three ERROR categories clear and `missing_definition` drops to live-term-only (179, the #377 work). `deprecated.tsv` is the hand-maintained source template, so this is a one-cell change; release artifacts rebuilt.

Remaining report items (not in scope here): `duplicate_exact_synonym` (70), `missing_superclass` (4 INFO), `duplicate_label_synonym` (3) — worth a separate look.

Note: METPO's *custom* QC profile already passed (it masks these), so CI was green before; this fixes the underlying defect so the default/OBO-dashboard profile is clean too. Leaving open for CI + Copilot review.