### PR TITLE
docs: synonym conventions + identifier scheme guidelines (+ typed owl:deprecated note)

### DIFF
--- a/docs/deprecation-workflow.md
+++ b/docs/deprecation-workflow.md
@@ -71,7 +71,9 @@ Add one row per deprecated term. Use:
   (`<owl:deprecated>true</owl:deprecated>`), which ROBOT/OWL API do not recognize as a
   deprecation — that previously caused ~4000 spurious default-profile report findings
   (deprecated terms not excluded from `missing_definition`/`duplicate_label`, plus
-  `deprecated_boolean_datatype` and `misused_obsolete_label`). Fixed in #467; keep it typed.
+  `deprecated_boolean_datatype` and `misused_obsolete_label`). The typed directive is the
+  fix in #467; keep it typed so this does not regress. (If `deprecated.tsv` still shows the
+  bare `A owl:deprecated`, #467 has not yet landed — apply the typed form.)
 - **obsolescence reason**: use `OMO:0001000` (out of scope) or `IAO:0000226`
   (placeholder removed) — see the existing rows for precedent. When in doubt, use
   `IAO:0000226`.

--- a/docs/deprecation-workflow.md
+++ b/docs/deprecation-workflow.md
@@ -57,16 +57,21 @@ by editing the upstream Google Sheet and running `make download-sheets`.
 The file is a ROBOT template. Column layout:
 
 ```
-ID            label                    TYPE              deprecated      obsolescence reason
-ID            LABEL                    TYPE              A owl:deprecated  AI IAO:0000231
-METPO:XXXXXXX obsolete <former label>  owl:Class         true            OMO:0001000
+ID            label                    TYPE              deprecated                        obsolescence reason
+ID            LABEL                    TYPE              AT owl:deprecated^^xsd:boolean    AI IAO:0000231
+METPO:XXXXXXX obsolete <former label>  owl:Class         true                              OMO:0001000
 ```
 
 Add one row per deprecated term. Use:
 - **label**: `obsolete ` + the former rdfs:label (e.g. `obsolete lyses`)
 - **TYPE**: `owl:Class` for classes, `owl:ObjectProperty` / `owl:DataProperty` /
   `owl:AnnotationProperty` for properties
-- **deprecated**: always `true`
+- **deprecated**: always `true`. The directive **must be typed** as
+  `AT owl:deprecated^^xsd:boolean`. A bare `A owl:deprecated` emits an *untyped* literal
+  (`<owl:deprecated>true</owl:deprecated>`), which ROBOT/OWL API do not recognize as a
+  deprecation — that previously caused ~4000 spurious default-profile report findings
+  (deprecated terms not excluded from `missing_definition`/`duplicate_label`, plus
+  `deprecated_boolean_datatype` and `misused_obsolete_label`). Fixed in #467; keep it typed.
 - **obsolescence reason**: use `OMO:0001000` (out of scope) or `IAO:0000226`
   (placeholder removed) — see the existing rows for precedent. When in doubt, use
   `IAO:0000226`.

--- a/docs/identifier-scheme.md
+++ b/docs/identifier-scheme.md
@@ -1,0 +1,67 @@
+# METPO Identifier and IRI Scheme
+
+**Purpose:** The canonical form of METPO identifiers and ontology IRIs, how they resolve,
+and where the values are configured. Follow this when minting terms, building releases,
+or editing ODK configuration.
+
+---
+
+## The Short Version
+
+- **Term IRIs** are `https://w3id.org/metpo/<7-digit id>` (prefix `METPO:` →
+  `https://w3id.org/metpo/`). Classes are `METPO:1xxxxxx`, properties `METPO:2xxxxxx`.
+- **`https://w3id.org/metpo/` is the canonical, resolvable base.** w3id delegates only the
+  `/metpo/` path, so *everything* — terms, the ontology document, version IRIs, and
+  release products — must live under it.
+- **METPO does not use `purl.obolibrary.org` PURLs.** METPO is not registered in the OBO
+  Foundry, so `http://purl.obolibrary.org/obo/METPO_<id>` returns HTTP 404. Do not mint,
+  advertise, or filter on obolibrary IRIs.
+
+---
+
+## Canonical IRIs
+
+| Thing | IRI |
+|---|---|
+| Term (class/property) | `https://w3id.org/metpo/<id>` |
+| Main ontology document | `https://w3id.org/metpo/metpo.owl` |
+| Version IRI | `https://w3id.org/metpo/releases/<date>/metpo.owl` |
+| Products (`-base`, `-full`) | `https://w3id.org/metpo/metpo-base.owl`, `…/metpo-full.owl` |
+
+All of these are under `https://w3id.org/metpo/`. An IRI **above** that path (e.g.
+`https://w3id.org/metpo.owl`) is **not resolvable** — it falls outside w3id's `/metpo/`
+delegation and 404s — so it must never be used as the ontology IRI.
+
+## Resolution
+
+The `/metpo/` catch-all in [`perma-id/w3id.org`](https://github.com/perma-id/w3id.org)
+redirects `https://w3id.org/metpo/*`:
+
+- `https://w3id.org/metpo/metpo.owl` → the raw release OWL on GitHub.
+- `https://w3id.org/metpo/<id>` → the BioPortal class page. This works in **browsers**
+  (BioPortal sits behind a Cloudflare bot challenge that only blocks non-browser clients;
+  human resolution is the design goal). Machine/linked-data dereferenceability would come
+  from OLS once METPO is loaded there (see #213).
+
+## Where the values are configured
+
+The IRI base lives in **`src/ontology/metpo-odk.yaml`** (`uribase`) and flows into the
+**generated** `src/ontology/Makefile` as `URIBASE` / `ONTBASE` and the report/base-artifact
+`--base-iri`. The correct values for the scheme above are:
+
+```
+URIBASE  = https://w3id.org/metpo
+ONTBASE  = https://w3id.org/metpo
+--base-iri = $(URIBASE)        # i.e. https://w3id.org/metpo, which matches term IRIs
+```
+
+**Do not hand-edit `src/ontology/Makefile`.** It is ODK-generated ("DO NOT EDIT THIS
+FILE"); `make update_repo` regenerates it and would overwrite manual edits. Configure the
+scheme in `metpo-odk.yaml` and regenerate. Note that ODK's IRI machinery is OBO-PURL
+oriented (it assumes `<base>/ONT_<id>` underscore terms and a registry-root ontology IRI),
+which does not map cleanly onto METPO's w3id slash scheme; reconciling this is tracked in
+**#465** (the ODK upgrade). Vestiges such as a `$(URIBASE)/METPO_` base-IRI in the report
+recipe come from that mismatch and match no real METPO term.
+
+See also: `docs/synonym-conventions.md`, `docs/deprecation-workflow.md`, and the
+"Identifiers and resolution" section of the top-level `README.md`.

--- a/docs/identifier-scheme.md
+++ b/docs/identifier-scheme.md
@@ -26,7 +26,7 @@ or editing ODK configuration.
 | Term (class/property) | `https://w3id.org/metpo/<id>` |
 | Main ontology document | `https://w3id.org/metpo/metpo.owl` |
 | Version IRI | `https://w3id.org/metpo/releases/<date>/metpo.owl` |
-| Products (`-base`, `-full`) | `https://w3id.org/metpo/metpo-base.owl`, `…/metpo-full.owl` |
+| Products (`-base`, `-full`) | `https://w3id.org/metpo/metpo-base.owl`, `https://w3id.org/metpo/metpo-full.owl` |
 
 All of these are under `https://w3id.org/metpo/`. An IRI **above** that path (e.g.
 `https://w3id.org/metpo.owl`) is **not resolvable** — it falls outside w3id's `/metpo/`
@@ -47,13 +47,19 @@ redirects `https://w3id.org/metpo/*`:
 
 The IRI base lives in **`src/ontology/metpo-odk.yaml`** (`uribase`) and flows into the
 **generated** `src/ontology/Makefile` as `URIBASE` / `ONTBASE` and the report/base-artifact
-`--base-iri`. The correct values for the scheme above are:
+`--base-iri`. The **target** values that produce the scheme above are:
 
 ```
 URIBASE  = https://w3id.org/metpo
 ONTBASE  = https://w3id.org/metpo
 --base-iri = $(URIBASE)        # i.e. https://w3id.org/metpo, which matches term IRIs
 ```
+
+> Current state: the repo ships `uribase: https://w3id.org` in `metpo-odk.yaml` and a
+> generated `URIBASE = https://w3id.org` (with `ONTBASE = https://w3id.org/metpo`), which
+> makes the main ontology IRI resolve *above* the delegation as the non-resolving
+> `https://w3id.org/metpo.owl`. Aligning the generated values with the target above is
+> tracked in #465 (it must be done via `odk.yaml` regeneration, not a Makefile edit).
 
 **Do not hand-edit `src/ontology/Makefile`.** It is ODK-generated ("DO NOT EDIT THIS
 FILE"); `make update_repo` regenerates it and would overwrite manual edits. Configure the

--- a/docs/synonym-conventions.md
+++ b/docs/synonym-conventions.md
@@ -1,0 +1,89 @@
+# METPO Synonym Conventions
+
+**Purpose:** How METPO records synonyms, which annotation property each Google-Sheet
+column maps to, and the rules a curator (or an automated check) must follow. The
+classes tab has two *kinds* of synonym column with different rules.
+
+---
+
+## The Short Version
+
+- **Ontology-native** synonyms are clean, curated US English that METPO asserts in its
+  own voice. They use `oboInOwl:hasExactSynonym` / `hasRelatedSynonym` with no source.
+- **Source-bound** synonyms are **verbatim** strings from an external database, paired
+  with a source column that **reifies** the synonym assertion with its provenance.
+- **Never normalize a source-bound value**, and **never de-duplicate source-bound
+  synonyms across classes** — both are intentional (see below).
+- An **exact** synonym should (almost) uniquely identify one class. The same exact
+  synonym on many classes is an *overload* and is discouraged.
+
+---
+
+## The columns and their ROBOT directives
+
+| Column | Directive | Property | Kind |
+|---|---|---|---|
+| `confirmed exact synonym` | `A oboInOwl:hasExactSynonym SPLIT=\|` | exact synonym | ontology-native |
+| `literature mining related synonyms` | `A oboInOwl:hasRelatedSynonym SPLIT=\|` | related synonym | ontology-native |
+| `madin synonym or field` | `A oboInOwl:hasRelatedSynonym SPLIT=\|` | related synonym | source-bound |
+| `Madin synonym source` | `>AI IAO:0000119 SPLIT=\|` | (axiom annotation) | source provenance |
+| `bacdive keyword synonym` | `A oboInOwl:hasRelatedSynonym SPLIT=\|` | related synonym | source-bound |
+| `Bacdive synonym source` | `>AI IAO:0000119` | (axiom annotation) | source provenance |
+| `bactotraits related synonym` | `A oboInOwl:hasRelatedSynonym SPLIT=\|` | related synonym | source-bound |
+| `Bactotraits synonym source` | `>AI IAO:0000119` | (axiom annotation) | source provenance |
+| `metatraits synonym` | `A oboInOwl:hasRelatedSynonym SPLIT=\|` | related synonym | source-bound |
+| `MetaTraits synonym source` | `>AI IAO:0000119` | (axiom annotation) | source provenance |
+
+The leading `>` on each `*source*` column is a ROBOT template directive that **annotates
+the preceding synonym assertion** rather than the term. The result is a reified
+synonym, e.g. in the OWL:
+
+```xml
+<owl:Axiom>
+  <owl:annotatedSource rdf:resource="https://w3id.org/metpo/2000002"/>
+  <owl:annotatedProperty rdf:resource="…oboInOwl#hasRelatedSynonym"/>
+  <owl:annotatedTarget>assimilation</owl:annotatedTarget>
+  <obo:IAO_0000119 rdf:resource="https://bacdive.dsmz.de/"/>
+</owl:Axiom>
+```
+
+This is how METPO records **which external-system value maps to which METPO entity**:
+the synonym is the verbatim external value and the `IAO:0000119` (definition source)
+annotation records the database it came from.
+
+---
+
+## Rules
+
+1. **Source-bound columns hold verbatim source strings.** Do not "correct" them, even
+   when the source has typos, odd casing, inconsistent prefixes, or non-English forms.
+   Downstream consumers (e.g. the kg-microbe transformers) match on the exact source
+   string; normalizing breaks the match.
+2. **Duplicate source-bound related synonyms across classes are intentional.** One
+   external value (e.g. a BactoTraits temperature bin code) legitimately maps to several
+   METPO classes; keeping it on each — each reified with its source — is the point. Do
+   **not** treat these as duplicates to remove. (A `duplicate_*_synonym` QC finding on a
+   `hasRelatedSynonym` is expected for source-bound values.)
+3. **Ontology-native columns use clean, consistent US English.** Foreign-language forms,
+   source typos, and one-off transcriptions belong in source-bound columns, not here.
+4. **Exact synonyms should be near-unique.** `oboInOwl:hasExactSynonym` asserts the value
+   *is* a name for the class, so the same exact synonym on many sibling classes is an
+   *overload* (a qualitative term like `mesophilic` stamped onto every numeric bin). Pick
+   one canonical owner; downgrade the others to `hasRelatedSynonym` or drop them. Tracked
+   in issue #444.
+5. **If a source value also happens to be the desired ontology-native synonym, put it in
+   both columns** — do not rely on a source-bound column to carry English semantics.
+
+---
+
+## Why reification (not bare synonyms)
+
+A bare synonym says "this string names this class." METPO additionally needs to say
+"this string is *the value used by database X*," so that the same human-facing concept
+can be mapped to multiple external vocabularies and back. The reified `IAO:0000119`
+provenance is what makes the synonym a *mapping record*, not just a label. (This is
+distinct from the observation-reification layer that was removed in #371; synonym-source
+reification is a deliberate, retained feature.)
+
+See also: `docs/deprecation-workflow.md`, `docs/identifier-scheme.md`, and the
+"Synonym Column Conventions" section of the repository `CLAUDE.md`.


### PR DESCRIPTION
Durable in-repo **guideline** docs (not todos) capturing conventions established during release prep, so contributors and automated checks have a reference and don't undo intentional design.

- **`docs/synonym-conventions.md`** — which annotation property each Sheet synonym column maps to; the source-bound vs ontology-native distinction; the reified `>AI IAO:0000119` source-provenance pattern (with the `owl:Axiom` example); and the rules: keep source values verbatim, **source-bound duplicates across classes are intentional** (cross-system value mapping — don't de-dup), exact synonyms should be near-unique (overload = #444).
- **`docs/identifier-scheme.md`** — canonical w3id term/ontology/version/product IRIs; `https://w3id.org/metpo/` is the resolvable base (anything above it 404s); no obolibrary PURLs; resolution behavior; and where the IRI values are configured (`metpo-odk.yaml`, not the generated Makefile — ODK/w3id mismatch tracked in #465).
- **`docs/deprecation-workflow.md`** — fixed the directive example to the typed `AT owl:deprecated^^xsd:boolean` and explained the cascade it prevents (the #467 fix).

Docs only — no ontology or code changes. Leaving open for your review.