### PR TITLE
Address Copilot review on #460 (encoding, docstring, CURIE-parent DEF-FORM)

### DIFF
--- a/metpo/scripts/metpo_proposal_lint.py
+++ b/metpo/scripts/metpo_proposal_lint.py
@@ -303,6 +303,11 @@ def check_definition_form(rid, typ, definition, parent_cell, mode):
         return []
     sev = "ERROR" if mode == "submit" else "WARN"
     parents = [p.strip() for p in parent_cell.split("|") if p.strip()]
+    # CURIE-form parents (e.g. METPO:1000000) are governed by PARENT/HOUSE-STYLE; the
+    # genus is compared only against LABEL-form parents (the sheet convention), so a
+    # CURIE parent never triggers a spurious DEF-FORM mismatch and is not cited as the
+    # expected genus.
+    label_parents = [p for p in parents if not re.match(r"^[A-Za-z][\w.]*:\S", p)]
     m = _DEF_GENUS_RE.match(definition)
     if not m:
         return [
@@ -311,15 +316,11 @@ def check_definition_form(rid, typ, definition, parent_cell, mode):
                 "DEF-FORM",
                 rid,
                 "definition is not Aristotelian 'A <genus> that/in-which/... <differentia>' "
-                f"(genus must be the parent label {parents or ['<none>']})",
+                f"(genus must be the parent label {label_parents or ['<none>']})",
             )
         ]
     genus = m.group(1).strip()
     glow = genus.lower()
-    # CURIE-form parents (e.g. METPO:1000000) are governed by PARENT/HOUSE-STYLE;
-    # the genus is compared only against LABEL-form parents (the sheet convention),
-    # so a CURIE parent does not trigger a spurious DEF-FORM mismatch.
-    label_parents = [p for p in parents if not re.match(r"^[A-Za-z][\w.]*:\S", p)]
     # Accept the parent label itself, or the parent label qualified as a head noun
     # ("a <parent> phenotype/preference in which ..."). For adjectival parents (e.g.
     # 'halophilic', 'anaerobic') the natural genus is "<parent> phenotype", which is

--- a/metpo/scripts/metpo_proposal_lint.py
+++ b/metpo/scripts/metpo_proposal_lint.py
@@ -20,7 +20,7 @@ definition_source (#344), parents that bypass ROBOT's label-resolution safety ne
 via CURIE form, and definitions whose genus disagrees with the asserted parent
 (DEF-FORM; the hierarchy/label/definition compatibility principle, #64/#377).
 
-Baseline ratchet: ``--write-baseline PATH`` records the currently-accepted findings;
+Baseline ratchet: ``--baseline PATH --write-baseline`` records the currently-accepted findings;
 a later run with ``--baseline PATH`` fails only on findings BEYOND that floor, so a
 large existing-debt audit can gate new additions without first paying down the debt.
 Regenerate the baseline as debt is fixed -- the count can only go down.
@@ -316,21 +316,25 @@ def check_definition_form(rid, typ, definition, parent_cell, mode):
         ]
     genus = m.group(1).strip()
     glow = genus.lower()
+    # CURIE-form parents (e.g. METPO:1000000) are governed by PARENT/HOUSE-STYLE;
+    # the genus is compared only against LABEL-form parents (the sheet convention),
+    # so a CURIE parent does not trigger a spurious DEF-FORM mismatch.
+    label_parents = [p for p in parents if not re.match(r"^[A-Za-z][\w.]*:\S", p)]
     # Accept the parent label itself, or the parent label qualified as a head noun
     # ("a <parent> phenotype/preference in which ..."). For adjectival parents (e.g.
     # 'halophilic', 'anaerobic') the natural genus is "<parent> phenotype", which is
     # still hierarchy/label/definition compatible.
     _heads = ("phenotype", "preference", "quality")
     genus_ok = any(
-        glow == p.lower() or glow in {f"{p.lower()} {h}" for h in _heads} for p in parents
+        glow == p.lower() or glow in {f"{p.lower()} {h}" for h in _heads} for p in label_parents
     )
-    if parents and not genus_ok:
+    if label_parents and not genus_ok:
         return [
             Finding(
                 sev,
                 "DEF-FORM",
                 rid,
-                f"definition genus '{genus}' does not match asserted parent(s) {parents} "
+                f"definition genus '{genus}' does not match asserted parent(s) {label_parents} "
                 "(hierarchy/label/definition must be compatible)",
             )
         ]
@@ -537,13 +541,15 @@ def main(template, known, mode, do_validate_curies, as_json, warn_only, baseline
     if write_baseline:
         if not baseline:
             raise click.UsageError("--write-baseline requires --baseline PATH")
-        Path(baseline).write_text(json.dumps(sorted({_fp(f) for f in findings}), indent=1) + "\n")
+        Path(baseline).write_text(
+            json.dumps(sorted({_fp(f) for f in findings}), indent=1) + "\n", encoding="utf-8"
+        )
         click.echo(f"# wrote baseline: {baseline}  ({len(findings)} findings recorded)")
         raise SystemExit(0)
 
     baseline_set = set()
     if baseline and Path(baseline).exists():
-        baseline_set = set(json.loads(Path(baseline).read_text()))
+        baseline_set = set(json.loads(Path(baseline).read_text(encoding="utf-8")))
     new_findings = [f for f in findings if _fp(f) not in baseline_set]
     baselined = len(findings) - len(new_findings)
     # When a baseline is in play, only findings beyond it count toward pass/fail.

--- a/tests/test_metpo_proposal_lint.py
+++ b/tests/test_metpo_proposal_lint.py
@@ -115,6 +115,7 @@ DEF_FORM_TEMPLATE = (
     "METPO:1007104\tin-which ok\towl:Class\ttrophic type\tA trophic type in which an organism fixes carbon.\tPMID:1\n"
     "METPO:1007105\tcharacterized ok\towl:Class\tcell shape\tA cell shape characterized by a rod morphology.\tPMID:1\n"
     "METPO:1007106\tparent phenotype genus\towl:Class\thalophilic\tA halophilic phenotype in which an organism requires high salt.\tPMID:1\n"
+    "METPO:1007107\tcurie parent\towl:Class\tMETPO:9999999\tA phenotype that is observable.\tPMID:1\n"
 )
 
 
@@ -140,6 +141,8 @@ def test_def_form(tmp_path):
     # 'in which' / 'characterized by' are valid connectors when genus == parent
     assert "DEF-FORM" not in by_id.get("METPO:1007104", set())
     assert "DEF-FORM" not in by_id.get("METPO:1007105", set())
+    # CURIE-form parent: genus comparison is skipped (PARENT/HOUSE-STYLE governs it)
+    assert "DEF-FORM" not in by_id.get("METPO:1007107", set())
     # genus "<parent> phenotype" (adjectival parent) is accepted
     assert "DEF-FORM" not in by_id.get("METPO:1007106", set())
 


### PR DESCRIPTION
Addresses the 3 Copilot inline comments on #460 that were not handled at merge time:
- **CURIE-parent DEF-FORM** (lint.py:327): genus now compared only against label-form parents, so a CURIE parent doesn't trigger a spurious DEF-FORM error (it's already governed by PARENT/HOUSE-STYLE).
- **encoding** (lint.py:536): baseline read/write use `encoding='utf-8'`.
- **docstring** (lint.py:24): corrected to `--baseline PATH --write-baseline`.

Tests added for the CURIE-parent case. Leaving open for CI + Copilot.