### PR TITLE
Ontology-header metadata QC, kept outside the ODK tree (closes #502)

### DIFF
--- a/tests/sparql_qc/README.md
+++ b/tests/sparql_qc/README.md
@@ -48,6 +48,16 @@ So:
 The fixture IRIs are fixture-only (`9999xxx` range, never allocated) and live
 only in this directory; they are never merged into the ontology.
 
+## Ontology-header check (#502)
+
+`ontology-header-check.sparql` is a QC check kept here rather than as an edit to
+an ODK query. The runner runs it twice: against the bad-header node in
+`qc-positive-fixture.ttl` (must match >= 1 row, so it is proven able to fail)
+and against the real `metpo.owl` (must match 0 rows). It flags a creator or
+contributor given as a literal placeholder instead of an agent IRI, and a
+`dcterms:modified` that disagrees with `owl:versionInfo`. Deprecated DC Elements
+1.1 is already caught by ODK's `dc-properties-violation` and is not repeated.
+
 ## Running it
 
 In the ODK container, from `src/ontology`:

--- a/tests/sparql_qc/ontology-header-check.sparql
+++ b/tests/sparql_qc/ontology-header-check.sparql
@@ -1,0 +1,40 @@
+# Ontology-header metadata QC (berkeleybop/metpo#502).
+#
+# This check lives OUTSIDE the ODK-managed tree on purpose (it does not edit any
+# ODK query). The meta-test runner runs it against the real metpo.owl, where it
+# must return 0 rows, and against qc-positive-fixture.ttl, where it must return
+# >= 1 row (so the check is proven able to fail).
+#
+# It returns a row for each problem on the ontology node:
+#   (1) creator/contributor given as a literal instead of an agent IRI (ORCID);
+#   (2) dcterms:modified disagreeing with the automated owl:versionInfo.
+# The header drifted unchecked until #495 (placeholder creator, fake
+# dcterms:issued, dcterms:modified contradicting owl:versionInfo). The deprecated
+# DC Elements 1.1 namespace is already caught by ODK's dc-properties-violation
+# (which scopes to https://w3id.org/metpo/ subjects, including the ontology node),
+# so it is not repeated here.
+
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+SELECT DISTINCT ?ontology ?predicate ?value ?problem WHERE {
+  {
+    # (1) creator/contributor as a literal placeholder instead of an agent IRI
+    ?ontology a owl:Ontology .
+    VALUES ?predicate { dcterms:creator dcterms:contributor }
+    ?ontology ?predicate ?value .
+    FILTER(isLiteral(?value))
+    BIND("creator/contributor must be an agent IRI (e.g. ORCID), not a literal placeholder" AS ?problem)
+  }
+  UNION
+  {
+    # (2) dcterms:modified disagreeing with the automated owl:versionInfo
+    ?ontology a owl:Ontology ;
+              dcterms:modified ?value ;
+              owl:versionInfo ?vi .
+    FILTER(STR(?value) != STR(?vi))
+    BIND(dcterms:modified AS ?predicate)
+    BIND(CONCAT("dcterms:modified '", STR(?value),
+                "' disagrees with owl:versionInfo '", STR(?vi), "'") AS ?problem)
+  }
+}

--- a/tests/sparql_qc/ontology-header-check.sparql
+++ b/tests/sparql_qc/ontology-header-check.sparql
@@ -18,19 +18,22 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 
 SELECT DISTINCT ?ontology ?predicate ?value ?problem WHERE {
+  # Scope to the METPO ontology node only, so a merged/imported ontology header
+  # in the input cannot raise a false positive (per Copilot review on #506).
+  ?ontology a owl:Ontology .
+  FILTER(isIRI(?ontology) && STRSTARTS(STR(?ontology), "https://w3id.org/metpo/"))
   {
-    # (1) creator/contributor as a literal placeholder instead of an agent IRI
-    ?ontology a owl:Ontology .
+    # (1) creator/contributor that is not an agent IRI (a literal placeholder, or
+    #     a blank node) -- anything non-IRI fails the "must be an ORCID" rule.
     VALUES ?predicate { dcterms:creator dcterms:contributor }
     ?ontology ?predicate ?value .
-    FILTER(isLiteral(?value))
+    FILTER(!isIRI(?value))
     BIND("creator/contributor must be an agent IRI (e.g. ORCID), not a literal placeholder" AS ?problem)
   }
   UNION
   {
     # (2) dcterms:modified disagreeing with the automated owl:versionInfo
-    ?ontology a owl:Ontology ;
-              dcterms:modified ?value ;
+    ?ontology dcterms:modified ?value ;
               owl:versionInfo ?vi .
     FILTER(STR(?value) != STR(?vi))
     BIND(dcterms:modified AS ?predicate)

--- a/tests/sparql_qc/qc-positive-fixture.ttl
+++ b/tests/sparql_qc/qc-positive-fixture.ttl
@@ -27,6 +27,17 @@ metpo:9999001 a owl:Class ;
     rdfs:label "fixture: deprecated dc-elements predicate" ;
     dce:creator "should be dcterms:creator" .
 
+# -> ontology-header-check.sparql : a bad ontology header.
+#    (1) creator as a literal placeholder, not an agent IRI;
+#    (2) dcterms:modified disagreeing with owl:versionInfo.
+#    Uses dcterms: (not the dc-elements namespace) and dcterms:creator (not
+#    contributor), so it trips only the header check, not the ODK dc-properties
+#    or iri-range queries.
+<https://w3id.org/metpo/fixture-ontology> a owl:Ontology ;
+    dcterms:creator "METPO Development Team" ;
+    dcterms:modified "2024-01-01" ;
+    owl:versionInfo "2026-06-05" .
+
 # -> iri-range-violation.sparql : a property whose value must be an IRI, given a literal
 metpo:9999002 a owl:Class ;
     rdfs:label "fixture: contributor as a literal, not an IRI" ;

--- a/tests/sparql_qc/run_sparql_metatest.sh
+++ b/tests/sparql_qc/run_sparql_metatest.sh
@@ -56,3 +56,41 @@ if [ "$fail" -ne 0 ]; then
 fi
 
 echo "All ${#queries[@]} QC violation queries matched their positive-control fixture."
+
+# ---------------------------------------------------------------------------
+# Ontology-header QC (berkeleybop/metpo#502). This check is maintained here,
+# outside the ODK tree, rather than as an edit to an ODK query. It must:
+#   (a) match >= 1 row against the bad-header fixture (proven able to fail), and
+#   (b) match 0 rows against the real released metpo.owl (the actual assertion).
+# ---------------------------------------------------------------------------
+echo
+HEADER_Q="$HERE/ontology-header-check.sparql"
+REAL_OWL="$REPO_ROOT/metpo.owl"
+
+robot query --input "$FIXTURE" --query "$HEADER_Q" "$OUT/header-fixture.tsv"
+hrows=$(($(wc -l < "$OUT/header-fixture.tsv") - 1))
+if [ "$hrows" -ge 1 ]; then
+  echo "OK   ontology-header-check.sparql matched $hrows fixture violation(s)"
+else
+  echo "::error::ontology-header-check.sparql matched 0 rows against the fixture: the check is a silent no-op."
+  fail=1
+fi
+
+if [ -f "$REAL_OWL" ]; then
+  robot query --input "$REAL_OWL" --query "$HEADER_Q" "$OUT/header-real.tsv"
+  rrows=$(($(wc -l < "$OUT/header-real.tsv") - 1))
+  if [ "$rrows" -le 0 ]; then
+    echo "OK   ontology-header-check.sparql found no problems in metpo.owl"
+  else
+    echo "::error::the ontology header in metpo.owl has $rrows metadata problem(s):"
+    cat "$OUT/header-real.tsv"
+    fail=1
+  fi
+else
+  echo "::error::expected released ontology at $REAL_OWL but it is missing."
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Stacks on #505 (base = `sparql-qc-metatest`; retarget to `main` after #505 merges).

The ontology header drifted unchecked until #495: `dcterms:creator` was the placeholder `"METPO Development Team"`, `dcterms:issued` was a fake `2024-01-01`, and `dcterms:modified` contradicted the automated `owl:versionInfo`.

This adds a header QC check **without editing any ODK-owned file**. Rather than extending `src/sparql/dc-properties-violation.sparql`, the check lives in `tests/sparql_qc/ontology-header-check.sparql` and is run by the meta-test runner two ways:

- against the bad-header node in `qc-positive-fixture.ttl`: must match >= 1 row (so the check is proven able to fail);
- against the real `metpo.owl`: must match 0 rows (the actual assertion).

It flags a creator/contributor given as a literal placeholder instead of an agent IRI, and a `dcterms:modified` that disagrees with `owl:versionInfo`. The deprecated DC Elements 1.1 namespace stays covered by ODK's untouched `dc-properties-violation`.

Verified in the odkfull container: clean repo passes; a dirtied header fails with a clear message; `metpo.owl` is unchanged. No writes to `src/ontology/` or `src/sparql/`.

Closes #502. Related: #495, #437, #505 (#500).