### PR TITLE
Add INCLUDE_OBSOLETE emission toggle for deprecated terms (#378)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,16 @@ cd src/ontology
 sh run.sh make IMP=false prepare_release
 ```
 
+**Obsolete-term emission toggle (#378):** deprecated/obsolete terms come only from
+`src/templates/deprecated.tsv`. `INCLUDE_OBSOLETE` controls whether they are built
+into the release OWL. Default is `true` (current behaviour; the committed artifacts
+and the artifact-freshness check reproduce with the default). To produce an
+obsolete-free build:
+```bash
+cd src/ontology
+sh run.sh make INCLUDE_OBSOLETE=false prepare_release
+```
+
 **Test:**
 ```bash
 cd src/ontology

--- a/src/ontology/metpo.Makefile
+++ b/src/ontology/metpo.Makefile
@@ -105,6 +105,19 @@ regenerate-deprecated:
 	rm -f ../templates/deprecated.tsv
 	$(MAKE) -f metpo.Makefile ../templates/deprecated.tsv
 
+# Emission control for deprecated/obsolete terms (berkeleybop/metpo#378).
+# INCLUDE_OBSOLETE=true (default) merges ../templates/deprecated.tsv into the build,
+# so the release OWL carries the obsolete classes (current behaviour; the committed
+# artifacts and the artifact-freshness check reproduce with the default).
+# INCLUDE_OBSOLETE=false omits that template, producing an obsolete-free build, e.g.
+#   sh run.sh make INCLUDE_OBSOLETE=false prepare_release
+INCLUDE_OBSOLETE ?= true
+ifeq ($(INCLUDE_OBSOLETE),true)
+DEPRECATED_TEMPLATE_ARG := --template ../templates/deprecated.tsv
+else
+DEPRECATED_TEMPLATE_ARG :=
+endif
+
 components/metpo_sheet.owl: ../templates/stubs.tsv ../templates/metpo-properties.tsv ../templates/metpo_sheet.tsv ../templates/deprecated.tsv
 	$(ROBOT) template \
 		--add-prefix 'METPO: https://w3id.org/metpo/' \
@@ -113,7 +126,7 @@ components/metpo_sheet.owl: ../templates/stubs.tsv ../templates/metpo-properties
 		--template ../templates/stubs.tsv \
 		--template ../templates/metpo_sheet.tsv \
 		--template ../templates/metpo-properties.tsv \
-		--template ../templates/deprecated.tsv \
+		$(DEPRECATED_TEMPLATE_ARG) \
 		annotate --ontology-iri $(ONTBASE)/$@ \
 		annotate -V $(ONTBASE)/releases/$(TODAY)/$@ \
 		--annotation owl:versionInfo $(TODAY) \

--- a/src/ontology/metpo.Makefile
+++ b/src/ontology/metpo.Makefile
@@ -114,11 +114,13 @@ regenerate-deprecated:
 INCLUDE_OBSOLETE ?= true
 ifeq ($(INCLUDE_OBSOLETE),true)
 DEPRECATED_TEMPLATE_ARG := --template ../templates/deprecated.tsv
+DEPRECATED_PREREQ := ../templates/deprecated.tsv
 else
 DEPRECATED_TEMPLATE_ARG :=
+DEPRECATED_PREREQ :=
 endif
 
-components/metpo_sheet.owl: ../templates/stubs.tsv ../templates/metpo-properties.tsv ../templates/metpo_sheet.tsv ../templates/deprecated.tsv
+components/metpo_sheet.owl: ../templates/stubs.tsv ../templates/metpo-properties.tsv ../templates/metpo_sheet.tsv $(DEPRECATED_PREREQ)
 	$(ROBOT) template \
 		--add-prefix 'METPO: https://w3id.org/metpo/' \
 		--add-prefix 'qudt: http://qudt.org/schema/qudt/' \


### PR DESCRIPTION
Provides the build control #378 asks for: whether deprecated/obsolete terms go into the released OWL.

Deprecated terms enter the build only through `src/templates/deprecated.tsv` (confirmed: `metpo-edit.owl` has zero `owl:deprecated`), which is templated into `components/metpo_sheet.owl`. This adds an `INCLUDE_OBSOLETE` make variable that conditionally drops that one template flag:

- `INCLUDE_OBSOLETE=true` (default): obsoletes included. The committed artifacts and the artifact-freshness check reproduce unchanged, so nothing about the current release changes.
- `INCLUDE_OBSOLETE=false`: obsolete-free build (`sh run.sh make INCLUDE_OBSOLETE=false prepare_release`).

Verified in the odkfull container at the component level (the sole source of obsoletes): `false` -> 0 `owl:deprecated`, 291 classes; `true` -> 1216 `owl:deprecated`, 1455 classes.

This is the mechanism only. Whether to flip the default for actual releases is the open decision in #378 and stays with the maintainers. Documented in CLAUDE.md.

Closes #378.