### PR TITLE
ci: add GitHub Actions to CodeQL language matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['python']
+        language: ['python', 'actions']
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Adds `actions` to the CodeQL matrix so the workflow files get scanned, not just Python. One-line change: `language: ['python']` becomes `language: ['python', 'actions']`. `build-mode: none` already covers both.

metpo has eight CodeQL-supported bytes of Ruby (no `.rb` files, just a stray Rakefile-class file), so Ruby is not worth a matrix entry. Scala, Shell, Makefile, and HTML have no CodeQL analyzer. Actions is the only meaningful gap.

zizmor and actionlint already audit workflow security, so this overlaps with them; the gain is modest but free. Verified locally: native actionlint clean, zizmor reports no findings.