### PR TITLE
ci: set least-privilege workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,9 @@ on:
     - cron: '0 6 * * 1'  # Monday 6am UTC
   workflow_dispatch:
 
+# Deny all permissions by default; the analyze job grants the minimum it needs.
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Deny all permissions by default; grant the minimum needed at the job level.
+permissions: {}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "ontology_qc"
@@ -20,6 +23,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container: obolibrary/odkfull:v1.6.1
+    # Only needs to read the repository to check it out and run the QC make target.
+    permissions:
+      contents: read
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Fixes code scanning alert #6 (`actions/missing-workflow-permissions`, CWE-275).

`qc.yml` set no `permissions` block, so its `GITHUB_TOKEN` inherited the repository default scope. It now denies all by default and grants the single QC job only `contents: read` (it just checks out the repo and runs the make target).

`codeql.yml` already scoped permissions at the job level; this adds the matching top-level `permissions: {}` default so both workflows follow the same deny-all-then-grant pattern.

Validated locally with zizmor (no findings).