### PR TITLE
chore: address low-risk Copilot AI findings (comments and strings)

### DIFF
--- a/src/ontology/metpo-edit.owl
+++ b/src/ontology/metpo-edit.owl
@@ -61,7 +61,7 @@ AnnotationAssertion(rdfs:label IAO:0000231 "has obsolescence reason")
 
 AnnotationAssertion(rdfs:label IAO:0100001 "term replaced by")
 
-# Obsolescence reason values (display labels; correct code ASSIGNMENT is tracked in #521)
+# Obsolescence reason values (display labels; correct IAO code assignment for these obsolescence reasons is tracked in issue #521)
 
 AnnotationAssertion(rdfs:label IAO:0000226 "placeholder removed")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/OMO_0001000> "out of scope")

--- a/src/ontology/metpo.Makefile
+++ b/src/ontology/metpo.Makefile
@@ -92,12 +92,12 @@ diff-sheets:
 
 # Diff current working templates against the last tagged release
 diff-release:
-	@command -v uv >/dev/null 2>&1 || { echo "ERROR: 'uv' is required for diff-release (host-only target)."; exit 1; }
-	@command -v git >/dev/null 2>&1 || { echo "ERROR: 'git' is required for diff-release."; exit 1; }
-	@git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "ERROR: diff-release must be run from within a git work tree."; exit 1; }
+	@command -v uv >/dev/null 2>&1 || { echo "Error: 'uv' is required for diff-release (host-only target)."; exit 1; }
+	@command -v git >/dev/null 2>&1 || { echo "Error: 'git' is required for diff-release."; exit 1; }
+	@git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Error: diff-release must be run from within a git work tree."; exit 1; }
 	@release_ref=$$(git describe --tags --abbrev=0 2>/dev/null); \
 	if [ -z "$$release_ref" ]; then \
-		echo "WARN: No git tags found; falling back to 'main'."; \
+		echo "Warning: No git tags found; falling back to 'main'."; \
 		release_ref=main; \
 	fi; \
 	cd ../.. && uv run diff-templates -a "$$release_ref" -b HEAD --cell-diffs

--- a/tests/sparql_qc/qc-positive-fixture.ttl
+++ b/tests/sparql_qc/qc-positive-fixture.ttl
@@ -50,6 +50,9 @@ metpo:9999003 a owl:Class ;
     rdfs:label "fixture: a label that wrongly embeds http://example.org/foo" .
 
 # -> multiple-replaced_by-violation.sparql : two distinct IAO:0100001 (term replaced by) values
+# metpo:1000000 and metpo:2000000 are intentional fixture-only IRIs: they supply
+# two distinct replacement targets for this violation case and are not declared
+# here, nor expected to exist as production METPO terms.
 metpo:9999004 a owl:Class ;
     rdfs:label "fixture: two different replacements" ;
     IAO:0100001 metpo:1000000 , metpo:2000000 .

--- a/tests/sparql_qc/qc-positive-fixture.ttl
+++ b/tests/sparql_qc/qc-positive-fixture.ttl
@@ -50,9 +50,6 @@ metpo:9999003 a owl:Class ;
     rdfs:label "fixture: a label that wrongly embeds http://example.org/foo" .
 
 # -> multiple-replaced_by-violation.sparql : two distinct IAO:0100001 (term replaced by) values
-# metpo:1000000 and metpo:2000000 are intentional fixture-only IRIs: they supply
-# two distinct replacement targets for this violation case and are not declared
-# here, nor expected to exist as production METPO terms.
 metpo:9999004 a owl:Class ;
     rdfs:label "fixture: two different replacements" ;
     IAO:0100001 metpo:1000000 , metpo:2000000 .


### PR DESCRIPTION
Applies the zero-risk subset of the Copilot AI code-quality findings: cosmetic message-string capitalization and a clarifying comment. No behavioral change.

- `src/ontology/metpo.Makefile`: `ERROR`/`WARN` to `Error`/`Warning` in the `diff-release` echo messages.
- `src/ontology/metpo-edit.owl`: clarify that correct IAO code assignment for the obsolescence-reason values is tracked in issue #521.

The QC-fixture comment finding moved to the METPO prefix-normalization PR (issue #16), where that file's `metpo:` -> `METPO:` is handled together so the comment lands in canonical uppercase form.

The behavioral findings (`cross_ontology_search.py`, `run_sparql_metatest.sh`) are deliberately left out for separate review.