### PR TITLE
chore: normalize lowercase metpo: CURIE prefix to uppercase METPO:

### DIFF
--- a/.github/workflows/curie-prefix-case.yml
+++ b/.github/workflows/curie-prefix-case.yml
@@ -1,0 +1,29 @@
+name: CURIE prefix case
+
+# Guardrail for the blessed METPO CURIE prefix case (berkeleybop/metpo#16):
+# uppercase METPO: over the lowercase URI path https://w3id.org/metpo/.
+# Keeps lowercase metpo: CURIE prefixes from creeping back into hand-authored
+# RDF, SPARQL, and documentation.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+# Deny all permissions by default; the job grants the minimum it needs.
+permissions: {}
+
+jobs:
+  curie-prefix-case:
+    runs-on: ubuntu-latest
+    # Only needs to read the repository to grep tracked files.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check METPO CURIE prefix case
+        run: bash tests/check_curie_prefix_case.sh

--- a/docs/n4l/graphdb_workflow/sparql/metpo_classes_temperature_limits.rq
+++ b/docs/n4l/graphdb_workflow/sparql/metpo_classes_temperature_limits.rq
@@ -3,22 +3,22 @@
 # Used by: N4L temperature categorization workflow (archived)
 # Returns: METPO temperature classes with RangeMin/RangeMax/Unit values
 
-PREFIX metpo: <https://w3id.org/metpo/>
+PREFIX METPO: <https://w3id.org/metpo/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 select
 distinct ?s ?l ?min ?max ?u
 where {
     values ?o  {
-        metpo:1000217 metpo:1000303 metpo:1000304 metpo:1000305 metpo:1000306
+        METPO:1000217 METPO:1000303 METPO:1000304 METPO:1000305 METPO:1000306
     }
     ?s rdfs:subClassOf+ ?o ;
     rdfs:label ?l ;
-    metpo:Unit ?u .
+    METPO:Unit ?u .
     optional {
-        ?s metpo:RangeMax ?max
+        ?s METPO:RangeMax ?max
     }
     optional {
-        ?s metpo:RangeMin ?min
+        ?s METPO:RangeMin ?min
     }
     FILTER(BOUND(?min) || BOUND(?max))
 }

--- a/docs/presentations/icbo_2025/figures/metpo_viz/current_metpo_structure.ttl
+++ b/docs/presentations/icbo_2025/figures/metpo_viz/current_metpo_structure.ttl
@@ -1,54 +1,54 @@
 # METPO Current Production Structure (2025-10-31)
 # Sample showing hierarchical organization
 
-@prefix metpo: <https://w3id.org/metpo/> .
+@prefix METPO: <https://w3id.org/metpo/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 
 # ===== ROOT CLASSES =====
 
-metpo:1000186 a owl:Class ;
+METPO:1000186 a owl:Class ;
     rdfs:label "material entity" ;
     obo:IAO_0000115 "A physical entity" .
 
-metpo:1000188 a owl:Class ;
+METPO:1000188 a owl:Class ;
     rdfs:label "quality" ;
     obo:IAO_0000115 "A characteristic or attribute of an entity" .
 
-metpo:1000630 a owl:Class ;
+METPO:1000630 a owl:Class ;
     rdfs:label "biological process" ;
     obo:IAO_0000115 "A process carried out by a biological entity" .
 
-metpo:1001000 a owl:Class ;
+METPO:1001000 a owl:Class ;
     rdfs:label "observation" ;
     obo:IAO_0000115 "A measurement or observation" .
 
 # ===== QUALITY (PHENOTYPE) HIERARCHY =====
 
 # Oxygen-related phenotypes (current IDs)
-metpo:1000602 a owl:Class ;
+METPO:1000602 a owl:Class ;
     rdfs:label "aerobic" ;
     obo:IAO_0000115 "Requiring oxygen for growth" ;
-    rdfs:subClassOf metpo:1000188 .
+    rdfs:subClassOf METPO:1000188 .
 
 # Motility phenotypes (current IDs)  
-metpo:1000702 a owl:Class ;
+METPO:1000702 a owl:Class ;
     rdfs:label "motile" ;
     obo:IAO_0000115 "Capable of self-propelled movement" ;
-    rdfs:subClassOf metpo:1000188 .
+    rdfs:subClassOf METPO:1000188 .
 
 # Cell shape phenotypes (current IDs)
-metpo:1000666 a owl:Class ;
+METPO:1000666 a owl:Class ;
     rdfs:label "cell shape" ;
     obo:IAO_0000115 "The morphological form of a cell" ;
-    rdfs:subClassOf metpo:1000188 .
+    rdfs:subClassOf METPO:1000188 .
 
 # Temperature phenotypes (current IDs)
-metpo:1000800 a owl:Class ;
+METPO:1000800 a owl:Class ;
     rdfs:label "temperature phenotype" ;
     obo:IAO_0000115 "A phenotype related to temperature adaptation" ;
-    rdfs:subClassOf metpo:1000188 .
+    rdfs:subClassOf METPO:1000188 .
 
 # ===== NOTE ON ID CHANGES =====
 
@@ -75,6 +75,6 @@ metpo:1000800 a owl:Class ;
 # Instance-level relationships (e.g., strain → phenotype) use RO properties:
 #
 # Example (not in METPO itself, used by applications):
-# :strain_XYZ RO:0000086 metpo:1000702 .  # has quality: motile
+# :strain_XYZ RO:0000086 METPO:1000702 .  # has quality: motile
 #
 # See KG-Microbe for actual property usage in production data.

--- a/docs/presentations/icbo_2025/figures/metpo_viz/key_properties.ttl
+++ b/docs/presentations/icbo_2025/figures/metpo_viz/key_properties.ttl
@@ -1,4 +1,4 @@
-@prefix metpo: <https://w3id.org/metpo/> .
+@prefix METPO: <https://w3id.org/metpo/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 
@@ -15,10 +15,10 @@
 # PHENOTYPE ASSERTION
 # ----------------------------------------------------------------------------
 
-metpo:2000102 a owl:ObjectProperty ;
+METPO:2000102 a owl:ObjectProperty ;
     rdfs:label "has phenotype" ;
-    rdfs:domain metpo:1000525 ;  # microbe
-    rdfs:range metpo:1000059 ;   # phenotype
+    rdfs:domain METPO:1000525 ;  # microbe
+    rdfs:range METPO:1000059 ;   # phenotype
     rdfs:comment """
         Used to assert that a microbial organism exhibits a particular phenotype.
         Example: Escherichia coli has_phenotype aerobic
@@ -28,10 +28,10 @@ metpo:2000102 a owl:ObjectProperty ;
 # BIOLOGICAL PROCESS CAPABILITY
 # ----------------------------------------------------------------------------
 
-metpo:2000103 a owl:ObjectProperty ;
+METPO:2000103 a owl:ObjectProperty ;
     rdfs:label "capable of" ;
-    rdfs:domain metpo:1000525 ;  # microbe
-    rdfs:range metpo:1000630 ;   # biological process
+    rdfs:domain METPO:1000525 ;  # microbe
+    rdfs:range METPO:1000630 ;   # biological process
     rdfs:comment """
         Used to assert that a microbial organism can perform a biological process.
         Example: Bacillus subtilis capable_of sporulation
@@ -41,10 +41,10 @@ metpo:2000103 a owl:ObjectProperty ;
 # CHEMICAL INTERACTIONS (Root Property)
 # ----------------------------------------------------------------------------
 
-metpo:2000001 a owl:ObjectProperty ;
+METPO:2000001 a owl:ObjectProperty ;
     rdfs:label "organism interacts with chemical" ;
-    rdfs:domain metpo:1000525 ;  # microbe
-    rdfs:range metpo:1000526 ;   # chemical entity
+    rdfs:domain METPO:1000525 ;  # microbe
+    rdfs:range METPO:1000526 ;   # chemical entity
     rdfs:comment """
         Root property for all chemical utilization relationships.
         Has many specific subproperties (see below).
@@ -54,103 +54,103 @@ metpo:2000001 a owl:ObjectProperty ;
 # CHEMICAL INTERACTION SUBPROPERTIES
 # ----------------------------------------------------------------------------
 
-metpo:2000002 a owl:ObjectProperty ;
+METPO:2000002 a owl:ObjectProperty ;
     rdfs:label "assimilates" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Organism incorporates the chemical into biomass" .
 
-metpo:2000006 a owl:ObjectProperty ;
+METPO:2000006 a owl:ObjectProperty ;
     rdfs:label "uses as carbon source" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical provides carbon for organism growth" .
 
-metpo:2000007 a owl:ObjectProperty ;
+METPO:2000007 a owl:ObjectProperty ;
     rdfs:label "degrades" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Organism breaks down the chemical" .
 
-metpo:2000008 a owl:ObjectProperty ;
+METPO:2000008 a owl:ObjectProperty ;
     rdfs:label "uses as electron acceptor" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical accepts electrons in respiration" .
 
-metpo:2000009 a owl:ObjectProperty ;
+METPO:2000009 a owl:ObjectProperty ;
     rdfs:label "uses as electron donor" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical donates electrons in respiration" .
 
-metpo:2000010 a owl:ObjectProperty ;
+METPO:2000010 a owl:ObjectProperty ;
     rdfs:label "uses as energy source" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical provides energy for organism" .
 
-metpo:2000011 a owl:ObjectProperty ;
+METPO:2000011 a owl:ObjectProperty ;
     rdfs:label "ferments" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Organism ferments the chemical" .
 
-metpo:2000012 a owl:ObjectProperty ;
+METPO:2000012 a owl:ObjectProperty ;
     rdfs:label "uses for growth" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical supports organism growth" .
 
-metpo:2000013 a owl:ObjectProperty ;
+METPO:2000013 a owl:ObjectProperty ;
     rdfs:label "hydrolyzes" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Organism hydrolyzes the chemical" .
 
-metpo:2000014 a owl:ObjectProperty ;
+METPO:2000014 a owl:ObjectProperty ;
     rdfs:label "uses as nitrogen source" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical provides nitrogen for organism" .
 
-metpo:2000016 a owl:ObjectProperty ;
+METPO:2000016 a owl:ObjectProperty ;
     rdfs:label "oxidizes" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Organism oxidizes the chemical" .
 
-metpo:2000017 a owl:ObjectProperty ;
+METPO:2000017 a owl:ObjectProperty ;
     rdfs:label "reduces" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Organism reduces the chemical" .
 
-metpo:2000018 a owl:ObjectProperty ;
+METPO:2000018 a owl:ObjectProperty ;
     rdfs:label "requires for growth" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical is required for organism growth" .
 
-metpo:2000019 a owl:ObjectProperty ;
+METPO:2000019 a owl:ObjectProperty ;
     rdfs:label "uses for respiration" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical is used in respiration" .
 
-metpo:2000020 a owl:ObjectProperty ;
+METPO:2000020 a owl:ObjectProperty ;
     rdfs:label "uses as sulfur source" ;
-    rdfs:subPropertyOf metpo:2000001 ;
+    rdfs:subPropertyOf METPO:2000001 ;
     rdfs:comment "Chemical provides sulfur for organism" .
 
 # ----------------------------------------------------------------------------
 # DOMAIN AND RANGE CLASSES
 # ----------------------------------------------------------------------------
 
-metpo:1000525 a owl:Class ;
+METPO:1000525 a owl:Class ;
     rdfs:label "microbe" ;
     rdfs:comment "The organism class - domain of has_phenotype and chemical interaction properties" .
 
-metpo:1000526 a owl:Class ;
+METPO:1000526 a owl:Class ;
     rdfs:label "chemical entity" ;
     rdfs:comment "The chemical class - range of chemical interaction properties" .
 
-metpo:1000059 a owl:Class ;
+METPO:1000059 a owl:Class ;
     rdfs:label "phenotype" ;
-    rdfs:subClassOf metpo:1000188 ;  # quality
+    rdfs:subClassOf METPO:1000188 ;  # quality
     rdfs:comment "The phenotype class - range of has_phenotype property" .
 
-metpo:1000630 a owl:Class ;
+METPO:1000630 a owl:Class ;
     rdfs:label "biological process" ;
     rdfs:comment "The process class - range of capable_of property" .
 
-metpo:1000188 a owl:Class ;
+METPO:1000188 a owl:Class ;
     rdfs:label "quality" ;
     rdfs:comment "Root class for all qualities/phenotypes" .
 

--- a/docs/presentations/icbo_2025/icbo_metpo_slides.md
+++ b/docs/presentations/icbo_2025/icbo_metpo_slides.md
@@ -170,21 +170,21 @@ We evaluated existing ontologies for microbial trait coverage:
 **Direct synonym assertion (no provenance):**
 
 ```turtle
-metpo:1000644 oboInOwl:hasRelatedSynonym "aerobic_heterotrophy" .
-metpo:1000644 oboInOwl:hasRelatedSynonym "heterotroph" .
+METPO:1000644 oboInOwl:hasRelatedSynonym "aerobic_heterotrophy" .
+METPO:1000644 oboInOwl:hasRelatedSynonym "heterotroph" .
 ```
 
 **Annotated axioms (with provenance):**
 
 ```turtle
 [] a owl:Axiom ;
-  owl:annotatedSource metpo:1000644 ;
+  owl:annotatedSource METPO:1000644 ;
   owl:annotatedProperty oboInOwl:hasRelatedSynonym ;
   owl:annotatedTarget "aerobic_heterotrophy" ;
   IAO:0000119 <https://github.com/jmadin/bacteria_archaea_traits> .
 
 [] a owl:Axiom ;
-  owl:annotatedSource metpo:1000644 ;
+  owl:annotatedSource METPO:1000644 ;
   owl:annotatedProperty oboInOwl:hasRelatedSynonym ;
   owl:annotatedTarget "heterotroph" ;
   IAO:0000119 <https://bacdive.dsmz.de/> .
@@ -200,23 +200,23 @@ metpo:1000644 oboInOwl:hasRelatedSynonym "heterotroph" .
 **1. Phenotype Assertions**
 
 ```turtle
-metpo:2000102 a owl:ObjectProperty ;
+METPO:2000102 a owl:ObjectProperty ;
   rdfs:label "has phenotype" ;
-  rdfs:domain metpo:1000525 ;  # microbe
-  rdfs:range metpo:1000059 .   # phenotype
+  rdfs:domain METPO:1000525 ;  # microbe
+  rdfs:range METPO:1000059 .   # phenotype
 
 # Usage example:
-NCBITaxon:562 metpo:2000102 metpo:1000602 .
+NCBITaxon:562 METPO:2000102 METPO:1000602 .
 # E. coli has_phenotype aerobic
 ```
 
 **2. Process Capabilities**
 
 ```turtle
-metpo:2000103 a owl:ObjectProperty ;
+METPO:2000103 a owl:ObjectProperty ;
   rdfs:label "capable of" ;
-  rdfs:domain metpo:1000525 ;  # microbe
-  rdfs:range metpo:1000630 .   # process
+  rdfs:domain METPO:1000525 ;  # microbe
+  rdfs:range METPO:1000630 .   # process
 
 # B. subtilis capable_of sporulation
 ```
@@ -227,10 +227,10 @@ metpo:2000103 a owl:ObjectProperty ;
 **3. Chemical Interactions (20+ subproperties)**
 
 ```turtle
-metpo:2000001 a owl:ObjectProperty ;
+METPO:2000001 a owl:ObjectProperty ;
   rdfs:label "organism interacts with chemical" ;
-  rdfs:domain metpo:1000525 ;  # microbe
-  rdfs:range metpo:1000526 .   # chemical
+  rdfs:domain METPO:1000525 ;  # microbe
+  rdfs:range METPO:1000526 .   # chemical
 
 # Subproperties include:
 # ferments, uses_as_carbon_source, degrades,
@@ -238,7 +238,7 @@ metpo:2000001 a owl:ObjectProperty ;
 # ... 14 more
 
 # Example:
-NCBITaxon:562 metpo:2000011 CHEBI:17234 .
+NCBITaxon:562 METPO:2000011 CHEBI:17234 .
 # E. coli ferments glucose
 ```
 

--- a/docs/src/sparql/definition_sources.sparql
+++ b/docs/src/sparql/definition_sources.sparql
@@ -1,4 +1,4 @@
-PREFIX metpo: <https://w3id.org/metpo/>
+PREFIX METPO: <https://w3id.org/metpo/>
 PREFIX IAO: <http://purl.obolibrary.org/obo/IAO_>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/sparql/README.md
+++ b/sparql/README.md
@@ -43,7 +43,7 @@ This directory contains SPARQL queries for different RDF backends used in the ME
 - LIMITED to 100 results
 
 ### `chem_interaction_props.rq`
-**Purpose:** List chemical interaction properties (subproperties of metpo:2000001)
+**Purpose:** List chemical interaction properties (subproperties of METPO:2000001)
 **Used by:** Schema documentation
 **Key patterns:**
 - Queries METPO object property hierarchy
@@ -53,7 +53,7 @@ This directory contains SPARQL queries for different RDF backends used in the ME
 **Purpose:** Extract BacDive-to-METPO oxygen preference mappings
 **Used by:** Data integration workflows
 **Key patterns:**
-- Queries subclasses of `metpo:1000601` (oxygen preference)
+- Queries subclasses of `METPO:1000601` (oxygen preference)
 - Extracts BacDive labels from `oboInOwl:hasRelatedSynonym`
 - Maps to METPO CURIEs and labels
 

--- a/sparql/bacdive_oxygen_phenotype_mappings.rq
+++ b/sparql/bacdive_oxygen_phenotype_mappings.rq
@@ -11,7 +11,7 @@ PREFIX  IAO:  <http://purl.obolibrary.org/obo/IAO_>
 SELECT  ?bacdive_label ?metpo_curie ?metpo_label
 WHERE
   { ?p  rdfs:subClassOf  oxpref:
-    BIND(replace(str(?p), "https://w3id.org/metpo/", "metpo:") AS ?metpo_curie)
+    BIND(replace(str(?p), "https://w3id.org/metpo/", "METPO:") AS ?metpo_curie)
     OPTIONAL
       { ?p  rdfs:label  ?metpo_label }
     OPTIONAL

--- a/sparql/chem_interaction_props.rq
+++ b/sparql/chem_interaction_props.rq
@@ -1,5 +1,5 @@
 # Backend: METPO OWL file (src/ontology/metpo.owl)
-# Purpose: List chemical interaction properties (subproperties of metpo:2000001)
+# Purpose: List chemical interaction properties (subproperties of METPO:2000001)
 # Used by: Schema documentation and property hierarchy analysis
 # Returns: All object properties related to chemical interactions
 

--- a/sparql/query_metpo_entities.sparql
+++ b/sparql/query_metpo_entities.sparql
@@ -3,7 +3,7 @@
 # Used by: Data extraction workflows
 # Returns: Complete METPO entity dump with optional synonyms
 
-PREFIX metpo: <https://w3id.org/metpo/>
+PREFIX METPO: <https://w3id.org/metpo/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>

--- a/tests/check_curie_prefix_case.sh
+++ b/tests/check_curie_prefix_case.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Enforce the blessed METPO CURIE prefix case (berkeleybop/metpo#16):
+#   - CURIE prefix token is UPPERCASE  -> METPO:1000059
+#   - URI namespace path stays lowercase -> https://w3id.org/metpo/
+#
+# This guards hand-authored RDF, SPARQL, and documentation against lowercase
+# `metpo:` CURIE prefixes creeping back in. The regex only matches `metpo:`
+# when it is preceded by a non-identifier character, so it ignores Make targets
+# (`load-metpo:`), YAML keys (`strain_phenotype_metpo:`), and Python names
+# (`curie_to_metpo:`), none of which are CURIEs.
+#
+# Deliberately NOT scanned:
+#   - external/         : frozen historical BioPortal submissions (archival record)
+#   - generated release artifacts (metpo.owl / -base / -full / *.obo): their
+#     lowercase `idspace: metpo` is tracked in berkeleybop/metpo#557 and fixed at
+#     the generator, not by hand.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# `metpo:` as a CURIE = preceded by start-of-line or a non-[A-Za-z0-9_-] char.
+pattern='(^|[^A-Za-z0-9_-])metpo:'
+
+hits=$(git grep -nIE "$pattern" -- \
+  '*.ttl' '*.rq' '*.sparql' '*.md' \
+  ':(exclude)external/**' \
+  ':(exclude)tests/check_curie_prefix_case.sh' || true)
+
+if [ -n "$hits" ]; then
+  echo "::error::Lowercase 'metpo:' CURIE prefix found. Use uppercase 'METPO:' (see berkeleybop/metpo#16)."
+  echo "$hits"
+  exit 1
+fi
+
+echo "OK: no lowercase 'metpo:' CURIE prefixes in tracked RDF/SPARQL/doc files."

--- a/tests/sparql_qc/qc-positive-fixture.ttl
+++ b/tests/sparql_qc/qc-positive-fixture.ttl
@@ -22,10 +22,10 @@
 @prefix dce:     <http://purl.org/dc/elements/1.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix IAO:     <http://purl.obolibrary.org/obo/IAO_> .
-@prefix metpo:   <https://w3id.org/metpo/> .
+@prefix METPO:   <https://w3id.org/metpo/> .
 
 # -> dc-properties-violation.sparql : deprecated DC Elements 1.1 predicate on a METPO term
-metpo:9999001 a owl:Class ;
+METPO:9999001 a owl:Class ;
     rdfs:label "fixture: deprecated dc-elements predicate" ;
     dce:creator "intentionally wrong for testing; production should use dcterms:creator" .
 
@@ -41,23 +41,26 @@ metpo:9999001 a owl:Class ;
     owl:versionInfo "2026-06-05" .
 
 # -> iri-range-violation.sparql : a property whose value must be an IRI, given a literal
-metpo:9999002 a owl:Class ;
+METPO:9999002 a owl:Class ;
     rdfs:label "fixture: contributor as a literal, not an IRI" ;
     dcterms:contributor "Jane Doe" .
 
 # -> label-with-iri-violation.sparql : an rdfs:label containing a URL
-metpo:9999003 a owl:Class ;
+METPO:9999003 a owl:Class ;
     rdfs:label "fixture: a label that wrongly embeds http://example.org/foo" .
 
 # -> multiple-replaced_by-violation.sparql : two distinct IAO:0100001 (term replaced by) values
-metpo:9999004 a owl:Class ;
+# METPO:1000000 and METPO:2000000 are intentional fixture-only IRIs: they supply
+# two distinct replacement targets for this violation case and are not declared
+# here, nor expected to exist as production METPO terms.
+METPO:9999004 a owl:Class ;
     rdfs:label "fixture: two different replacements" ;
-    IAO:0100001 metpo:1000000 , metpo:2000000 .
+    IAO:0100001 METPO:1000000 , METPO:2000000 .
 
 # -> owldef-self-reference-violation.sparql : equivalent-class definition that references itself
-metpo:9999005 a owl:Class ;
+METPO:9999005 a owl:Class ;
     rdfs:label "fixture: self-referential equivalent class" ;
     owl:equivalentClass [
         a owl:Class ;
-        owl:intersectionOf ( metpo:9999005 )
+        owl:intersectionOf ( METPO:9999005 )
     ] .


### PR DESCRIPTION
Closes the gap between the blessed prefix decision (#16) and the hand-authored source: the CURIE prefix should be uppercase `METPO:` over the lowercase URI path `https://w3id.org/metpo/` (matches bioregistry `preferred_prefix: METPO`, `README.md`, `metpo-odk.yaml`, `metpo-idranges.owl`).

Normalizes `metpo:` -> `METPO:` in 9 RDF/SPARQL/doc files (prefix bindings and usages flipped together, so resolution is unchanged), plus adds a CI guard.

One change affects emitted output, called out for review: `sparql/bacdive_oxygen_phenotype_mappings.rq` builds a display CURIE; its `BIND(... "metpo:" ...)` becomes `"METPO:"`, so the `?metpo_curie` column is now emitted in canonical case.

New guard `tests/check_curie_prefix_case.sh` + `curie-prefix-case.yml` workflow fails on a lowercase `metpo:` CURIE prefix in tracked `.ttl`/`.rq`/`.sparql`/`.md`. Its regex ignores non-CURIE `metpo:` (Make targets like `load-metpo:`, YAML keys, Python names). Verified locally: passes clean, catches a planted violation, ignores the false positives.

Deliberately out of scope:
- Generated release artifacts (`metpo.obo`/`-base`/`-full`, `.owl`) still carry lowercase `idspace: metpo`; that needs a generator fix + rebuild and is tracked in #557 (so the guard does not scan them).
- `external/metpo_historical/*.owl` are frozen archival BioPortal submissions, left as-is.
- A synthetic `metpo:<filename>` placeholder id in `analyze_metpo_grounding.py` is an internal analysis id, not an ontology term CURIE, so it is left as-is and outside the guard's RDF/query/doc scope.