### PR TITLE
fix: emit uppercase METPO idspace in OBO release artifacts (#557)

### DIFF
--- a/metpo-base.obo
+++ b/metpo-base.obo
@@ -2,7 +2,7 @@ format-version: 1.2
 data-version: https://w3id.org/metpo/releases/2026-06-12/metpo-base.owl
 idspace: dc http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
-idspace: metpo https://w3id.org/metpo/ 
+idspace: METPO https://w3id.org/metpo/ 
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
 idspace: qudt http://qudt.org/schema/qudt/ 
 idspace: skos http://www.w3.org/2004/02/skos/core# 
@@ -20,7566 +20,7566 @@ property_value: seeAlso https://bioregistry.io/registry/metpo
 property_value: seeAlso https://github.com/berkeleybop/metpo
 
 [Term]
-id: metpo:0000001
+id: METPO:0000001
 name: obsolete Temperature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000002
+id: METPO:0000002
 name: obsolete Salinity
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000003
+id: METPO:0000003
 name: obsolete pH
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000004
+id: METPO:0000004
 name: obsolete Oxygen
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000005
+id: METPO:0000005
 name: obsolete Trophic type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000631
+replaced_by: METPO:1000631
 
 [Term]
-id: metpo:0000006
+id: METPO:0000006
 name: obsolete Motility
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000701
+replaced_by: METPO:1000701
 
 [Term]
-id: metpo:0000007
+id: METPO:0000007
 name: obsolete Sporulation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:0000008
+id: METPO:0000008
 name: obsolete Pressure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000009
+id: METPO:0000009
 name: obsolete GC content
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:000001
+id: METPO:000001
 name: obsolete Temperature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000010
+id: METPO:0000010
 name: obsolete Cell Width
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000011
+id: METPO:0000011
 name: obsolete Cell Length
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000012
+id: METPO:0000012
 name: obsolete Temperature Optimum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000304
+replaced_by: METPO:1000304
 
 [Term]
-id: metpo:0000013
+id: METPO:0000013
 name: obsolete Temperature Range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000306
+replaced_by: METPO:1000306
 
 [Term]
-id: metpo:0000014
+id: METPO:0000014
 name: obsolete pH Optimum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000331
+replaced_by: METPO:1000331
 
 [Term]
-id: metpo:0000015
+id: METPO:0000015
 name: obsolete pH Range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000332
+replaced_by: METPO:1000332
 
 [Term]
-id: metpo:0000016
+id: METPO:0000016
 name: obsolete NaCl Optimum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000333
+replaced_by: METPO:1000333
 
 [Term]
-id: metpo:0000017
+id: METPO:0000017
 name: obsolete NaCl Range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000334
+replaced_by: METPO:1000334
 
 [Term]
-id: metpo:0000018
+id: METPO:0000018
 name: obsolete pH delta
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000232
+replaced_by: METPO:1000232
 
 [Term]
-id: metpo:0000019
+id: METPO:0000019
 name: obsolete NaCl delta
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000335
+replaced_by: METPO:1000335
 
 [Term]
-id: metpo:000002
+id: METPO:000002
 name: obsolete Salinity
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000020
+id: METPO:0000020
 name: obsolete Temperature Delta
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000303
+replaced_by: METPO:1000303
 
 [Term]
-id: metpo:0000021
+id: METPO:0000021
 name: obsolete METPO Morphology
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000022
+id: METPO:0000022
 name: obsolete Psychrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:0000023
+id: METPO:0000023
 name: obsolete Psychrotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:0000024
+id: METPO:0000024
 name: obsolete Mesophilie
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000025
+id: METPO:0000025
 name: obsolete Thermotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:0000026
+id: METPO:0000026
 name: obsolete Thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:0000027
+id: METPO:0000027
 name: obsolete Extreme thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:0000028
+id: METPO:0000028
 name: obsolete Hyperthermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:0000029
+id: METPO:0000029
 name: obsolete Extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:000003
+id: METPO:000003
 name: obsolete pH
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000030
+id: METPO:0000030
 name: obsolete Halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:0000031
+id: METPO:0000031
 name: obsolete Non-halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:0000032
+id: METPO:0000032
 name: obsolete Slight halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:0000033
+id: METPO:0000033
 name: obsolete Moderate halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:0000034
+id: METPO:0000034
 name: obsolete Extreme halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:0000035
+id: METPO:0000035
 name: obsolete Halotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:0000036
+id: METPO:0000036
 name: obsolete Haloalkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:0000037
+id: METPO:0000037
 name: obsolete Extreme Acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000038
+id: METPO:0000038
 name: obsolete Acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:0000039
+id: METPO:0000039
 name: obsolete Neutrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:000004
+id: METPO:000004
 name: obsolete Oxygen
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000040
+id: METPO:0000040
 name: obsolete Alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:0000041
+id: METPO:0000041
 name: obsolete Acid Tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000042
+id: METPO:0000042
 name: obsolete Alkali Tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000043
+id: METPO:0000043
 name: obsolete Extreme Alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000044
+id: METPO:0000044
 name: obsolete Facultative acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:0000045
+id: METPO:0000045
 name: obsolete Obligative acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:0000046
+id: METPO:0000046
 name: obsolete Aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000047
+id: METPO:0000047
 name: obsolete Anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:0000048
+id: METPO:0000048
 name: obsolete Facultative anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:0000049
+id: METPO:0000049
 name: obsolete Facultative aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:000005
+id: METPO:000005
 name: obsolete Trophic type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000631
+replaced_by: METPO:1000631
 
 [Term]
-id: metpo:0000050
+id: METPO:0000050
 name: obsolete Microaerophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:0000051
+id: METPO:0000051
 name: obsolete Aerotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:0000052
+id: METPO:0000052
 name: obsolete Microaerotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:0000053
+id: METPO:0000053
 name: obsolete Aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000054
+id: METPO:0000054
 name: obsolete Obligate aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:0000055
+id: METPO:0000055
 name: obsolete Obligate anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:0000056
+id: METPO:0000056
 name: obsolete Oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000057
+id: METPO:0000057
 name: obsolete Anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000058
+id: METPO:0000058
 name: obsolete Autotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:0000059
+id: METPO:0000059
 name: obsolete Photoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:000006
+id: METPO:000006
 name: obsolete Motility
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000701
+replaced_by: METPO:1000701
 
 [Term]
-id: metpo:0000060
+id: METPO:0000060
 name: obsolete Chemoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:0000061
+id: METPO:0000061
 name: obsolete Heterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:0000062
+id: METPO:0000062
 name: obsolete Photoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:0000063
+id: METPO:0000063
 name: obsolete Chemoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:0000064
+id: METPO:0000064
 name: obsolete Lithotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:0000065
+id: METPO:0000065
 name: obsolete Organotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:0000066
+id: METPO:0000066
 name: obsolete Phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:0000067
+id: METPO:0000067
 name: obsolete Chemotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:0000068
+id: METPO:0000068
 name: obsolete Oligotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:0000069
+id: METPO:0000069
 name: obsolete Copiotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:000007
+id: METPO:000007
 name: obsolete Sporulation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:0000070
+id: METPO:0000070
 name: obsolete Lithoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:0000071
+id: METPO:0000071
 name: obsolete Mixotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:0000072
+id: METPO:0000072
 name: obsolete Lithoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:0000073
+id: METPO:0000073
 name: obsolete Chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:0000074
+id: METPO:0000074
 name: obsolete Chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:0000075
+id: METPO:0000075
 name: obsolete Methylotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:0000076
+id: METPO:0000076
 name: obsolete Methanotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:0000077
+id: METPO:0000077
 name: obsolete Carboxydotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:0000078
+id: METPO:0000078
 name: obsolete Hydrogenotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:0000079
+id: METPO:0000079
 name: obsolete Hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000008
+id: METPO:000008
 name: obsolete Pressure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000080
+id: METPO:0000080
 name: obsolete Hydrogen producer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000081
+id: METPO:0000081
 name: obsolete Nitrogen fixer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000082
+id: METPO:0000082
 name: obsolete Methanogen
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000083
+id: METPO:0000083
 name: obsolete Sulfate reducer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000084
+id: METPO:0000084
 name: obsolete Sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000085
+id: METPO:0000085
 name: obsolete Denitrifier
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000086
+id: METPO:0000086
 name: obsolete Capnophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:0000087
+id: METPO:0000087
 name: obsolete Motile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:0000088
+id: METPO:0000088
 name: obsolete Non-motile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:0000089
+id: METPO:0000089
 name: obsolete Flagellated
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:000009
+id: METPO:000009
 name: obsolete GC content
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:0000090
+id: METPO:0000090
 name: obsolete Peritrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000091
+id: METPO:0000091
 name: obsolete Lophotrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000092
+id: METPO:0000092
 name: obsolete Monotrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000093
+id: METPO:0000093
 name: obsolete Ciliated
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000094
+id: METPO:0000094
 name: obsolete Gliding
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:0000095
+id: METPO:0000095
 name: obsolete Twitching
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000096
+id: METPO:0000096
 name: obsolete Sliding
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000097
+id: METPO:0000097
 name: obsolete Swarming
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000098
+id: METPO:0000098
 name: obsolete Endospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000099
+id: METPO:0000099
 name: obsolete Exospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000010
+id: METPO:000010
 name: obsolete Cell Width
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000100
+id: METPO:0000100
 name: obsolete Myxospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000101
+id: METPO:0000101
 name: obsolete Arthrospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000102
+id: METPO:0000102
 name: obsolete Conidia
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000103
+id: METPO:0000103
 name: obsolete Sporangiospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000104
+id: METPO:0000104
 name: obsolete Zygospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000105
+id: METPO:0000105
 name: obsolete Akinetes
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000106
+id: METPO:0000106
 name: obsolete Chlamydospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000107
+id: METPO:0000107
 name: obsolete Sporocysts
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000108
+id: METPO:0000108
 name: obsolete Hypnospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000109
+id: METPO:0000109
 name: obsolete Gemmae
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000011
+id: METPO:000011
 name: obsolete Cell Length
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000110
+id: METPO:0000110
 name: obsolete Oospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000111
+id: METPO:0000111
 name: obsolete Azygospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000112
+id: METPO:0000112
 name: obsolete Cysts
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000113
+id: METPO:0000113
 name: obsolete Ascospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000114
+id: METPO:0000114
 name: obsolete Basidiospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000115
+id: METPO:0000115
 name: obsolete Aleuriospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000116
+id: METPO:0000116
 name: obsolete Stylospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000117
+id: METPO:0000117
 name: obsolete Sclerotia
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000118
+id: METPO:0000118
 name: obsolete Zoospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000119
+id: METPO:0000119
 name: obsolete Teliospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000012
+id: METPO:000012
 name: obsolete Temperature Optimum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000304
+replaced_by: METPO:1000304
 
 [Term]
-id: metpo:0000120
+id: METPO:0000120
 name: obsolete Urediniospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000121
+id: METPO:0000121
 name: obsolete Pycnidiospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000122
+id: METPO:0000122
 name: obsolete Acriospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000123
+id: METPO:0000123
 name: obsolete Aplanospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000124
+id: METPO:0000124
 name: obsolete Statismospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000125
+id: METPO:0000125
 name: obsolete Barotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000126
+id: METPO:0000126
 name: obsolete Piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000127
+id: METPO:0000127
 name: obsolete Piezotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000128
+id: METPO:0000128
 name: obsolete Piezosensitive
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000129
+id: METPO:0000129
 name: obsolete Obligate barophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000013
+id: METPO:000013
 name: obsolete Temperature Range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000306
+replaced_by: METPO:1000306
 
 [Term]
-id: metpo:0000130
+id: METPO:0000130
 name: obsolete Facultative barophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000131
+id: METPO:0000131
 name: obsolete Hyperbarophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000132
+id: METPO:0000132
 name: obsolete Hypobarophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000133
+id: METPO:0000133
 name: obsolete Atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000134
+id: METPO:0000134
 name: obsolete Moderate piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000135
+id: METPO:0000135
 name: obsolete Extreme piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000136
+id: METPO:0000136
 name: obsolete Stenopiezic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000137
+id: METPO:0000137
 name: obsolete Eurypiezic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000138
+id: METPO:0000138
 name: obsolete Pressure-sensitive
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000139
+id: METPO:0000139
 name: obsolete Pressure-resistant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000014
+id: METPO:000014
 name: obsolete pH Optimum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000331
+replaced_by: METPO:1000331
 
 [Term]
-id: metpo:0000140
+id: METPO:0000140
 name: obsolete Pressure-adapted
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000141
+id: METPO:0000141
 name: obsolete Piezo-acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000142
+id: METPO:0000142
 name: obsolete Piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000143
+id: METPO:0000143
 name: obsolete Piezo-halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000144
+id: METPO:0000144
 name: obsolete Piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000145
+id: METPO:0000145
 name: obsolete Piezo-thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000146
+id: METPO:0000146
 name: obsolete Piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000147
+id: METPO:0000147
 name: obsolete Piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:0000148
+id: METPO:0000148
 name: obsolete Piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000149
+id: METPO:0000149
 name: obsolete Piezo-endolithic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000015
+id: METPO:000015
 name: obsolete pH Range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000332
+replaced_by: METPO:1000332
 
 [Term]
-id: metpo:0000150
+id: METPO:0000150
 name: obsolete Piezo-tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000151
+id: METPO:0000151
 name: obsolete GC low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000429
+replaced_by: METPO:1000429
 
 [Term]
-id: metpo:0000152
+id: METPO:0000152
 name: obsolete GC mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000430
+replaced_by: METPO:1000430
 
 [Term]
-id: metpo:0000153
+id: METPO:0000153
 name: obsolete GC mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000431
+replaced_by: METPO:1000431
 
 [Term]
-id: metpo:0000154
+id: METPO:0000154
 name: obsolete GC high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000432
+replaced_by: METPO:1000432
 
 [Term]
-id: metpo:0000155
+id: METPO:0000155
 name: obsolete Cell width very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000887
+replaced_by: METPO:1000887
 
 [Term]
-id: metpo:0000156
+id: METPO:0000156
 name: obsolete Cell width low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000157
+id: METPO:0000157
 name: obsolete Cell width mid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000889
+replaced_by: METPO:1000889
 
 [Term]
-id: metpo:0000158
+id: METPO:0000158
 name: obsolete Cell width high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000159
+id: METPO:0000159
 name: obsolete Cell length very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000883
+replaced_by: METPO:1000883
 
 [Term]
-id: metpo:000016
+id: METPO:000016
 name: obsolete NaCl Optimum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000333
+replaced_by: METPO:1000333
 
 [Term]
-id: metpo:0000160
+id: METPO:0000160
 name: obsolete Cell length low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000161
+id: METPO:0000161
 name: obsolete Cell length mid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000885
+replaced_by: METPO:1000885
 
 [Term]
-id: metpo:0000162
+id: METPO:0000162
 name: obsolete Cell length high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000163
+id: METPO:0000163
 name: obsolete Temperature Optimum very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000441
+replaced_by: METPO:1000441
 
 [Term]
-id: metpo:0000164
+id: METPO:0000164
 name: obsolete Temperature Optimum low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000442
+replaced_by: METPO:1000442
 
 [Term]
-id: metpo:0000165
+id: METPO:0000165
 name: obsolete Temperature Optimum mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000443
+replaced_by: METPO:1000443
 
 [Term]
-id: metpo:0000166
+id: METPO:0000166
 name: obsolete Temperature Optimum mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000444
+replaced_by: METPO:1000444
 
 [Term]
-id: metpo:0000167
+id: METPO:0000167
 name: obsolete Temperature Optimum mid3
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:0000168
+id: METPO:0000168
 name: obsolete Temperature Optimum mid4
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000446
+replaced_by: METPO:1000446
 
 [Term]
-id: metpo:0000169
+id: METPO:0000169
 name: obsolete Temperature Optimum high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000447
+replaced_by: METPO:1000447
 
 [Term]
-id: metpo:000017
+id: METPO:000017
 name: obsolete NaCl Range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000334
+replaced_by: METPO:1000334
 
 [Term]
-id: metpo:0000170
+id: METPO:0000170
 name: obsolete Temperature Range very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000448
+replaced_by: METPO:1000448
 
 [Term]
-id: metpo:0000171
+id: METPO:0000171
 name: obsolete Temperature Range low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000449
+replaced_by: METPO:1000449
 
 [Term]
-id: metpo:0000172
+id: METPO:0000172
 name: obsolete Temperature Range mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000450
+replaced_by: METPO:1000450
 
 [Term]
-id: metpo:0000173
+id: METPO:0000173
 name: obsolete Temperature Range mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000451
+replaced_by: METPO:1000451
 
 [Term]
-id: metpo:0000174
+id: METPO:0000174
 name: obsolete Temperature Range mid3
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000452
+replaced_by: METPO:1000452
 
 [Term]
-id: metpo:0000175
+id: METPO:0000175
 name: obsolete Temperature Range mid4
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000453
+replaced_by: METPO:1000453
 
 [Term]
-id: metpo:0000176
+id: METPO:0000176
 name: obsolete Temperature Range high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000454
+replaced_by: METPO:1000454
 
 [Term]
-id: metpo:0000177
+id: METPO:0000177
 name: obsolete pH Optimum low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000455
+replaced_by: METPO:1000455
 
 [Term]
-id: metpo:0000178
+id: METPO:0000178
 name: obsolete pH Optimum mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000456
+replaced_by: METPO:1000456
 
 [Term]
-id: metpo:0000179
+id: METPO:0000179
 name: obsolete pH Optimum mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000457
+replaced_by: METPO:1000457
 
 [Term]
-id: metpo:000018
+id: METPO:000018
 name: obsolete pH delta
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000232
+replaced_by: METPO:1000232
 
 [Term]
-id: metpo:0000180
+id: METPO:0000180
 name: obsolete pH Optimum high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000458
+replaced_by: METPO:1000458
 
 [Term]
-id: metpo:0000181
+id: METPO:0000181
 name: obsolete pH Range very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000459
+replaced_by: METPO:1000459
 
 [Term]
-id: metpo:0000182
+id: METPO:0000182
 name: obsolete pH Range low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000460
+replaced_by: METPO:1000460
 
 [Term]
-id: metpo:0000183
+id: METPO:0000183
 name: obsolete pH Range mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000461
+replaced_by: METPO:1000461
 
 [Term]
-id: metpo:0000184
+id: METPO:0000184
 name: obsolete pH Range mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000462
+replaced_by: METPO:1000462
 
 [Term]
-id: metpo:0000185
+id: METPO:0000185
 name: obsolete pH Range mid3
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000463
+replaced_by: METPO:1000463
 
 [Term]
-id: metpo:0000186
+id: METPO:0000186
 name: obsolete pH Range high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000464
+replaced_by: METPO:1000464
 
 [Term]
-id: metpo:0000187
+id: METPO:0000187
 name: obsolete NaCl Optimum low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000465
+replaced_by: METPO:1000465
 
 [Term]
-id: metpo:0000188
+id: METPO:0000188
 name: obsolete NaCl Optimum mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000466
+replaced_by: METPO:1000466
 
 [Term]
-id: metpo:0000189
+id: METPO:0000189
 name: obsolete NaCl Optimum mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000467
+replaced_by: METPO:1000467
 
 [Term]
-id: metpo:000019
+id: METPO:000019
 name: obsolete NaCl delta
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000335
+replaced_by: METPO:1000335
 
 [Term]
-id: metpo:0000190
+id: METPO:0000190
 name: obsolete NaCl Optimum high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000468
+replaced_by: METPO:1000468
 
 [Term]
-id: metpo:0000191
+id: METPO:0000191
 name: obsolete NaCl Range low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000469
+replaced_by: METPO:1000469
 
 [Term]
-id: metpo:0000192
+id: METPO:0000192
 name: obsolete NaCl Range mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000470
+replaced_by: METPO:1000470
 
 [Term]
-id: metpo:0000193
+id: METPO:0000193
 name: obsolete NaCl Range mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000471
+replaced_by: METPO:1000471
 
 [Term]
-id: metpo:0000194
+id: METPO:0000194
 name: obsolete NaCl Range high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000472
+replaced_by: METPO:1000472
 
 [Term]
-id: metpo:0000195
+id: METPO:0000195
 name: obsolete pH Delta very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000473
+replaced_by: METPO:1000473
 
 [Term]
-id: metpo:0000196
+id: METPO:0000196
 name: obsolete pH Delta low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000474
+replaced_by: METPO:1000474
 
 [Term]
-id: metpo:0000197
+id: METPO:0000197
 name: obsolete pH Delta mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000475
+replaced_by: METPO:1000475
 
 [Term]
-id: metpo:0000198
+id: METPO:0000198
 name: obsolete pH Delta mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000476
+replaced_by: METPO:1000476
 
 [Term]
-id: metpo:0000199
+id: METPO:0000199
 name: obsolete pH Delta mid3
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000477
+replaced_by: METPO:1000477
 
 [Term]
-id: metpo:000020
+id: METPO:000020
 name: obsolete Temperature Delta
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000303
+replaced_by: METPO:1000303
 
 [Term]
-id: metpo:0000200
+id: METPO:0000200
 name: obsolete pH Delta high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000478
+replaced_by: METPO:1000478
 
 [Term]
-id: metpo:0000201
+id: METPO:0000201
 name: obsolete NaCl Delta low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000479
+replaced_by: METPO:1000479
 
 [Term]
-id: metpo:0000202
+id: METPO:0000202
 name: obsolete NaCl Delta mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000481
+replaced_by: METPO:1000481
 
 [Term]
-id: metpo:0000203
+id: METPO:0000203
 name: obsolete NaCl Delta mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000481
+replaced_by: METPO:1000481
 
 [Term]
-id: metpo:0000204
+id: METPO:0000204
 name: obsolete NaCl Delta high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000482
+replaced_by: METPO:1000482
 
 [Term]
-id: metpo:0000205
+id: METPO:0000205
 name: obsolete Temperature Delta very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000483
+replaced_by: METPO:1000483
 
 [Term]
-id: metpo:0000206
+id: METPO:0000206
 name: obsolete Temperature Delta low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000484
+replaced_by: METPO:1000484
 
 [Term]
-id: metpo:0000207
+id: METPO:0000207
 name: obsolete Temperature Delta mid1
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000485
+replaced_by: METPO:1000485
 
 [Term]
-id: metpo:0000208
+id: METPO:0000208
 name: obsolete Temperature Delta mid2
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000486
+replaced_by: METPO:1000486
 
 [Term]
-id: metpo:0000209
+id: METPO:0000209
 name: obsolete Temperature Delta high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000487
+replaced_by: METPO:1000487
 
 [Term]
-id: metpo:000021
+id: METPO:000021
 name: obsolete Morphology
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000210
+id: METPO:0000210
 name: obsolete Bacillus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000211
+id: METPO:0000211
 name: obsolete Branced
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000212
+id: METPO:0000212
 name: obsolete Coccobacillus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000213
+id: METPO:0000213
 name: obsolete Coccus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000214
+id: METPO:0000214
 name: obsolete Crescent
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000215
+id: METPO:0000215
 name: obsolete Curved
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000216
+id: METPO:0000216
 name: obsolete Curved Spiral
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000217
+id: METPO:0000217
 name: obsolete Diplococcus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000218
+id: METPO:0000218
 name: obsolete Disc
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000219
+id: METPO:0000219
 name: obsolete Dumbbell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000022
+id: METPO:000022
 name: obsolete Other
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000220
+id: METPO:0000220
 name: obsolete Ellipsoidal
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:0000221
+id: METPO:0000221
 name: obsolete Filament
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000222
+id: METPO:0000222
 name: obsolete Flask
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000223
+id: METPO:0000223
 name: obsolete Fusiform
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000224
+id: METPO:0000224
 name: obsolete Helical
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000225
+id: METPO:0000225
 name: obsolete Irregular
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000226
+id: METPO:0000226
 name: obsolete Oval
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000227
+id: METPO:0000227
 name: obsolete Ovoid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000228
+id: METPO:0000228
 name: obsolete Pleomorphic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000229
+id: METPO:0000229
 name: obsolete Ring
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000023
+id: METPO:000023
 name: obsolete Psychrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:0000230
+id: METPO:0000230
 name: obsolete Rod
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000231
+id: METPO:0000231
 name: obsolete Sphere
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000232
+id: METPO:0000232
 name: obsolete Spindle
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000233
+id: METPO:0000233
 name: obsolete Spiral
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000234
+id: METPO:0000234
 name: obsolete Spirochete
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000235
+id: METPO:0000235
 name: obsolete Spore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000236
+id: METPO:0000236
 name: obsolete Square
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000237
+id: METPO:0000237
 name: obsolete Star
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000238
+id: METPO:0000238
 name: obsolete Star - Dumbbell - Pleomorphic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000239
+id: METPO:0000239
 name: obsolete Tailed
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000024
+id: METPO:000024
 name: obsolete Psychrotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:0000240
+id: METPO:0000240
 name: obsolete Triangular
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000241
+id: METPO:0000241
 name: obsolete Vibrio
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000242
+id: METPO:0000242
 name: obsolete Environmental Parameter
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000243
+id: METPO:0000243
 name: obsolete Growth Condition
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000244
+id: METPO:0000244
 name: obsolete Physiological Trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000245
+id: METPO:0000245
 name: obsolete Metabolic Classification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000246
+id: METPO:0000246
 name: obsolete Cellular Characteristic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000247
+id: METPO:0000247
 name: obsolete Taxonomic Feature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000248
+id: METPO:0000248
 name: obsolete Microbial Adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000249
+id: METPO:0000249
 name: obsolete Growth Parameter
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000025
+id: METPO:000025
 name: obsolete Mesophilie
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000250
+id: METPO:0000250
 name: obsolete Structural Feature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000251
+id: METPO:0000251
 name: obsolete Temperature Adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000252
+id: METPO:0000252
 name: obsolete Salinity Adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000253
+id: METPO:0000253
 name: obsolete pH Adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000254
+id: METPO:0000254
 name: obsolete Oxygen Requirement
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000255
+id: METPO:0000255
 name: obsolete Carbon Source Utilization
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000256
+id: METPO:0000256
 name: obsolete Energy Acquisition Mode
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000257
+id: METPO:0000257
 name: obsolete Electron Donor Type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000258
+id: METPO:0000258
 name: obsolete Motility Mechanism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000259
+id: METPO:0000259
 name: obsolete Motility Structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000026
+id: METPO:000026
 name: obsolete Thermotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:0000260
+id: METPO:0000260
 name: obsolete Bacterial Spore Type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000261
+id: METPO:0000261
 name: obsolete Fungal Spore Type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000262
+id: METPO:0000262
 name: obsolete Reproductive Structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000263
+id: METPO:0000263
 name: obsolete Dormancy Structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000264
+id: METPO:0000264
 name: obsolete Pressure Adaptation Type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000265
+id: METPO:0000265
 name: obsolete Pressure Tolerance Range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:0000266
+id: METPO:0000266
 name: obsolete Genomic Feature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000267
+id: METPO:0000267
 name: obsolete Cell Dimension
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000268
+id: METPO:0000268
 name: obsolete Optimal Growth Parameter
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000269
+id: METPO:0000269
 name: obsolete Growth Range Parameter
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000027
+id: METPO:000027
 name: obsolete Thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:0000270
+id: METPO:0000270
 name: obsolete Growth Tolerance Metric
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000271
+id: METPO:0000271
 name: obsolete Cell Shape
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:0000272
+id: METPO:0000272
 name: obsolete Cell Arrangement
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:0000273
+id: METPO:0000273
 name: obsolete Colony Morphology
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:0000274
+id: METPO:0000274
 name: obsolete Physical Property
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000275
+id: METPO:0000275
 name: obsolete Environmental Context
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000276
+id: METPO:0000276
 name: obsolete Biological Property
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:0000277
+id: METPO:0000277
 name: obsolete Functional Classification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000278
+id: METPO:0000278
 name: obsolete Classification Property
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000279
+id: METPO:0000279
 name: obsolete METPO Biological Process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:000028
+id: METPO:000028
 name: obsolete Extreme thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:0000280
+id: METPO:0000280
 name: obsolete Measurable Property
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000281
+id: METPO:0000281
 name: obsolete Gram-stain negative
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000699
+replaced_by: METPO:1000699
 
 [Term]
-id: metpo:0000282
+id: METPO:0000282
 name: obsolete Gram-stain positive
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000698
+replaced_by: METPO:1000698
 
 [Term]
-id: metpo:000029
+id: METPO:000029
 name: obsolete Hyperthermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:000030
+id: METPO:000030
 name: obsolete Extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:000031
+id: METPO:000031
 name: obsolete Halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:000032
+id: METPO:000032
 name: obsolete Non-halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:000033
+id: METPO:000033
 name: obsolete Slight halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:000034
+id: METPO:000034
 name: obsolete Moderate halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:000035
+id: METPO:000035
 name: obsolete Extreme halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:000036
+id: METPO:000036
 name: obsolete Halotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:000037
+id: METPO:000037
 name: obsolete Haloalkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:000038
+id: METPO:000038
 name: obsolete Extreme Acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000039
+id: METPO:000039
 name: obsolete Acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:000040
+id: METPO:000040
 name: obsolete Neutrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:000041
+id: METPO:000041
 name: obsolete Alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:000042
+id: METPO:000042
 name: obsolete Acid Tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000043
+id: METPO:000043
 name: obsolete Alkali Tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000044
+id: METPO:000044
 name: obsolete Extreme Alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000045
+id: METPO:000045
 name: obsolete Facultative acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:000046
+id: METPO:000046
 name: obsolete Obligative acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:000047
+id: METPO:000047
 name: obsolete Aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000048
+id: METPO:000048
 name: obsolete Anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:000049
+id: METPO:000049
 name: obsolete Facultative anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:000050
+id: METPO:000050
 name: obsolete Facultative aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:000051
+id: METPO:000051
 name: obsolete Microaerophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:000052
+id: METPO:000052
 name: obsolete Aerotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:000053
+id: METPO:000053
 name: obsolete Microaerotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:000054
+id: METPO:000054
 name: obsolete Aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000055
+id: METPO:000055
 name: obsolete Obligate aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:000056
+id: METPO:000056
 name: obsolete Obligate anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:000057
+id: METPO:000057
 name: obsolete Oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000058
+id: METPO:000058
 name: obsolete Anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000059
+id: METPO:000059
 name: obsolete Autotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:000060
+id: METPO:000060
 name: obsolete Photoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:000061
+id: METPO:000061
 name: obsolete Chemoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:000062
+id: METPO:000062
 name: obsolete Heterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:000063
+id: METPO:000063
 name: obsolete Photoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:000064
+id: METPO:000064
 name: obsolete Chemoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:000065
+id: METPO:000065
 name: obsolete Lithotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:000066
+id: METPO:000066
 name: obsolete Organotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:000067
+id: METPO:000067
 name: obsolete Phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:000068
+id: METPO:000068
 name: obsolete Chemotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:000069
+id: METPO:000069
 name: obsolete Oligotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:000070
+id: METPO:000070
 name: obsolete Copiotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:000071
+id: METPO:000071
 name: obsolete Lithoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:000072
+id: METPO:000072
 name: obsolete Mixotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:000073
+id: METPO:000073
 name: obsolete Lithoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:000074
+id: METPO:000074
 name: obsolete Chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:000075
+id: METPO:000075
 name: obsolete Chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:000076
+id: METPO:000076
 name: obsolete Methylotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:000077
+id: METPO:000077
 name: obsolete Methanotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:000078
+id: METPO:000078
 name: obsolete Carboxydotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:000079
+id: METPO:000079
 name: obsolete Hydrogenotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:000080
+id: METPO:000080
 name: obsolete Hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000081
+id: METPO:000081
 name: obsolete Hydrogen producer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000082
+id: METPO:000082
 name: obsolete Nitrogen fixer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000083
+id: METPO:000083
 name: obsolete Methanogen
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000084
+id: METPO:000084
 name: obsolete Sulfate reducer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000085
+id: METPO:000085
 name: obsolete Sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000086
+id: METPO:000086
 name: obsolete Denitrifier
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000087
+id: METPO:000087
 name: obsolete Capnophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:000088
+id: METPO:000088
 name: obsolete Motile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:000089
+id: METPO:000089
 name: obsolete Non-motile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:000090
+id: METPO:000090
 name: obsolete Flagellated
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:000091
+id: METPO:000091
 name: obsolete Peritrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000092
+id: METPO:000092
 name: obsolete Lophotrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000093
+id: METPO:000093
 name: obsolete Monotrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000094
+id: METPO:000094
 name: obsolete Ciliated
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000095
+id: METPO:000095
 name: obsolete Gliding
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:000096
+id: METPO:000096
 name: obsolete Twitching
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000097
+id: METPO:000097
 name: obsolete Sliding
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000098
+id: METPO:000098
 name: obsolete Swarming
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000099
+id: METPO:000099
 name: obsolete Endospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000100
+id: METPO:000100
 name: obsolete Exospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001000
+id: METPO:0001000
 name: obsolete sensitivity to oxygen
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001001
+id: METPO:0001001
 name: obsolete sensitivity toward
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001002
+id: METPO:0001002
 name: obsolete 'organismal quality'
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001003
+id: METPO:0001003
 name: obsolete 'physicial object quality'
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001004
+id: METPO:0001004
 name: obsolete 'quality'
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000188
+replaced_by: METPO:1000188
 
 [Term]
-id: metpo:0001006
+id: METPO:0001006
 name: obsolete size
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001007
+id: METPO:0001007
 name: obsolete 1-D extent
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001008
+id: METPO:0001008
 name: obsolete width
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001009
+id: METPO:0001009
 name: obsolete length
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000101
+id: METPO:000101
 name: obsolete Myxospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001010
+id: METPO:0001010
 name: obsolete 'prokaryotic metabolically differentiated cell'
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001012
+id: METPO:0001012
 name: obsolete heterotrophy
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001013
+id: METPO:0001013
 name: obsolete structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001014
+id: METPO:0001014
 name: obsolete spore type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001016
+id: METPO:0001016
 name: obsolete sensitivity toward pressure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001017
+id: METPO:0001017
 name: obsolete sensitivity toward NaCl
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001018
+id: METPO:0001018
 name: obsolete sensitivity toward pH
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001019
+id: METPO:0001019
 name: obsolete sensitivity toward temperature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000102
+id: METPO:000102
 name: obsolete Arthrospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001020
+id: METPO:0001020
 name: obsolete metabolic constraints
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001021
+id: METPO:0001021
 name: obsolete cell by chemical produced
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000103
+id: METPO:000103
 name: obsolete Conidia
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000104
+id: METPO:000104
 name: obsolete Sporangiospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000105
+id: METPO:000105
 name: obsolete Zygospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000106
+id: METPO:000106
 name: obsolete Akinetes
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000107
+id: METPO:000107
 name: obsolete Chlamydospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000108
+id: METPO:000108
 name: obsolete Sporocysts
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000109
+id: METPO:000109
 name: obsolete Hypnospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000110
+id: METPO:000110
 name: obsolete Gemmae
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000111
+id: METPO:000111
 name: obsolete Oospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000112
+id: METPO:000112
 name: obsolete Azygospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000113
+id: METPO:000113
 name: obsolete Cysts
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000114
+id: METPO:000114
 name: obsolete Ascospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000115
+id: METPO:000115
 name: obsolete Basidiospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000116
+id: METPO:000116
 name: obsolete Aleuriospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000117
+id: METPO:000117
 name: obsolete Stylospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000118
+id: METPO:000118
 name: obsolete Sclerotia
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000119
+id: METPO:000119
 name: obsolete Zoospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000120
+id: METPO:000120
 name: obsolete Teliospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000121
+id: METPO:000121
 name: obsolete Urediniospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000122
+id: METPO:000122
 name: obsolete Pycnidiospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000123
+id: METPO:000123
 name: obsolete Acriospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000124
+id: METPO:000124
 name: obsolete Aplanospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000125
+id: METPO:000125
 name: obsolete Statismospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000126
+id: METPO:000126
 name: obsolete Barotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000127
+id: METPO:000127
 name: obsolete Piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000128
+id: METPO:000128
 name: obsolete Piezotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000129
+id: METPO:000129
 name: obsolete Piezosensitive
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000130
+id: METPO:000130
 name: obsolete Obligate barophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000131
+id: METPO:000131
 name: obsolete Facultative barophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000132
+id: METPO:000132
 name: obsolete Hyperbarophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000133
+id: METPO:000133
 name: obsolete Hypobarophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000134
+id: METPO:000134
 name: obsolete Atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000135
+id: METPO:000135
 name: obsolete Moderate piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000136
+id: METPO:000136
 name: obsolete Extreme piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000137
+id: METPO:000137
 name: obsolete Stenopiezic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000138
+id: METPO:000138
 name: obsolete Eurypiezic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000139
+id: METPO:000139
 name: obsolete Pressure-sensitive
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000140
+id: METPO:000140
 name: obsolete Pressure-resistant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000141
+id: METPO:000141
 name: obsolete Pressure-adapted
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000142
+id: METPO:000142
 name: obsolete Piezo-acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000143
+id: METPO:000143
 name: obsolete Piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000144
+id: METPO:000144
 name: obsolete Piezo-halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000145
+id: METPO:000145
 name: obsolete Piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000146
+id: METPO:000146
 name: obsolete Piezo-thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000147
+id: METPO:000147
 name: obsolete Piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000148
+id: METPO:000148
 name: obsolete Piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:000149
+id: METPO:000149
 name: obsolete Piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000150
+id: METPO:000150
 name: obsolete Piezo-endolithic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000151
+id: METPO:000151
 name: obsolete Piezo-tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000152
+id: METPO:000152
 name: obsolete GC% low ( < 42.65)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000153
+id: METPO:000153
 name: obsolete GC% mid1 (42.65 - 57)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000154
+id: METPO:000154
 name: obsolete GC% mid2 (57 - 66.3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000155
+id: METPO:000155
 name: obsolete GC% high ( > 66.3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000156
+id: METPO:000156
 name: obsolete Cell width uM very low (< 0.5)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000157
+id: METPO:000157
 name: obsolete Cell width uM low (0.5 - 0.65)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000158
+id: METPO:000158
 name: obsolete Cell width uM mid (0.65 - 0.9)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000159
+id: METPO:000159
 name: obsolete Cell width uM high (> 0.9)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000160
+id: METPO:000160
 name: obsolete Cell length uM very low (<= 1.3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000161
+id: METPO:000161
 name: obsolete Cell length uM low (1.3 - 2)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000162
+id: METPO:000162
 name: obsolete Cell length uM mid (2 - 3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000163
+id: METPO:000163
 name: obsolete Cell length uM high (> 3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000164
+id: METPO:000164
 name: obsolete Temperature Optimum C very low (<= 10)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000441
+replaced_by: METPO:1000441
 
 [Term]
-id: metpo:000165
+id: METPO:000165
 name: obsolete Temperature Optimum C low (10 - 22)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000166
+id: METPO:000166
 name: obsolete Temperature Optimum C mid1 (22 - 27)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000443
+replaced_by: METPO:1000443
 
 [Term]
-id: metpo:000167
+id: METPO:000167
 name: obsolete Temperature Optimum C mid2 (27 - 30)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000444
+replaced_by: METPO:1000444
 
 [Term]
-id: metpo:000168
+id: METPO:000168
 name: obsolete Temperature Optimum C mid3 (30 - 34)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:000169
+id: METPO:000169
 name: obsolete Temperature Optimum C mid4 (34 - 40)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:000170
+id: METPO:000170
 name: obsolete Temperature Optimum C high (> 40)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000447
+replaced_by: METPO:1000447
 
 [Term]
-id: metpo:000171
+id: METPO:000171
 name: obsolete Temperature Range C very low (<= 10)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000448
+replaced_by: METPO:1000448
 
 [Term]
-id: metpo:000172
+id: METPO:000172
 name: obsolete Temperature Range C low (10 - 22)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000173
+id: METPO:000173
 name: obsolete Temperature Range C mid1 (22 - 27)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000174
+id: METPO:000174
 name: obsolete Temperature Range C mid2 (27 - 30)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000175
+id: METPO:000175
 name: obsolete Temperature Range C mid3 (30 - 34)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000176
+id: METPO:000176
 name: obsolete Temperature Range C mid4 (34 - 40)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000177
+id: METPO:000177
 name: obsolete Temperature Range C high (> 40)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000454
+replaced_by: METPO:1000454
 
 [Term]
-id: metpo:000178
+id: METPO:000178
 name: obsolete pH Optimum low (0 - 6)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000179
+id: METPO:000179
 name: obsolete pH Optimum mid1 (6 - 7)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000180
+id: METPO:000180
 name: obsolete pH Optimum mid2 (7 - 8)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000181
+id: METPO:000181
 name: obsolete pH Optimum high (8 - 14)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000182
+id: METPO:000182
 name: obsolete pH Range very low (0 - 4)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000459
+replaced_by: METPO:1000459
 
 [Term]
-id: metpo:000183
+id: METPO:000183
 name: obsolete pH Range low (4 - 6)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000184
+id: METPO:000184
 name: obsolete pH Range mid1 (6 - 7)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000185
+id: METPO:000185
 name: obsolete pH Range mid2 (7 - 8)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000186
+id: METPO:000186
 name: obsolete pH Range mid3 (8 - 10)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000187
+id: METPO:000187
 name: obsolete pH Range high (10 - 14)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000188
+id: METPO:000188
 name: obsolete % NaCl Optimum low (<= 1)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000189
+id: METPO:000189
 name: obsolete % NaCl Optimum mid1 (1 - 3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000190
+id: METPO:000190
 name: obsolete % NaCl Optimum mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000191
+id: METPO:000191
 name: obsolete % NaCl Optimum high (> 8)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000468
+replaced_by: METPO:1000468
 
 [Term]
-id: metpo:000192
+id: METPO:000192
 name: obsolete % NaCl Range low (<= 1)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000193
+id: METPO:000193
 name: obsolete % NaCl Range mid1 (1 - 3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000194
+id: METPO:000194
 name: obsolete % NaCl Range mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000195
+id: METPO:000195
 name: obsolete % NaCl Range high (> 8)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000196
+id: METPO:000196
 name: obsolete pH delta very low (<= 1)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000473
+replaced_by: METPO:1000473
 
 [Term]
-id: metpo:000197
+id: METPO:000197
 name: obsolete pH delta low (1 - 2)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000198
+id: METPO:000198
 name: obsolete pH delta mid1 (2 - 3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000199
+id: METPO:000199
 name: obsolete pH delta mid2 (3 - 4)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000200
+id: METPO:000200
 name: obsolete pH delta mid3 (4 - 5)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000201
+id: METPO:000201
 name: obsolete pH delta high (5 - 9)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000202
+id: METPO:000202
 name: obsolete % NaCl delta low (<= 1)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000203
+id: METPO:000203
 name: obsolete % NaCl delta mid2 (1 - 3)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000204
+id: METPO:000204
 name: obsolete % NaCl delta mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000205
+id: METPO:000205
 name: obsolete % NaCl delta high (>= 8)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000206
+id: METPO:000206
 name: obsolete Temperature C delta very low (1 - 5)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000483
+replaced_by: METPO:1000483
 
 [Term]
-id: metpo:000207
+id: METPO:000207
 name: obsolete Temperature C delta low (5 - 10)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000208
+id: METPO:000208
 name: obsolete Temperature C delta mid1 (10 - 20)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000209
+id: METPO:000209
 name: obsolete Temperature C delta mid2 (20 - 30)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000210
+id: METPO:000210
 name: obsolete Temperature C delta high (>= 30)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000487
+replaced_by: METPO:1000487
 
 [Term]
-id: metpo:000211
+id: METPO:000211
 name: obsolete bacillus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000212
+id: METPO:000212
 name: obsolete branced
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000213
+id: METPO:000213
 name: obsolete coccobacillus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000214
+id: METPO:000214
 name: obsolete coccus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000215
+id: METPO:000215
 name: obsolete crescent
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000216
+id: METPO:000216
 name: obsolete curved
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000217
+id: METPO:000217
 name: obsolete curved spiral
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000218
+id: METPO:000218
 name: obsolete diplococcus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000219
+id: METPO:000219
 name: obsolete disc
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000220
+id: METPO:000220
 name: obsolete dumbbell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000221
+id: METPO:000221
 name: obsolete ellipsoidal
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:000222
+id: METPO:000222
 name: obsolete filament
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000223
+id: METPO:000223
 name: obsolete flask
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000224
+id: METPO:000224
 name: obsolete fusiform
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000225
+id: METPO:000225
 name: obsolete helical
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000226
+id: METPO:000226
 name: obsolete irregular
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000227
+id: METPO:000227
 name: obsolete oval
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000228
+id: METPO:000228
 name: obsolete ovoid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000229
+id: METPO:000229
 name: obsolete pleomorphic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000230
+id: METPO:000230
 name: obsolete ring
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000231
+id: METPO:000231
 name: obsolete rod
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000232
+id: METPO:000232
 name: obsolete sphere
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000233
+id: METPO:000233
 name: obsolete spindle
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000234
+id: METPO:000234
 name: obsolete spiral
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000235
+id: METPO:000235
 name: obsolete spirochete
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000236
+id: METPO:000236
 name: obsolete spore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000237
+id: METPO:000237
 name: obsolete square
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000238
+id: METPO:000238
 name: obsolete star
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000239
+id: METPO:000239
 name: obsolete star - dumbbell - pleomorphic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000240
+id: METPO:000240
 name: obsolete tailed
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000241
+id: METPO:000241
 name: obsolete triangular
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000242
+id: METPO:000242
 name: obsolete vibrio
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000243
+id: METPO:000243
 name: obsolete Environmental Parameter
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000244
+id: METPO:000244
 name: obsolete Growth Condition
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000245
+id: METPO:000245
 name: obsolete Physiological Trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000246
+id: METPO:000246
 name: obsolete Metabolic Classification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000247
+id: METPO:000247
 name: obsolete Cellular Characteristic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000248
+id: METPO:000248
 name: obsolete Taxonomic Feature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000249
+id: METPO:000249
 name: obsolete Microbial Adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000250
+id: METPO:000250
 name: obsolete Growth Parameter
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000251
+id: METPO:000251
 name: obsolete Structural Feature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000252
+id: METPO:000252
 name: obsolete Temperature Adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000253
+id: METPO:000253
 name: obsolete Salinity Adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000254
+id: METPO:000254
 name: obsolete pH Adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000255
+id: METPO:000255
 name: obsolete Oxygen Requirement
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000256
+id: METPO:000256
 name: obsolete Carbon Source Utilization
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000257
+id: METPO:000257
 name: obsolete Energy Acquisition Mode
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000258
+id: METPO:000258
 name: obsolete Electron Donor Type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000259
+id: METPO:000259
 name: obsolete Motility Mechanism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000260
+id: METPO:000260
 name: obsolete Motility Structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000261
+id: METPO:000261
 name: obsolete Bacterial Spore Type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000262
+id: METPO:000262
 name: obsolete Fungal Spore Type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000263
+id: METPO:000263
 name: obsolete Reproductive Structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000264
+id: METPO:000264
 name: obsolete Dormancy Structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000265
+id: METPO:000265
 name: obsolete Pressure Adaptation Type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000266
+id: METPO:000266
 name: obsolete Pressure Tolerance Range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:000267
+id: METPO:000267
 name: obsolete GenomicFeature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000268
+id: METPO:000268
 name: obsolete Cell Dimension
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000269
+id: METPO:000269
 name: obsolete Optimal Growth Parameter
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000270
+id: METPO:000270
 name: obsolete Growth Range Parameter
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000271
+id: METPO:000271
 name: obsolete Growth Tolerance Metric
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000272
+id: METPO:000272
 name: obsolete Cell Shape
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:000273
+id: METPO:000273
 name: obsolete Cell Arrangement
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:000274
+id: METPO:000274
 name: obsolete Colony Morphology
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:1000001
+id: METPO:1000001
 name: obsolete acid-fast
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000002
+id: METPO:1000002
 name: obsolete acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:1000003
+id: METPO:1000003
 name: obsolete active transport
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000004
+id: METPO:1000004
 name: obsolete adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000005
+id: METPO:1000005
 name: obsolete adaptive trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000006
+id: METPO:1000006
 name: obsolete adhesin
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000007
+id: METPO:1000007
 name: obsolete adhesion structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000008
+id: METPO:1000008
 name: obsolete aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000009
+id: METPO:1000009
 name: obsolete aerobic respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000801
+replaced_by: METPO:1000801
 
 [Term]
-id: metpo:1000010
+id: METPO:1000010
 name: obsolete aerotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:1000011
+id: METPO:1000011
 name: obsolete aggregate
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000012
+id: METPO:1000012
 name: obsolete akinete
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000013
+id: METPO:1000013
 name: obsolete alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:1000014
+id: METPO:1000014
 name: obsolete ammonification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000015
+id: METPO:1000015
 name: obsolete amylolysis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000016
+id: METPO:1000016
 name: obsolete anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:1000017
+id: METPO:1000017
 name: obsolete anaerobic respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000802
+replaced_by: METPO:1000802
 
 [Term]
-id: metpo:1000018
+id: METPO:1000018
 name: obsolete anoxygenic photosynthesis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000019
+id: METPO:1000019
 name: obsolete antibiotic production
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000020
+id: METPO:1000020
 name: obsolete antibiotic resistance
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000021
+id: METPO:1000021
 name: obsolete antimicrobial resistance
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000022
+id: METPO:1000022
 name: obsolete appendage
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000023
+id: METPO:1000023
 name: obsolete arthrospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000024
+id: METPO:1000024
 name: obsolete ascospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000025
+id: METPO:1000025
 name: obsolete autotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:1000026
+id: METPO:1000026
 name: obsolete autotrophic process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000027
+id: METPO:1000027
 name: obsolete auxotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000028
+id: METPO:1000028
 name: obsolete axial filament
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000029
+id: METPO:1000029
 name: obsolete bacillus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000030
+id: METPO:1000030
 name: obsolete barophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000031
+id: METPO:1000031
 name: obsolete barotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000032
+id: METPO:1000032
 name: obsolete basidiospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000033
+id: METPO:1000033
 name: obsolete binary fission
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000034
+id: METPO:1000034
 name: obsolete biofilm
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000035
+id: METPO:1000035
 name: obsolete biofilm component
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000036
+id: METPO:1000036
 name: obsolete biofilm formation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000037
+id: METPO:1000037
 name: obsolete biogeochemical cycling
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000038
+id: METPO:1000038
 name: obsolete bioluminescence
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000039
+id: METPO:1000039
 name: obsolete budding
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000040
+id: METPO:1000040
 name: obsolete buoyancy structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000041
+id: METPO:1000041
 name: obsolete capnophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:1000042
+id: METPO:1000042
 name: obsolete capsule
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000043
+id: METPO:1000043
 name: obsolete carbon fixation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000044
+id: METPO:1000044
 name: obsolete carbon source
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000045
+id: METPO:1000045
 name: obsolete carboxydotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:1000046
+id: METPO:1000046
 name: obsolete cell arrangement
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:1000047
+id: METPO:1000047
 name: obsolete cell envelope
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000048
+id: METPO:1000048
 name: obsolete cell length category
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000049
+id: METPO:1000049
 name: obsolete cell shape
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:1000050
+id: METPO:1000050
 name: obsolete cell size
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000051
+id: METPO:1000051
 name: obsolete cell wall characteristic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000052
+id: METPO:1000052
 name: obsolete cell wall component
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000053
+id: METPO:1000053
 name: obsolete cell width category
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000054
+id: METPO:1000054
 name: obsolete cellular characteristic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000055
+id: METPO:1000055
 name: obsolete cellular component
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000056
+id: METPO:1000056
 name: obsolete cellular process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000057
+id: METPO:1000057
 name: obsolete cellular product
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000058
+id: METPO:1000058
 name: obsolete cellulolysis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000059
+id: METPO:1000059
 name: phenotype
 def: "A quality that differentiates specific instances of a species from other instances of the same species." [] {IAO:0000119="PHIPO:0000505"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/PhenotypicQuality
 
 [Term]
-id: metpo:1000060
+id: METPO:1000060
 name: metabolism
 def: "A biological process that maintain life in an organism." [] {IAO:0000119="https://purl.dsmz.de/schema/MetabolicProcess", IAO:0000119="GO:0008152"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000061
+id: METPO:1000061
 name: obsolete chemoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000062
+id: METPO:1000062
 name: obsolete chemotaxis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000063
+id: METPO:1000063
 name: obsolete chlamydospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000064
+id: METPO:1000064
 name: obsolete class
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000065
+id: METPO:1000065
 name: obsolete clinically relevant feature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000066
+id: METPO:1000066
 name: obsolete coccus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000067
+id: METPO:1000067
 name: obsolete cold shock protein
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000068
+id: METPO:1000068
 name: obsolete cold shock response
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000069
+id: METPO:1000069
 name: obsolete colonization
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000070
+id: METPO:1000070
 name: obsolete colony elevation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000071
+id: METPO:1000071
 name: obsolete colony margin
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000072
+id: METPO:1000072
 name: obsolete colony morphology
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:1000073
+id: METPO:1000073
 name: obsolete colony texture
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000074
+id: METPO:1000074
 name: obsolete commensalism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000075
+id: METPO:1000075
 name: obsolete community behavior
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000076
+id: METPO:1000076
 name: obsolete community structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000077
+id: METPO:1000077
 name: obsolete compatible solute
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000078
+id: METPO:1000078
 name: obsolete competence
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000079
+id: METPO:1000079
 name: obsolete component
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000080
+id: METPO:1000080
 name: obsolete conidium
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000081
+id: METPO:1000081
 name: obsolete conjugation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000082
+id: METPO:1000082
 name: obsolete CRISPR
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000083
+id: METPO:1000083
 name: obsolete culturability
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000084
+id: METPO:1000084
 name: obsolete cyst
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000085
+id: METPO:1000085
 name: obsolete death phase
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000086
+id: METPO:1000086
 name: obsolete denitrification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005038
+replaced_by: METPO:1005038
 
 [Term]
-id: metpo:1000087
+id: METPO:1000087
 name: obsolete developmental process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000088
+id: METPO:1000088
 name: obsolete diagnostic enzyme
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000089
+id: METPO:1000089
 name: obsolete diagnostic feature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000090
+id: METPO:1000090
 name: obsolete diazotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000091
+id: METPO:1000091
 name: obsolete differentiation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000092
+id: METPO:1000092
 name: obsolete dimorphism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000093
+id: METPO:1000093
 name: obsolete disc-shaped cell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000094
+id: METPO:1000094
 name: obsolete domain
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000095
+id: METPO:1000095
 name: obsolete dormancy
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000096
+id: METPO:1000096
 name: obsolete dormancy structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000097
+id: METPO:1000097
 name: obsolete dumbbell-shaped cell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000672
+replaced_by: METPO:1000672
 
 [Term]
-id: metpo:1000098
+id: METPO:1000098
 name: obsolete ecological niche
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000099
+id: METPO:1000099
 name: obsolete ecological process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:1000100
+id: METPO:1000100
 name: obsolete ecological trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000101
+id: METPO:1000101
 name: obsolete ectosymbiosis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000102
+id: METPO:1000102
 name: obsolete electron acceptor
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000103
+id: METPO:1000103
 name: obsolete electron donor
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000104
+id: METPO:1000104
 name: obsolete endospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000105
+id: METPO:1000105
 name: obsolete endosymbiosis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000106
+id: METPO:1000106
 name: obsolete energy metabolism process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000107
+id: METPO:1000107
 name: obsolete enzyme activity
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000108
+id: METPO:1000108
 name: obsolete epigenetic modification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000109
+id: METPO:1000109
 name: obsolete evolutionary process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000110
+id: METPO:1000110
 name: obsolete exospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000111
+id: METPO:1000111
 name: obsolete exponential phase
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000112
+id: METPO:1000112
 name: obsolete extracellular
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000113
+id: METPO:1000113
 name: obsolete extracellular polysaccharide
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000114
+id: METPO:1000114
 name: obsolete extreme halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:1000115
+id: METPO:1000115
 name: obsolete extremophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000116
+id: METPO:1000116
 name: obsolete facultative
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000117
+id: METPO:1000117
 name: obsolete facultative anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:1000118
+id: METPO:1000118
 name: obsolete family
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000119
+id: METPO:1000119
 name: obsolete fastidious
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000120
+id: METPO:1000120
 name: obsolete fermentation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1002005
+replaced_by: METPO:1002005
 
 [Term]
-id: metpo:1000121
+id: METPO:1000121
 name: obsolete filamentous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000122
+id: METPO:1000122
 name: obsolete fimbriae
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000123
+id: METPO:1000123
 name: obsolete flagellum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000124
+id: METPO:1000124
 name: obsolete flask-shaped cell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000125
+id: METPO:1000125
 name: obsolete fungal spore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000126
+id: METPO:1000126
 name: obsolete gas vesicle
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000127
+id: METPO:1000127
 name: GC content
 def: "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs." [] {IAO:0000119="https://purl.dsmz.de/schema/GCContent"}
 synonym: "GC percentage" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000128
+id: METPO:1000128
 name: obsolete high GC content
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:1000129
+id: METPO:1000129
 name: obsolete low GC content
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:1000130
+id: METPO:1000130
 name: obsolete lower-mid GC content
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000131
+id: METPO:1000131
 name: obsolete upper-mid GC content
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000132
+id: METPO:1000132
 name: obsolete generation time
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000133
+id: METPO:1000133
 name: obsolete genetic element
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000134
+id: METPO:1000134
 name: obsolete genetic exchange
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000135
+id: METPO:1000135
 name: obsolete genetic process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000136
+id: METPO:1000136
 name: obsolete genome size
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000137
+id: METPO:1000137
 name: obsolete genomic element
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000138
+id: METPO:1000138
 name: obsolete genomic island
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000139
+id: METPO:1000139
 name: obsolete genomic trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000140
+id: METPO:1000140
 name: obsolete genus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000141
+id: METPO:1000141
 name: obsolete gliding motility
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000142
+id: METPO:1000142
 name: obsolete global regulator
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000143
+id: METPO:1000143
 name: obsolete Gram-negative
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000699
+replaced_by: METPO:1000699
 
 [Term]
-id: metpo:1000144
+id: METPO:1000144
 name: obsolete Gram-positive
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000698
+replaced_by: METPO:1000698
 
 [Term]
-id: metpo:1000145
+id: METPO:1000145
 name: obsolete Gram stain
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000697
+replaced_by: METPO:1000697
 
 [Term]
-id: metpo:1000146
+id: METPO:1000146
 name: obsolete growth characteristic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000147
+id: METPO:1000147
 name: obsolete growth conditions constraints
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000148
+id: METPO:1000148
 name: obsolete growth pattern
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000149
+id: METPO:1000149
 name: obsolete growth rate
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000150
+id: METPO:1000150
 name: obsolete habitat
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000151
+id: METPO:1000151
 name: obsolete halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:1000152
+id: METPO:1000152
 name: obsolete halotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:1000153
+id: METPO:1000153
 name: obsolete heat shock protein
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000154
+id: METPO:1000154
 name: obsolete heat shock response
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000155
+id: METPO:1000155
 name: obsolete hemolysis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005025
+replaced_by: METPO:1005025
 
 [Term]
-id: metpo:1000156
+id: METPO:1000156
 name: obsolete heterocyst
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000157
+id: METPO:1000157
 name: obsolete heterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:1000158
+id: METPO:1000158
 name: obsolete holdfast
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000159
+id: METPO:1000159
 name: obsolete horizontal gene transfer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000160
+id: METPO:1000160
 name: obsolete hydrolase
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000161
+id: METPO:1000161
 name: obsolete hyperthermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:1000162
+id: METPO:1000162
 name: obsolete inclusion body
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000163
+id: METPO:1000163
 name: obsolete infection
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000164
+id: METPO:1000164
 name: obsolete interaction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000165
+id: METPO:1000165
 name: obsolete interaction with a phage
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000166
+id: METPO:1000166
 name: obsolete interaction with an environment
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000167
+id: METPO:1000167
 name: obsolete interaction with host
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000168
+id: METPO:1000168
 name: obsolete interaction within a community
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000169
+id: METPO:1000169
 name: obsolete intracellular
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000170
+id: METPO:1000170
 name: obsolete invasion
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000171
+id: METPO:1000171
 name: obsolete laboratory characteristic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000172
+id: METPO:1000172
 name: obsolete lag phase
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000173
+id: METPO:1000173
 name: obsolete life cycle
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000174
+id: METPO:1000174
 name: obsolete life cycle phase
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000175
+id: METPO:1000175
 name: obsolete lipolysis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000176
+id: METPO:1000176
 name: obsolete lipopolysaccharide
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000177
+id: METPO:1000177
 name: obsolete localization
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000178
+id: METPO:1000178
 name: obsolete lysogeny
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000179
+id: METPO:1000179
 name: obsolete macroscopic trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000180
+id: METPO:1000180
 name: obsolete magnetotaxis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000181
+id: METPO:1000181
 name: obsolete mesophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000615
+replaced_by: METPO:1000615
 
 [Term]
-id: metpo:1000182
+id: METPO:1000182
 name: obsolete metabolic partner
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000183
+id: METPO:1000183
 name: obsolete metabolic trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000184
+id: METPO:1000184
 name: obsolete methanogenesis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000844
+replaced_by: METPO:1000844
 
 [Term]
-id: metpo:1000185
+id: METPO:1000185
 name: obsolete methylation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000186
+id: METPO:1000186
 name: material entity
 def: "An object or portion of a substance or mixture of substances that consists of matter" [] {IAO:0000119="BFO:0000040"}
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000187
+id: METPO:1000187
 name: obsolete process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000188
+id: METPO:1000188
 name: quality
 def: "A characteristic of an entity that depends on the entity's existence, size, color, and physiological traits." []
 
 [Term]
-id: metpo:1000189
+id: METPO:1000189
 name: obsolete system
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000190
+id: METPO:1000190
 name: obsolete microaerophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:1000191
+id: METPO:1000191
 name: obsolete mobile genetic element
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000192
+id: METPO:1000192
 name: obsolete moderate halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:1000193
+id: METPO:1000193
 name: obsolete morphological trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000194
+id: METPO:1000194
 name: obsolete motility process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000195
+id: METPO:1000195
 name: obsolete motility structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000196
+id: METPO:1000196
 name: obsolete mutualism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000197
+id: METPO:1000197
 name: obsolete mycolic acid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000198
+id: METPO:1000198
 name: obsolete mycorrhization
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000199
+id: METPO:1000199
 name: obsolete neutrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:1000200
+id: METPO:1000200
 name: obsolete nitrification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005001
+replaced_by: METPO:1005001
 
 [Term]
-id: metpo:1000201
+id: METPO:1000201
 name: obsolete nitrogen fixation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1000202
+id: METPO:1000202
 name: obsolete nodulation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000203
+id: METPO:1000203
 name: obsolete nucleoid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000204
+id: METPO:1000204
 name: obsolete nutrient utilization
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000205
+id: METPO:1000205
 name: obsolete obligate
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000206
+id: METPO:1000206
 name: obsolete obligate aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:1000207
+id: METPO:1000207
 name: obsolete obligate anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:1000208
+id: METPO:1000208
 name: obsolete oospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000209
+id: METPO:1000209
 name: obsolete order
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000210
+id: METPO:1000210
 name: obsolete microbe characterized by growth conditions
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000211
+id: METPO:1000211
 name: obsolete microbe characterized by nutritional requirement
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000212
+id: METPO:1000212
 name: obsolete microbe characterized by product produced
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000213
+id: METPO:1000213
 name: obsolete microbe characterized by relation to oxygen
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000214
+id: METPO:1000214
 name: obsolete microbe characterized by relation to ph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000215
+id: METPO:1000215
 name: obsolete microbe characterized by relation to pressure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000216
+id: METPO:1000216
 name: obsolete microbe characterized by relation to salt concentration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000217
+id: METPO:1000217
 name: obsolete microbe characterized by relation to temperature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000218
+id: METPO:1000218
 name: obsolete microbe characterized by shape
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000219
+id: METPO:1000219
 name: obsolete microbe characterized by trophic type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000220
+id: METPO:1000220
 name: obsolete osmophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000221
+id: METPO:1000221
 name: obsolete osmoregulation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000222
+id: METPO:1000222
 name: obsolete oxidative stress response
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000223
+id: METPO:1000223
 name: obsolete oxidoreductase
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000224
+id: METPO:1000224
 name: obsolete oxygen requirement
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000225
+id: METPO:1000225
 name: obsolete oxygenic photosynthesis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000226
+id: METPO:1000226
 name: obsolete pan-genome
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000227
+id: METPO:1000227
 name: obsolete parasitism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000228
+id: METPO:1000228
 name: obsolete passive transport
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000229
+id: METPO:1000229
 name: obsolete pathogenicity
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000230
+id: METPO:1000230
 name: obsolete pathogenicity island
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000231
+id: METPO:1000231
 name: obsolete peptidoglycan
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000232
+id: METPO:1000232
 name: pH delta
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000233
+id: METPO:1000233
 name: obsolete pH optimum (growth range)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000234
+id: METPO:1000234
 name: obsolete pH preference
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000235
+id: METPO:1000235
 name: obsolete pH range (growth tolerance)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000236
+id: METPO:1000236
 name: obsolete pH tolerance
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000237
+id: METPO:1000237
 name: obsolete phage defense
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000238
+id: METPO:1000238
 name: obsolete photoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:1000239
+id: METPO:1000239
 name: obsolete photoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:1000240
+id: METPO:1000240
 name: obsolete photosynthesis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000241
+id: METPO:1000241
 name: obsolete phototaxis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000242
+id: METPO:1000242
 name: obsolete phylum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000243
+id: METPO:1000243
 name: obsolete physiological process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:1000244
+id: METPO:1000244
 name: obsolete physiological state
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000245
+id: METPO:1000245
 name: obsolete physiological trait
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000246
+id: METPO:1000246
 name: obsolete piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000247
+id: METPO:1000247
 name: obsolete pigment
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000248
+id: METPO:1000248
 name: obsolete pigmentation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003021
+replaced_by: METPO:1003021
 
 [Term]
-id: metpo:1000249
+id: METPO:1000249
 name: obsolete pilus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000250
+id: METPO:1000250
 name: obsolete plant growth promotion
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000251
+id: METPO:1000251
 name: obsolete plasmid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000252
+id: METPO:1000252
 name: obsolete pleomorphism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000253
+id: METPO:1000253
 name: obsolete process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000254
+id: METPO:1000254
 name: obsolete prophage
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000255
+id: METPO:1000255
 name: obsolete prostheca
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000256
+id: METPO:1000256
 name: obsolete protein synthesis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000257
+id: METPO:1000257
 name: obsolete proteolysis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000258
+id: METPO:1000258
 name: obsolete prototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000259
+id: METPO:1000259
 name: obsolete psychrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:1000260
+id: METPO:1000260
 name: obsolete qualifier
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000261
+id: METPO:1000261
 name: obsolete quorum sensing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000262
+id: METPO:1000262
 name: obsolete regulation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000263
+id: METPO:1000263
 name: obsolete regulatory mechanism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000264
+id: METPO:1000264
 name: obsolete reproductive process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000265
+id: METPO:1000265
 name: obsolete reproductive structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000266
+id: METPO:1000266
 name: obsolete resistance mechanism
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000267
+id: METPO:1000267
 name: obsolete respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000800
+replaced_by: METPO:1000800
 
 [Term]
-id: metpo:1000268
+id: METPO:1000268
 name: obsolete restriction-modification system
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000269
+id: METPO:1000269
 name: obsolete ribosome
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000270
+id: METPO:1000270
 name: obsolete S-layer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000271
+id: METPO:1000271
 name: obsolete salinity delta
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000272
+id: METPO:1000272
 name: obsolete salinity preference
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000273
+id: METPO:1000273
 name: obsolete secondary metabolite
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000274
+id: METPO:1000274
 name: obsolete secretion
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000275
+id: METPO:1000275
 name: obsolete secretion system
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000276
+id: METPO:1000276
 name: obsolete sheathed
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000277
+id: METPO:1000277
 name: obsolete siderophore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000278
+id: METPO:1000278
 name: obsolete sigma factor
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000279
+id: METPO:1000279
 name: obsolete signaling
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000280
+id: METPO:1000280
 name: obsolete slime layer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000281
+id: METPO:1000281
 name: obsolete specialized cell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000282
+id: METPO:1000282
 name: obsolete species
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000283
+id: METPO:1000283
 name: obsolete spirillum
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000284
+id: METPO:1000284
 name: obsolete spirochete
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000285
+id: METPO:1000285
 name: obsolete sporangiospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000286
+id: METPO:1000286
 name: obsolete sporulation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:1000287
+id: METPO:1000287
 name: obsolete square cell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000288
+id: METPO:1000288
 name: obsolete stalk
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000289
+id: METPO:1000289
 name: obsolete star-shaped cell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000290
+id: METPO:1000290
 name: obsolete stationary phase
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000291
+id: METPO:1000291
 name: obsolete storage structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000292
+id: METPO:1000292
 name: obsolete strain
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000293
+id: METPO:1000293
 name: obsolete stress response
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000294
+id: METPO:1000294
 name: obsolete structure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000295
+id: METPO:1000295
 name: obsolete sulfate reducer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000296
+id: METPO:1000296
 name: obsolete swarming
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000297
+id: METPO:1000297
 name: obsolete symbiosis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000298
+id: METPO:1000298
 name: obsolete symbiotic process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000299
+id: METPO:1000299
 name: obsolete syntrophy
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1002006
+replaced_by: METPO:1002006
 
 [Term]
-id: metpo:1000300
+id: METPO:1000300
 name: obsolete taxonomic identifier
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000301
+id: METPO:1000301
 name: obsolete taxonomic rank
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000302
+id: METPO:1000302
 name: obsolete teichoic acid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000303
+id: METPO:1000303
 name: temperature delta
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000304
+id: METPO:1000304
 name: temperature optimum
 def: "A temperature phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction." [] {IAO:0000119="https://purl.dsmz.de/schema/OptimumTemperature"}
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000305
+id: METPO:1000305
 name: obsolete temperature preference
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000613
+replaced_by: METPO:1000613
 
 [Term]
-id: metpo:1000306
+id: METPO:1000306
 name: temperature range
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 
 [Term]
-id: metpo:1000307
+id: METPO:1000307
 name: obsolete thermal tolerance
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000308
+id: METPO:1000308
 name: obsolete thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:1000309
+id: METPO:1000309
 name: obsolete toxin
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000310
+id: METPO:1000310
 name: obsolete transcription factor
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000311
+id: METPO:1000311
 name: obsolete transduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000312
+id: METPO:1000312
 name: obsolete transferase
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000313
+id: METPO:1000313
 name: obsolete transformation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000314
+id: METPO:1000314
 name: obsolete transport system
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000315
+id: METPO:1000315
 name: obsolete transposon
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000316
+id: METPO:1000316
 name: obsolete triangular cell
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000317
+id: METPO:1000317
 name: obsolete trichome
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000318
+id: METPO:1000318
 name: obsolete twitching motility
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000319
+id: METPO:1000319
 name: obsolete two-component system
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000320
+id: METPO:1000320
 name: obsolete viable but non-culturable
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000321
+id: METPO:1000321
 name: obsolete vibrio
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000322
+id: METPO:1000322
 name: obsolete virulence
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000323
+id: METPO:1000323
 name: obsolete virulence factor
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000324
+id: METPO:1000324
 name: obsolete virulence process
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000325
+id: METPO:1000325
 name: obsolete xylanolysis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000326
+id: METPO:1000326
 name: obsolete zoospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000327
+id: METPO:1000327
 name: obsolete zygospore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000328
+id: METPO:1000328
 name: obsolete pressure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000329
+id: METPO:1000329
 name: obsolete temperature optimum (metabolic activity)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000330
+id: METPO:1000330
 name: obsolete temperature range (metabolic viability)
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000331
+id: METPO:1000331
 name: pH optimum
 def: "A pH phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction." []
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 
 [Term]
-id: metpo:1000332
+id: METPO:1000332
 name: pH range
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000333
+id: METPO:1000333
 name: NaCl optimum
 def: "A salinity phenotype with numerical limits that supports the most efficient growth and reproduction of an organism." [] {IAO:0000119="https://purl.dsmz.de/schema/OptimumSalinity"}
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000334
+id: METPO:1000334
 name: NaCl range
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000335
+id: METPO:1000335
 name: NaCl delta
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000336
+id: METPO:1000336
 name: obsolete psychrotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:1000337
+id: METPO:1000337
 name: obsolete thermotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:1000338
+id: METPO:1000338
 name: obsolete extreme thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:1000339
+id: METPO:1000339
 name: obsolete extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:1000340
+id: METPO:1000340
 name: obsolete non-halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:1000341
+id: METPO:1000341
 name: obsolete slight halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:1000342
+id: METPO:1000342
 name: obsolete haloalkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:1000343
+id: METPO:1000343
 name: obsolete extreme acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000344
+id: METPO:1000344
 name: obsolete acid tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000345
+id: METPO:1000345
 name: obsolete alkali tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000346
+id: METPO:1000346
 name: obsolete extreme alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000347
+id: METPO:1000347
 name: obsolete facultative acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:1000348
+id: METPO:1000348
 name: obsolete obligative acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:1000349
+id: METPO:1000349
 name: obsolete facultative aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:1000350
+id: METPO:1000350
 name: obsolete microaerophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:1000351
+id: METPO:1000351
 name: obsolete microaerotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:1000352
+id: METPO:1000352
 name: obsolete aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000353
+id: METPO:1000353
 name: obsolete obligate aerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:1000354
+id: METPO:1000354
 name: obsolete obligate anaerobe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:1000355
+id: METPO:1000355
 name: obsolete oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000356
+id: METPO:1000356
 name: obsolete anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000357
+id: METPO:1000357
 name: obsolete chemoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:1000358
+id: METPO:1000358
 name: obsolete chemoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000359
+id: METPO:1000359
 name: obsolete lithotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:1000360
+id: METPO:1000360
 name: obsolete organotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:1000361
+id: METPO:1000361
 name: obsolete phototroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:1000362
+id: METPO:1000362
 name: obsolete chemotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:1000363
+id: METPO:1000363
 name: obsolete oligotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:1000364
+id: METPO:1000364
 name: obsolete copiotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:1000365
+id: METPO:1000365
 name: obsolete lithoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:1000366
+id: METPO:1000366
 name: obsolete mixotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:1000367
+id: METPO:1000367
 name: obsolete lithoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:1000368
+id: METPO:1000368
 name: obsolete chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:1000369
+id: METPO:1000369
 name: obsolete chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:1000370
+id: METPO:1000370
 name: obsolete methylotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:1000371
+id: METPO:1000371
 name: obsolete methanotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:1000372
+id: METPO:1000372
 name: obsolete hydrogenotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:1000373
+id: METPO:1000373
 name: obsolete hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000374
+id: METPO:1000374
 name: obsolete hydrogen producer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000375
+id: METPO:1000375
 name: obsolete nitrogen fixer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000376
+id: METPO:1000376
 name: obsolete methanogen
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000377
+id: METPO:1000377
 name: obsolete sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000378
+id: METPO:1000378
 name: obsolete denitrifier
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000379
+id: METPO:1000379
 name: obsolete motile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:1000380
+id: METPO:1000380
 name: obsolete non-motile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:1000381
+id: METPO:1000381
 name: obsolete flagellated
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:1000382
+id: METPO:1000382
 name: obsolete peritrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000383
+id: METPO:1000383
 name: obsolete lophotrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000384
+id: METPO:1000384
 name: obsolete monotrichous
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000385
+id: METPO:1000385
 name: obsolete ciliated
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000386
+id: METPO:1000386
 name: obsolete gliding
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:1000387
+id: METPO:1000387
 name: obsolete twitching
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000388
+id: METPO:1000388
 name: obsolete sliding
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000389
+id: METPO:1000389
 name: obsolete myxospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000390
+id: METPO:1000390
 name: obsolete conidia
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000391
+id: METPO:1000391
 name: obsolete chlamydospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000392
+id: METPO:1000392
 name: obsolete sporocysts
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000393
+id: METPO:1000393
 name: obsolete hypnospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000394
+id: METPO:1000394
 name: obsolete gemmae
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000395
+id: METPO:1000395
 name: obsolete azygospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000396
+id: METPO:1000396
 name: obsolete aleuriospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000397
+id: METPO:1000397
 name: obsolete stylospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000398
+id: METPO:1000398
 name: obsolete sclerotia
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000399
+id: METPO:1000399
 name: obsolete teliospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000400
+id: METPO:1000400
 name: obsolete urediniospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000401
+id: METPO:1000401
 name: obsolete pycnidiospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000402
+id: METPO:1000402
 name: obsolete acriospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000403
+id: METPO:1000403
 name: obsolete aplanospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000404
+id: METPO:1000404
 name: obsolete statismospores
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000405
+id: METPO:1000405
 name: obsolete piezotolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000406
+id: METPO:1000406
 name: obsolete piezosensitive
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000407
+id: METPO:1000407
 name: obsolete obligate barophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000408
+id: METPO:1000408
 name: obsolete facultative barophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000409
+id: METPO:1000409
 name: obsolete hyperbarophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000410
+id: METPO:1000410
 name: obsolete hypobarophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000411
+id: METPO:1000411
 name: obsolete atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000412
+id: METPO:1000412
 name: obsolete moderate piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000413
+id: METPO:1000413
 name: obsolete extreme piezophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000414
+id: METPO:1000414
 name: obsolete stenopiezic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000415
+id: METPO:1000415
 name: obsolete eurypiezic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000416
+id: METPO:1000416
 name: obsolete pressure-sensitive
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000417
+id: METPO:1000417
 name: obsolete pressure-resistant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000418
+id: METPO:1000418
 name: obsolete pressure-adapted
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000419
+id: METPO:1000419
 name: obsolete piezo-acidophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000420
+id: METPO:1000420
 name: obsolete piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000421
+id: METPO:1000421
 name: obsolete piezo-halophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000422
+id: METPO:1000422
 name: obsolete piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000423
+id: METPO:1000423
 name: obsolete piezo-thermophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000424
+id: METPO:1000424
 name: obsolete piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000425
+id: METPO:1000425
 name: obsolete piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000426
+id: METPO:1000426
 name: obsolete piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000427
+id: METPO:1000427
 name: obsolete piezo-endolithic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000428
+id: METPO:1000428
 name: obsolete piezo-tolerant
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000429
+id: METPO:1000429
 name: GC low
 synonym: "GC_<=42.65" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "42.65" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "42.65" xsd:string
 
 [Term]
-id: metpo:1000430
+id: METPO:1000430
 name: GC mid1
 synonym: "GC_42.65_57.0" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "57" xsd:string
-property_value: metpo:range_min "42.65" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "57" xsd:string
+property_value: METPO:range_min "42.65" xsd:string
 
 [Term]
-id: metpo:1000431
+id: METPO:1000431
 name: GC mid2
 synonym: "GC_57.0_66.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "66.3" xsd:string
-property_value: metpo:range_min "57" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "66.3" xsd:string
+property_value: METPO:range_min "57" xsd:string
 
 [Term]
-id: metpo:1000432
+id: METPO:1000432
 name: GC high
 synonym: "GC_>66.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_min "66.3" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_min "66.3" xsd:string
 
 [Term]
-id: metpo:1000433
+id: METPO:1000433
 name: obsolete cell width very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000887
+replaced_by: METPO:1000887
 
 [Term]
-id: metpo:1000434
+id: METPO:1000434
 name: obsolete cell width low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:1000435
+id: METPO:1000435
 name: obsolete cell width mid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000889
+replaced_by: METPO:1000889
 
 [Term]
-id: metpo:1000436
+id: METPO:1000436
 name: obsolete cell width high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:1000437
+id: METPO:1000437
 name: obsolete cell length very low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000883
+replaced_by: METPO:1000883
 
 [Term]
-id: metpo:1000438
+id: METPO:1000438
 name: obsolete cell length low
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:1000439
+id: METPO:1000439
 name: obsolete cell length mid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000885
+replaced_by: METPO:1000885
 
 [Term]
-id: metpo:1000440
+id: METPO:1000440
 name: obsolete cell length high
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:1000441
+id: METPO:1000441
 name: temperature optimum very low
 synonym: "Psychrophile" EXACT []
 synonym: "TO_<=10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "10" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000442
+id: METPO:1000442
 name: temperature optimum low
 synonym: "Psychrophile" EXACT []
 synonym: "Psychrotolerant" EXACT []
 synonym: "TO_10_to_22" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "22" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "22" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000443
+id: METPO:1000443
 name: temperature optimum mid1
 synonym: "mesophilic" EXACT []
 synonym: "TO_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "27" xsd:string
-property_value: metpo:range_min "22" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "27" xsd:string
+property_value: METPO:range_min "22" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000444
+id: METPO:1000444
 name: temperature optimum mid2
 synonym: "mesophilic" EXACT []
 synonym: "TO_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "27" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "27" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000445
+id: METPO:1000445
 name: temperature optimum mid3
 synonym: "mesophilic" EXACT []
 synonym: "TO_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "34" xsd:string
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "34" xsd:string
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000446
+id: METPO:1000446
 name: temperature optimum mid4
 synonym: "mesophilic" EXACT []
 synonym: "TO_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "40" xsd:string
-property_value: metpo:range_min "34" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "40" xsd:string
+property_value: METPO:range_min "34" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000447
+id: METPO:1000447
 name: temperature optimum high
 synonym: "Thermophile" EXACT []
 synonym: "TO_>40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_min "40" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_min "40" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000448
+id: METPO:1000448
 name: temperature range very low
 synonym: "Psychrophile" EXACT []
 synonym: "TR_<=10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "10" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000449
+id: METPO:1000449
 name: temperature range low
 synonym: "Psychrophile" EXACT []
 synonym: "Psychrotolerant" EXACT []
 synonym: "TR_10_to_22" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "22" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "22" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000450
+id: METPO:1000450
 name: temperature range mid1
 synonym: "mesophilic" EXACT []
 synonym: "TR_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "27" xsd:string
-property_value: metpo:range_min "22" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "27" xsd:string
+property_value: METPO:range_min "22" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000451
+id: METPO:1000451
 name: temperature range mid2
 synonym: "mesophilic" EXACT []
 synonym: "TR_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "27" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "27" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000452
+id: METPO:1000452
 name: temperature range mid3
 synonym: "mesophilic" EXACT []
 synonym: "TR_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "34" xsd:string
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "34" xsd:string
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000453
+id: METPO:1000453
 name: temperature range mid4
 synonym: "mesophilic" EXACT []
 synonym: "TR_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "40" xsd:string
-property_value: metpo:range_min "34" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "40" xsd:string
+property_value: METPO:range_min "34" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000454
+id: METPO:1000454
 name: temperature range high
 synonym: "Thermophile" EXACT []
 synonym: "TR_>40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_min "40" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_min "40" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000455
+id: METPO:1000455
 name: pH optimum low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
@@ -7587,44 +7587,44 @@ synonym: "Extreme Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHO_0_to_6" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "6" xsd:string
-property_value: metpo:range_min "0" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "6" xsd:string
+property_value: METPO:range_min "0" xsd:string
 
 [Term]
-id: metpo:1000456
+id: METPO:1000456
 name: pH optimum mid1
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHO_6_to_7" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "7" xsd:string
-property_value: metpo:range_min "6" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "7" xsd:string
+property_value: METPO:range_min "6" xsd:string
 
 [Term]
-id: metpo:1000457
+id: METPO:1000457
 name: pH optimum mid2
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHO_7_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "7" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "7" xsd:string
 
 [Term]
-id: metpo:1000458
+id: METPO:1000458
 name: pH optimum high
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
 synonym: "pHO_8_to_14" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "14" xsd:string
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "14" xsd:string
+property_value: METPO:range_min "8" xsd:string
 
 [Term]
-id: metpo:1000459
+id: METPO:1000459
 name: pH range very low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
@@ -7632,1054 +7632,1054 @@ synonym: "Extreme Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHR_0_to_4" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "4" xsd:string
-property_value: metpo:range_min "0" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "4" xsd:string
+property_value: METPO:range_min "0" xsd:string
 
 [Term]
-id: metpo:1000460
+id: METPO:1000460
 name: pH range low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHR_4_to_6" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "6" xsd:string
-property_value: metpo:range_min "4" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "6" xsd:string
+property_value: METPO:range_min "4" xsd:string
 
 [Term]
-id: metpo:1000461
+id: METPO:1000461
 name: pH range mid1
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHR_6_to_7" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "7" xsd:string
-property_value: metpo:range_min "6" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "7" xsd:string
+property_value: METPO:range_min "6" xsd:string
 
 [Term]
-id: metpo:1000462
+id: METPO:1000462
 name: pH range mid2
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHR_7_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "7" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "7" xsd:string
 
 [Term]
-id: metpo:1000463
+id: METPO:1000463
 name: pH range mid3
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "pHR_8_to_10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "10" xsd:string
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "10" xsd:string
+property_value: METPO:range_min "8" xsd:string
 
 [Term]
-id: metpo:1000464
+id: METPO:1000464
 name: pH range high
 synonym: "10_to_14" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "14" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "14" xsd:string
+property_value: METPO:range_min "10" xsd:string
 
 [Term]
-id: metpo:1000465
+id: METPO:1000465
 name: NaCl optimum low
 synonym: "Halotolerant" EXACT []
 synonym: "NaO_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Non-halophile" EXACT []
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000466
+id: METPO:1000466
 name: NaCl optimum mid1
 synonym: "Halotolerant" EXACT []
 synonym: "NaO_1_to_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Slight halophile" EXACT []
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000467
+id: METPO:1000467
 name: NaCl optimum mid2
 synonym: "Halotolerant" EXACT []
 synonym: "Moderate halophile" EXACT []
 synonym: "NaO_3_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000468
+id: METPO:1000468
 name: NaCl optimum high
 synonym: "Extreme halophile" EXACT []
 synonym: "NaO_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000469
+id: METPO:1000469
 name: NaCl range low
 synonym: "Halotolerant" EXACT []
 synonym: "NaR_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Non-halophile" EXACT []
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000470
+id: METPO:1000470
 name: NaCl range mid1
 synonym: "Halotolerant" EXACT []
 synonym: "NaR_1_to_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Slight halophile" EXACT []
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000471
+id: METPO:1000471
 name: NaCl range mid2
 synonym: "Halotolerant" EXACT []
 synonym: "Moderate halophile" EXACT []
 synonym: "NaR_3_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000472
+id: METPO:1000472
 name: NaCl range high
 synonym: "Extreme halophile" EXACT []
 synonym: "NaR_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000473
+id: METPO:1000473
 name: pH delta very low
 synonym: "pHd_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "1" xsd:string
 
 [Term]
-id: metpo:1000474
+id: METPO:1000474
 name: pH delta low
 synonym: "pHd_1_2" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "2" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "2" xsd:string
+property_value: METPO:range_min "1" xsd:string
 
 [Term]
-id: metpo:1000475
+id: METPO:1000475
 name: pH delta mid1
 synonym: "pHd_2_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "2" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "2" xsd:string
 
 [Term]
-id: metpo:1000476
+id: METPO:1000476
 name: pH delta mid2
 synonym: "pHd_3_4" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "4" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "4" xsd:string
+property_value: METPO:range_min "3" xsd:string
 
 [Term]
-id: metpo:1000477
+id: METPO:1000477
 name: pH delta mid3
 synonym: "pHd_4_5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "5" xsd:string
-property_value: metpo:range_min "4" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "5" xsd:string
+property_value: METPO:range_min "4" xsd:string
 
 [Term]
-id: metpo:1000478
+id: METPO:1000478
 name: pH delta high
 synonym: "pHd_5_9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "9" xsd:string
-property_value: metpo:range_min "5" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "9" xsd:string
+property_value: METPO:range_min "5" xsd:string
 
 [Term]
-id: metpo:1000479
+id: METPO:1000479
 name: NaCl delta low
 synonym: "Nad_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000480
+id: METPO:1000480
 name: NaCl delta mid1
 synonym: "Nad_1_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000481
+id: METPO:1000481
 name: NaCl delta mid2
 synonym: "Nad_3_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000482
+id: METPO:1000482
 name: NaCl delta high
 synonym: "Nad_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000483
+id: METPO:1000483
 name: temperature delta very low
 synonym: "Td_1_5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "5" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "5" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000484
+id: METPO:1000484
 name: temperature delta low
 synonym: "Td_5_10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "10" xsd:string
-property_value: metpo:range_min "5" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "10" xsd:string
+property_value: METPO:range_min "5" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000485
+id: METPO:1000485
 name: temperature delta mid1
 synonym: "Td_10_20" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "20" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "20" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000486
+id: METPO:1000486
 name: temperature delta mid2
 synonym: "Td_20_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "20" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "20" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000487
+id: METPO:1000487
 name: temperature delta high
 synonym: "Td_>30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000488
+id: METPO:1000488
 name: obsolete branched
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000489
+id: METPO:1000489
 name: obsolete coccobacillus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000490
+id: METPO:1000490
 name: obsolete crescent
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000491
+id: METPO:1000491
 name: obsolete curved
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000492
+id: METPO:1000492
 name: obsolete curved spiral
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000493
+id: METPO:1000493
 name: obsolete diplococcus
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000494
+id: METPO:1000494
 name: obsolete ellipsoidal
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:1000495
+id: METPO:1000495
 name: obsolete filament
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000496
+id: METPO:1000496
 name: obsolete fusiform
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000497
+id: METPO:1000497
 name: obsolete helical
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000498
+id: METPO:1000498
 name: obsolete irregular
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000499
+id: METPO:1000499
 name: obsolete oval
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000500
+id: METPO:1000500
 name: obsolete ovoid
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000501
+id: METPO:1000501
 name: obsolete pleomorphic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000502
+id: METPO:1000502
 name: obsolete ring
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000503
+id: METPO:1000503
 name: obsolete rod
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000504
+id: METPO:1000504
 name: obsolete sphere
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000505
+id: METPO:1000505
 name: obsolete spindle
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000506
+id: METPO:1000506
 name: obsolete spiral
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000507
+id: METPO:1000507
 name: obsolete star - dumbbell - pleomorphic
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000508
+id: METPO:1000508
 name: obsolete tailed
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000509
+id: METPO:1000509
 name: obsolete temperature adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000510
+id: METPO:1000510
 name: obsolete salinity adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000511
+id: METPO:1000511
 name: obsolete pH adaptation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000512
+id: METPO:1000512
 name: obsolete bacterial spore
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000513
+id: METPO:1000513
 name: obsolete pressure adaptation type
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000514
+id: METPO:1000514
 name: obsolete pressure tolerance range
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:1000515
+id: METPO:1000515
 name: obsolete sensitivity to oxygen
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000516
+id: METPO:1000516
 name: obsolete sensitivity toward
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000517
+id: METPO:1000517
 name: obsolete size
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000518
+id: METPO:1000518
 name: obsolete 1-D extent
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000519
+id: METPO:1000519
 name: obsolete width
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000520
+id: METPO:1000520
 name: obsolete length
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000521
+id: METPO:1000521
 name: obsolete sensitivity toward pressure
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000522
+id: METPO:1000522
 name: obsolete sensitivity toward nacl
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000523
+id: METPO:1000523
 name: obsolete sensitivity toward ph
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000524
+id: METPO:1000524
 name: obsolete sensitivity toward temperature
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000525
+id: METPO:1000525
 name: microbe
 def: "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation." [] {IAO:0000119="OHMI:0000460"}
 comment: METPO is primarily concerned with unicellular, prokaryotic life forms, i.e. bacteria and archaea, including the cases of giant bacteria like Thiomargarita
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: IAO:0000117 "Luke Wang" xsd:string
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/OrganismTaxon
 
 [Term]
-id: metpo:1000526
+id: METPO:1000526
 name: chemical entity
 def: "A material entity that is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances." [] {IAO:0000119="CHEBI:24431"}
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/ChemicalEntity
 
 [Term]
-id: metpo:1000527
+id: METPO:1000527
 name: enzyme
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 
 [Term]
-id: metpo:1000528
+id: METPO:1000528
 name: obsolete structured susceptibility detail
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000529
+id: METPO:1000529
 name: obsolete facultative psychrophile
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000720
+replaced_by: METPO:1000720
 
 [Term]
-id: metpo:1000531
+id: METPO:1000531
 name: pH phenotype with numerical limits
 def: "A phenotype characterized by specific pH values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000532
+id: METPO:1000532
 name: salinity phenotype with numerical limits
 def: "A phenotype characterized by specific salt concentration values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000533
+id: METPO:1000533
 name: temperature phenotype with numerical limits
 def: "A phenotype characterized by specific temperature values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000534
+id: METPO:1000534
 name: delta phenotype with numerical limits
 def: "A phenotype characterized by the difference between maximum and minimum values of a growth parameter." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000535
+id: METPO:1000535
 name: growth range phenotype with numerical limits
 def: "A phenotype characterized by the span of values within which an organism can maintain growth." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000536
+id: METPO:1000536
 name: optimum phenotype with numerical limits
 def: "A phenotype characterized by the value at which an organism exhibits maximum growth rate or activity." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000601
+id: METPO:1000601
 name: oxygen preference
 def: "A phenotype that is relating to an organism's oxygen requirements or tolerance for growth." [] {IAO:0000119="UPHENO:0049673", IAO:0000119="https://purl.dsmz.de/schema/OxygenTolerance"}
 synonym: "metabolism" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "oxygen preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Physiology and metabolism.oxygen tolerance.oxygen tolerance" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000602
+id: METPO:1000602
 name: aerobic
 def: "An oxygen preference in which growth occurs in the presence of molecular oxygen (O2), typically using O2 as the terminal electron acceptor." [] {IAO:0000119="ECOCORE:00000173", IAO:0000119="OMP:0005253"}
 synonym: "aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "aerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_aerobic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000603
+id: METPO:1000603
 name: anaerobic
 def: "An oxygen preference in which growth occurs in the absence of molecular oxygen (O2)." [] {IAO:0000119="MICRO:0000495"}
 synonym: "anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_anaerobic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000604
+id: METPO:1000604
 name: microaerophilic
 def: "An oxygen preference that requires molecular oxygen (O2) at concentrations lower than atmospheric." [] {IAO:0000119="ECOCORE:00000180", IAO:0000119="OMP:0005254", IAO:0000119="MICRO:0000515"}
 synonym: "microaerophile" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "microaerophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_microerophile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000605
+id: METPO:1000605
 name: facultatively anaerobic
 def: "An oxygen preference in which growth can occur with or without molecular oxygen (O2)." [] {IAO:0000119="OMP:0000087", IAO:0000119="MICRO:0001520"}
 synonym: "facultative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "facultative anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "facultative anaerobe" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000606
+id: METPO:1000606
 name: obligately aerobic
 def: "An aerobic phenotype that requires molecular oxygen (O2) for growth." [] {IAO:0000119="MICRO:0000516"}
 synonym: "obligate aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "obligate aerobic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "obligate aerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000602 ! aerobic
+is_a: METPO:1000602 ! aerobic
 
 [Term]
-id: metpo:1000607
+id: METPO:1000607
 name: obligately anaerobic
 def: "An anaerobic phenotype in which molecular oxygen (O2) inhibits or prevents growth." [] {IAO:0000119="MICRO:0000504"}
 synonym: "obligate anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "obligate anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000603 ! anaerobic
+is_a: METPO:1000603 ! anaerobic
 
 [Term]
-id: metpo:1000608
+id: METPO:1000608
 name: facultatively aerobic
 def: "An oxygen preference in which growth can occur without oxygen but is capable of aerobic growth." [] {IAO:0000119="OMP:0000087", IAO:0000119="ECOCORE:00000177"}
 synonym: "facultative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "facultative aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000609
+id: METPO:1000609
 name: aerotolerant
 def: "An oxygen preference that does not use O2 for growth but tolerates its presence." [] {IAO:0000119="MICRO:0000502"}
 synonym: "aerotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "aerotolerant" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000610
+id: METPO:1000610
 name: microaerotolerant
 def: "An oxygen preference that tolerates low levels of molecular oxygen (O2) without requiring it." [] {IAO:0000119="ECOCORE:00000180", IAO:0000119="ECOCORE:00000181", IAO:0000119="OMP:0000087", IAO:0000119="OMP:0000105"}
 synonym: "microaerotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000611
+id: METPO:1000611
 name: strictly anaerobic
 def: "An obligately anaerobic where a microorganism does not grow in the presence of oxygen gas (O2)." [] {IAO:0000119="OMP:0000184"}
 synonym: "obligate anaerobic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "strictly anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000607 ! obligately anaerobic
+is_a: METPO:1000607 ! obligately anaerobic
 
 [Term]
-id: metpo:1000612
+id: METPO:1000612
 name: facultative oxygen preference
 def: "An oxygen preference that describes a microorganism that can grow with or without molecular oxygen." [] {IAO:0000119="OMP:0000087"}
 synonym: "Ox_facultative_aerobe_anaerobe" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000613
+id: METPO:1000613
 name: temperature preference
 def: "A phenotype that describes characteristic growth with respect to environmental temperature." [] {IAO:0000119="OMP:0005002"}
 synonym: "Physiology and metabolism.culture temp.temperature" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "range_tmp" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "temperature preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000614
+id: METPO:1000614
 name: psychrophilic
 def: "A temperature preference in which growth is favored at low temperatures, typically near or below ~15 C." [] {IAO:0000119="MICRO:0001306"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000615
+id: METPO:1000615
 name: mesophilic
 def: "A temperature preference in which growth is favored at intermediate temperatures, typically ~20-45 C." [] {IAO:0000119="MICRO:0000111"}
 synonym: "mesophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "mesophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000616
+id: METPO:1000616
 name: thermophilic
 def: "A temperature preference in which growth is favored at elevated temperatures, typically >=45 C." [] {IAO:0000119="OMP:0005003", IAO:0000119="OMP:0005004", IAO:0000119="MICRO:0000118"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000617
+id: METPO:1000617
 name: hyperthermophilic
 def: "A temperature preference in which growth is favored at very high temperatures, typically >=80 C." [] {IAO:0000119="MICRO:0001538"}
 synonym: "extreme thermophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "hyperthermophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000618
+id: METPO:1000618
 name: psychrotolerant
 def: "A temperature preference in which growth can occur at low temperatures without an obligate low-temperature preference." [] {IAO:0000119="MICRO:0001310", IAO:0000119="OMP:0005007", IAO:0000119="OMP:0005006"}
 synonym: "psychrotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000619
+id: METPO:1000619
 name: thermotolerant
 def: "A temperature preference in which growth can occur at elevated temperatures without an obligate high-temperature preference." [] {IAO:0000119="MICRO:0001286"}
 synonym: "thermotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000620
+id: METPO:1000620
 name: halophilic
 def: "A halophily preference in which an organism requires high concentrations of salt for growth and survival." [] {IAO:0000119="GO:0170002", IAO:0000119="OMP:0005016", IAO:0000119="MICRO:0001315", IAO:0000119="MICRO:0001314"}
 synonym: "halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000621
+id: METPO:1000621
 name: haloalkaliphilic
 def: "A halophily preference in which an organism requires both high salt concentrations and alkaline pH for optimal growth." [] {IAO:0000119="MICRO:0001392", IAO:0000119="MICRO:0001554", IAO:0000119="OMP:0005011", IAO:0000119="MICRO:0001314"}
 synonym: "haloalkaliphilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000622
+id: METPO:1000622
 name: halotolerant
 def: "A halophily preference in which an organism can tolerate high salt concentrations but does not require them for growth." [] {IAO:0000119="MICRO:0001316"}
 synonym: "halotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "halotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000623
+id: METPO:1000623
 name: moderately halophilic
 def: "A halophilic phenotype in which an organism requires high levels of sodium chloride, usually above or about 0.2 M." [] {IAO:0000119="OMP:0005016"}
 synonym: "moderate-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "moderately halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000624
+id: METPO:1000624
 name: non halophilic
 def: "A halophily preference in which an organism does not require or prefer elevated salt concentrations for growth." []
 synonym: "non-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "non-halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000625
+id: METPO:1000625
 name: slightly halophilic
 def: "A halophilic phenotype in which an organism requires low to moderate salt concentrations (0.3 to 0.8 M NaCl) for optimal growth." [] {IAO:0000119="OMP:0005016"}
 synonym: "slightly halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 
 [Term]
-id: metpo:1000626
+id: METPO:1000626
 name: stenohaline
 def: "A halophily preference in which an organism can only tolerate a narrow range of salinity concentrations and cannot survive significant changes in environmental salt levels." [] {IAO:0000119="https://purl.dsmz.de/schema/SaltTolerance"}
 synonym: "stenohaline" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000627
+id: METPO:1000627
 name: euryhaline
 def: "A halophily preference in which an organism can tolerate a wide range of salinity conditions." []
 synonym: "euryhaline" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000628
+id: METPO:1000628
 name: extremely halophilic
 def: "A halophilic phenotype in which an organism requires very high salt concentrations (typically 15-30% NaCl or higher) for optimal growth and cannot grow at salt concentrations below approximately 12%." [] {IAO:0000119="OMP:0005016", IAO:0000119="MICRO:0001314"}
 synonym: "extreme-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "extremely halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000629
+id: METPO:1000629
 name: halophily preference
 def: "A phenotype that is relating to an organism's salt concentration requirements or tolerance for growth." [] {IAO:0000119="https://purl.dsmz.de/schema/SaltTolerance", IAO:0000119="OMP:0005016"}
 synonym: "Physiology and metabolism.halophily.halophily level" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "range_salinity" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "salinity preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000630
+id: METPO:1000630
 name: biological process
 def: "A execution of a genetically-encoded biological module or program. It consists of all the steps required to achieve the specific biological objective of the module. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence." []
 
 [Term]
-id: metpo:1000631
+id: METPO:1000631
 name: trophic type
 def: "A phenotype that is describing how an organism obtains carbon and energy for growth and metabolism." []
 synonym: "nutritional type" RELATED []
 synonym: "pathways" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Physiology and metabolism.nutrition type.type" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000632
+id: METPO:1000632
 name: autotrophic
 def: "A trophic type in which an organism produces organic compounds from inorganic carbon sources (primarily carbon dioxide or bicarbonate) using energy from light (photoautotrophy) or from the oxidation of inorganic compounds (chemoautotrophy)." [] {IAO:0000119="ECOCORE:00000009", IAO:0000119="MICRO:0001456"}
 synonym: "autotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "autotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_autotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000633
+id: METPO:1000633
 name: carboxydotrophic
 def: "A trophic type in which an organism derives energy from the oxidation of carbon monoxide." []
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000634
+id: METPO:1000634
 name: chemoautolithotrophic
 def: "A trophic type in which an organism uses chemical oxidation of inorganic compounds as the energy source and carbon dioxide as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000129", IAO:0000119="ECOCORE:00000124", IAO:0000119="ECOCORE:00000123", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110"}
 synonym: "chemoautolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000635
+id: METPO:1000635
 name: chemoautotrophic
 def: "A trophic type in which an organism obtains energy from oxidation of inorganic compounds and carbon from carbon dioxide." [] {IAO:0000119="ECOCORE:00000129", IAO:0000119="MICRO:0001480", IAO:0000119="ECOCORE:00000123", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110"}
 synonym: "chemoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000636
+id: METPO:1000636
 name: chemoheterotrophic
 def: "A trophic type in which an organism obtains both energy and carbon from organic compounds." [] {IAO:0000119="ECOCORE:00000012", IAO:0000119="ECOCORE:00000132", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110", IAO:0000119="ECOCORE:00000127"}
 synonym: "aerobic_chemo_heterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "chemoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000637
+id: METPO:1000637
 name: chemolithoautotrophic
 def: "A trophic type in which an organism obtains energy from oxidation of inorganic compounds (lithotrophy) and carbon from carbon dioxide." [] {IAO:0000119="MICRO:0000511"}
 synonym: "chemolithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000638
+id: METPO:1000638
 name: chemolithoheterotrophic
 def: "A trophic type characterized by the use of inorganic chemical compounds as electron donors for energy generation while utilizing organic compounds as the primary carbon source." [] {IAO:0000119="MICRO:0001478", IAO:0000119="MICRO:0000512"}
 synonym: "chemolithoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000639
+id: METPO:1000639
 name: chemolithotrophic
 def: "A trophic type characterized by the use of inorganic chemical compounds as electron donors and carbon dioxide as the primary carbon source for energy generation and biosynthesis." [] {IAO:0000119="MICRO:0001499", IAO:0000119="OMP:0007110"}
 synonym: "chemolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000640
+id: METPO:1000640
 name: chemoorganoheterotrophic
 def: "A trophic type in which an organism obtains both energy and carbon from organic compounds through oxidation." [] {IAO:0000119="MICRO:0001481", IAO:0000119="MICRO:0000514", IAO:0000119="OMP:0007111", IAO:0000119="ECOCORE:00000127", IAO:0000119="MICRO:0001479"}
 synonym: "chemoorganoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000641
+id: METPO:1000641
 name: chemotrophic
 def: "A trophic type in which an organism obtains energy from chemical oxidation of either inorganic or organic compounds." [] {IAO:0000119="MICRO:0001458"}
 synonym: "chemotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_chemotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000642
+id: METPO:1000642
 name: copiotrophic
 def: "A nutrient adaptation in which an organism thrives in environments with high nutrient concentrations, typically exhibiting rapid growth rates and utilizing diverse carbon sources." []
 synonym: "copiotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000731 ! nutrient adaptation
+is_a: METPO:1000731 ! nutrient adaptation
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000643
+id: METPO:1000643
 name: obsolete denitrifying
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000644
+id: METPO:1000644
 name: heterotrophic
 def: "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide." [] {IAO:0000119="MICRO:0001474"}
 synonym: "aerobic_heterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "heterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "heterotrophic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_heterotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000645
+id: METPO:1000645
 name: obsolete hydrogen-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000646
+id: METPO:1000646
 name: hydrogenotrophic
 def: "A trophic type in which an organism uses molecular hydrogen as an electron donor for energy generation and carbon dioxide as the primary carbon source." []
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000647
+id: METPO:1000647
 name: lithoautotrophic
 def: "A trophic type in which an organism obtains energy from inorganic electron donors and carbon from carbon dioxide." [] {IAO:0000119="ECOCORE:00000009", IAO:0000119="MICRO:0001483", IAO:0000119="ECOCORE:00000122", IAO:0000119="ECOCORE:00000014", IAO:0000119="MICRO:0001477"}
 synonym: "lithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000648
+id: METPO:1000648
 name: lithoheterotrophic
 def: "A trophic type in which an organism obtains energy from the oxidation of inorganic compounds while using organic compounds as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="MICRO:0001459", IAO:0000119="ECOCORE:00000014", IAO:0000119="MICRO:0001478", IAO:0000119="OMP:0007110"}
 synonym: "lithoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000649
+id: METPO:1000649
 name: lithotrophic
 def: "A trophic type in which an organism uses inorganic compounds as electron donors for energy generation." [] {IAO:0000119="MICRO:0001459"}
 synonym: "lithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_lithotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000650
+id: METPO:1000650
 name: methanotrophic
 def: "A trophic type in which an organism uses methane as the primary carbon and energy source through oxidation of methane to carbon dioxide." []
 synonym: "methanotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000651
+id: METPO:1000651
 name: methylotrophic
 def: "A trophic type in which an organism obtains energy and carbon from reduced one-carbon compounds." []
 synonym: "methylotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "methylotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_methylotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000652
+id: METPO:1000652
 name: mixotrophic
 def: "A trophic type in which an organism can use both organic and inorganic carbon sources for growth." [] {IAO:0000119="MICRO:0001475"}
 synonym: "mixotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000653
+id: METPO:1000653
 name: obsolete nitrogen-fixing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1000654
+id: METPO:1000654
 name: oligotrophic
 def: "A nutrient adaptation characterized by the ability to thrive in environments with very low nutrient concentrations, typically possessing efficient nutrient uptake and utilization systems." [] {IAO:0000119="ENVO:01000774", IAO:0000119="ENVO:00002223"}
 synonym: "oligotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_oligotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000731 ! nutrient adaptation
+is_a: METPO:1000731 ! nutrient adaptation
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000655
+id: METPO:1000655
 name: organotrophic
 def: "A trophic type in which an organism obtains energy from the oxidation of organic compounds." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="OMP:0007111"}
 synonym: "organotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_organotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000656
+id: METPO:1000656
 name: photoautotrophic
 def: "A trophic type characterized by the use of light as the energy source and carbon dioxide as the primary carbon source for biosynthesis." [] {IAO:0000119="MICRO:0001483", IAO:0000119="OMP:0006008", IAO:0000119="ECOCORE:00000121", IAO:0000119="ECOCORE:00000017", IAO:0000119="MICRO:0001457"}
 synonym: "anoxygenic_photoautotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
@@ -8688,3005 +8688,3005 @@ synonym: "anoxygenic_photoautotrophy_iron_oxidation" RELATED [] {IAO:0000119="ht
 synonym: "anoxygenic_photoautotrophy_sulfur_oxidation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "photoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "photoautotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000657
+id: METPO:1000657
 name: photoheterotrophic
 def: "A trophic type in which an organism uses light as the energy source and organic compounds as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000131"}
 synonym: "photoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "photoheterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000658
+id: METPO:1000658
 name: photolithotrophic
 def: "A trophic type in which an organism uses light as the energy source and inorganic compounds as electron donors, typically with carbon dioxide as the primary carbon source." [] {IAO:0000119="MICRO:0001482"}
 synonym: "photolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000659
+id: METPO:1000659
 name: photoorganoheterotrophic
 def: "A trophic type in which an organism obtains energy from light and carbon from organic compounds." [] {IAO:0000119="MICRO:0000510"}
 synonym: "photoorganoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000660
+id: METPO:1000660
 name: phototrophic
 def: "A trophic type characterized by the use of light as the primary energy source for metabolic processes, regardless of carbon source." [] {IAO:0000119="OMP:0007064", IAO:0000119="MICRO:0001457"}
 synonym: "aerobic_anoxygenic_phototrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "phototroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_phototroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000661
+id: METPO:1000661
 name: obsolete sulfate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000662
+id: METPO:1000662
 name: obsolete sulfur-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000663
+id: METPO:1000663
 name: chemoorganotrophic
 def: "A trophic type in which an organism obtains energy through chemical oxidation of organic compounds that also serve as the carbon source for biosynthesis." [] {IAO:0000119="OMP:0007111"}
 synonym: "chemoorganotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000664
+id: METPO:1000664
 name: organoheterotrophic
 def: "A trophic type characterized by the use of organic compounds as both electron donors and primary carbon sources for energy generation and biosynthesis." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="ECOCORE:00000121", IAO:0000119="ECOCORE:00000126", IAO:0000119="ECOCORE:00000125", IAO:0000119="ECOCORE:00000127"}
 synonym: "organoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000665
+id: METPO:1000665
 name: photolithoautotrophic
 def: "A trophic type in which an organism obtains energy from light and carbon from carbon dioxide using inorganic electron donors." [] {IAO:0000119="MICRO:0000500"}
 synonym: "photolithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000666
+id: METPO:1000666
 name: cell shape
 def: "A phenotype that describes the characteristic three-dimensional morphological form of a microbial cell, determined by cell wall structure, cytoskeletal elements, and environmental factors." [] {IAO:0000119="OMP:0000073"}
 synonym: "cell shape" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "cell_shape" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Morphology.cell morphology.cell shape" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000667
+id: METPO:1000667
 name: bacillus shaped
 def: "A cell shape characterized by an elongated, rod cylindrical morphology with relatively parallel sides and rounded ends." [] {IAO:0000119="OMP:0000076"}
 synonym: "bacillus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000668
+id: METPO:1000668
 name: coccus shaped
 def: "A cell shape in which an organism has a spherical or nearly spherical morphology, with roughly equal dimensions in all directions." [] {IAO:0000119="OMP:0000075", IAO:0000119="OMP:0000123", IAO:0000119="MICRO:0000402"}
 synonym: "coccus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "coccus-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000669
+id: METPO:1000669
 name: crescent shaped
 synonym: "crescent-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000670
+id: METPO:1000670
 name: curved shaped
 synonym: "curved-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_curved_spiral" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000671
+id: METPO:1000671
 name: diplococcus shaped
 def: "A cell shape in which spherical cells remain attached in pairs following cell division, forming characteristic doublets." [] {IAO:0000119="OMP:0000117"}
 synonym: "diplococcus-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000672
+id: METPO:1000672
 name: dumbbell shaped
 synonym: "dumbbell-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000673
+id: METPO:1000673
 name: ellipsoidal
 def: "A cell shape in which an organism has an oval or ellipse morphology, elongated along one axis with rounded ends, intermediate between spherical and rod-shaped." [] {IAO:0000119="PATO:0000947"}
 synonym: "ellipsoidal" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000674
+id: METPO:1000674
 name: filament shaped
 synonym: "filament" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "filament-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_filament" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000675
+id: METPO:1000675
 name: flask shaped
 synonym: "flask" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "flask-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000676
+id: METPO:1000676
 name: helical shaped
 synonym: "helical-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000677
+id: METPO:1000677
 name: ovoid shaped
 def: "A cell shape in which an organism has an oval morphology, rounded at both ends with one end often slightly broader than the other." [] {IAO:0000119="PATO:0001891"}
 synonym: "ovoid-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_ovoid" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000678
+id: METPO:1000678
 name: oval shaped
 def: "A cell shape characterized by an ellipsoidal morphology with rounded ends, resembling an elongated sphere." [] {IAO:0000119="OMP:0007100"}
 synonym: "oval-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000679
+id: METPO:1000679
 name: pleomorphic shaped
 def: "A cell shape characterized by variable and irregular morphology, where individual cells within a population exhibit multiple distinct shapes." [] {IAO:0000119="OMP:0000132"}
 synonym: "pleomorphic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "pleomorphic-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000680
+id: METPO:1000680
 name: ring shaped
 def: "A cell shape in which an organism forms circular or toroidal structures." [] {IAO:0000119="PATO:0002539"}
 synonym: "ring" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "ring-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000681
+id: METPO:1000681
 name: rod shaped
 def: "A cell shape in which an organism has an elongated, cylindrical morphology with relatively straight sides and rounded or flat ends." [] {IAO:0000119="OMP:0000076"}
 synonym: "rod-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_rod" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000682
+id: METPO:1000682
 name: spore shaped
 synonym: "spore-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000683
+id: METPO:1000683
 name: sphere shaped
 synonym: "S_sphere" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "sphere-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000684
+id: METPO:1000684
 name: spiral shaped
 synonym: "S_curved_spiral" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "spiral" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "spiral-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000685
+id: METPO:1000685
 name: star shaped
 def: "A cell shape in which an organism has multiple radiating projections from a central body." [] {IAO:0000119="OMP:0000130", IAO:0000119="PATO:0002065"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "star" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "star-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000686
+id: METPO:1000686
 name: vibrio shaped
 def: "A cell shape in which an organism has a curved rod or comma morphology, characterized by a short curved cylindrical form with a single arc." [] {IAO:0000119="OMP:0000086", IAO:0000119="OMP:0000077"}
 synonym: "vibrio" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "vibrio-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000687
+id: METPO:1000687
 name: branched shaped
 synonym: "branced" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000688
+id: METPO:1000688
 name: coccobacillus shaped
 synonym: "coccobacillus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000689
+id: METPO:1000689
 name: disc shaped
 def: "A cell shape in which an organism is flat and circular." []
 synonym: "disc" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000690
+id: METPO:1000690
 name: fusiform shaped
 def: "A cell shape that is wide in the middle and tapers at both ends." [] {IAO:0000119="PATO:0002400"}
 synonym: "fusiform" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000691
+id: METPO:1000691
 name: irregular shaped
 synonym: "irregular" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000692
+id: METPO:1000692
 name: spindle shaped
 synonym: "spindle" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000693
+id: METPO:1000693
 name: spirochete shaped
 def: "A cell shape in which an organism has an elongated, tightly coiled helical morphology with periplasmic flagella (endoflagella) located between the cell wall and outer membrane." [] {IAO:0000119="OMP:0000086", IAO:0000119="OMP:0000124", IAO:0000119="OMP:0000125"}
 synonym: "spirochete" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000694
+id: METPO:1000694
 name: square shaped
 synonym: "square" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000695
+id: METPO:1000695
 name: tailed shaped
 synonym: "tailed" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000696
+id: METPO:1000696
 name: triangular shaped
 synonym: "triangular" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000697
+id: METPO:1000697
 name: gram stain
 def: "A phenotype where microorganisms are grouped based on their ability to retain crystal violet dye in the Gram staining procedure." [] {IAO:0000119="OMP:0000191"}
 synonym: "gram_stain" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Morphology.cell morphology.gram stain" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000698
+id: METPO:1000698
 name: gram positive
 def: "A gram stain in which an organism retains crystal violet dye and appears purple under microscopy due to a thick peptidoglycan cell wall." [] {IAO:0000119="OMP:0000188", IAO:0000119="https://purl.dsmz.de/schema/GramPositiveBacteria"}
 synonym: "G_positive" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "gram positive" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "positive" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "positive" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 
 [Term]
-id: metpo:1000699
+id: METPO:1000699
 name: gram negative
 def: "A gram stain in which bacteria do not retain crystal violet dye and appear pink or red after staining, indicating a thin peptidoglycan layer and presence of an outer membrane." []
 synonym: "G_negative" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "gram negative" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "negative" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "negative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000700
+id: METPO:1000700
 name: gram variable
 def: "A gram stain in which bacteria from the same culture show both gram-positive and gram-negative staining characteristics, often due to age of culture or cell wall degradation." [] {IAO:0000119="OMP:0000190"}
 synonym: "variable" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000701
+id: METPO:1000701
 name: motility
 def: "A phenotype in which an organism has the capability to move independently through its environment, typically by means of flagella, pili, gliding mechanisms, or other locomotory structures." [] {IAO:0000119="OMP:0000001"}
 synonym: "Morphology.cell morphology.motility" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "motility" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "presence of motility" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000702
+id: METPO:1000702
 name: motile
 def: "A motility in which an organism has the ability to move independently using metabolic energy." [] {IAO:0000119="CL:0000219", IAO:0000119="OMP:0000005"}
 synonym: "motile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "yes" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "yes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000701 ! motility
+is_a: METPO:1000701 ! motility
 
 [Term]
-id: metpo:1000703
+id: METPO:1000703
 name: non motile
 def: "A motility in which an organism lacks the ability to move independently under its own power." [] {IAO:0000119="OMP:0007489", IAO:0000119="OMP:0007488", IAO:0000119="OMP:0000133", IAO:0000119="UPHENO:0034076", IAO:0000119="OMP:0007490"}
 synonym: "no" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "no" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "non-motile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000701 ! motility
+is_a: METPO:1000701 ! motility
 
 [Term]
-id: metpo:1000704
+id: METPO:1000704
 name: flagellated
 def: "A motile in which an organism possesses flagella for locomotion." [] {IAO:0000119="MICRO:0000272", IAO:0000119="CL:0011016", IAO:0000119="OMP:0000029", IAO:0000119="GO:0030317"}
 synonym: "flagella" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 
 [Term]
-id: metpo:1000705
+id: METPO:1000705
 name: axially filamented
 def: "A motile in which the flagellum filament of an organism is located in the periplasm and does not extend past the cell envelope." [] {IAO:0000119="OMP:0000023", IAO:0000119="GO:0055040"}
 synonym: "axial filament" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000706
+id: METPO:1000706
 name: gliding
 def: "A motile in which an organism moves smoothly along solid surfaces without flagella or pili." [] {IAO:0000119="OMP:0000112", IAO:0000119="GO:0071976", IAO:0000119="MICRO:0000437"}
 synonym: "gliding" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 
 [Term]
-id: metpo:1000720
+id: METPO:1000720
 name: facultative psychrophilic
 def: "A temperature preference characterized by the ability to grow at low temperatures (typically below 20C) while maintaining optimal growth at moderate temperatures." [] {IAO:0000119="OMP:0005007", IAO:0000119="MICRO:0001306", IAO:0000119="MICRO:0001417"}
 synonym: "facultative psychrophile" RELATED []
 synonym: "facultative psychrophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000721
+id: METPO:1000721
 name: extreme hyperthermophilic
 def: "A hyperthermophilic phenotype in which an organism grows optimally at temperatures above 90 C." [] {IAO:0000119="ENVO:00002027", IAO:0000119="OMP:0005003", IAO:0000119="MICRO:0001294", IAO:0000119="MICRO:0001538"}
 synonym: "extreme hyperthermophile" RELATED []
 synonym: "extremely hyperthermophilic" RELATED []
-is_a: metpo:1000617 ! hyperthermophilic
+is_a: METPO:1000617 ! hyperthermophilic
 
 [Term]
-id: metpo:1000731
+id: METPO:1000731
 name: nutrient adaptation
 def: "A trophic type that involves an organism's physiological and metabolic adaptations to specific nutrient availability." [] {IAO:0000119="PHIPO:0001216"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000800
+id: METPO:1000800
 name: respiration
 def: "A metabolism that is characterized by the method of performing cellular respiration, distinguished primarily by the specific terminal electron acceptor utilized for producing cellular energy." [] {IAO:0000119="GO:0045333", IAO:0000119="GO:0009060"}
 synonym: "pathways" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "respiration" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000801
+id: METPO:1000801
 name: Aerobic respiration
 def: "A respiration in which molecular oxygen serves as the terminal electron acceptor in the electron transport chain, generating ATP through oxidative phosphorylation with water as the final product." [] {IAO:0000119="GO:0009060"}
 synonym: "Oxic respiration" RELATED []
 synonym: "Oxygen respiration" RELATED []
-is_a: metpo:1000800 ! respiration
+is_a: METPO:1000800 ! respiration
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000802
+id: METPO:1000802
 name: Anaerobic respiration
 def: "A respiration in which an organism uses electron acceptors other than oxygen for energy production." [] {IAO:0000119="GO:0009061"}
 synonym: "Anoxic respiration" RELATED []
 synonym: "Dissimilatory respiration (non-O2)" RELATED []
-is_a: metpo:1000800 ! respiration
+is_a: METPO:1000800 ! respiration
 
 [Term]
-id: metpo:1000803
+id: METPO:1000803
 name: Oxidative phosphorylation
 def: "A metabolism that generates ATP through the transfer of electrons from electron donors to electron acceptors via redox reactions, coupled to the pumping of protons across a membrane to create an electrochemical gradient." [] {IAO:0000119="GO:0006119"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000804
+id: METPO:1000804
 name: Substrate-level phosphorylation
 def: "A metabolism in which ATP is formed directly by transfer of a phosphoryl group from a substrate to ADP." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1000805
+id: METPO:1000805
 name: Electron transfer
 def: "A metabolism in which electrons are transferred from an electron donor to an electron acceptor." [] {IAO:0000119="GO:0009055"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000806
+id: METPO:1000806
 name: Disproportionation
 def: "A metabolism in which a single substrate simultaneously undergoes both oxidation and reduction reactions, with part of the substrate serving as the electron donor and another part serving as the electron acceptor." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000807
+id: METPO:1000807
 name: obsolete Nitrogen compound respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000808
+id: METPO:1000808
 name: obsolete Nitrate reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000809
+id: METPO:1000809
 name: obsolete Denitrification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005038
+replaced_by: METPO:1005038
 
 [Term]
-id: metpo:1000810
+id: METPO:1000810
 name: obsolete Dissimilatory nitrate reduction to ammonium
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000811
+id: METPO:1000811
 name: obsolete Nitrite reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000812
+id: METPO:1000812
 name: obsolete Anaerobic ammonium oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000813
+id: METPO:1000813
 name: obsolete Nitric oxide reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000814
+id: METPO:1000814
 name: obsolete Nitrous oxide reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000815
+id: METPO:1000815
 name: obsolete Sulfur and sulfoxide compound respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000816
+id: METPO:1000816
 name: obsolete Sulfate reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000817
+id: METPO:1000817
 name: obsolete Sulfur reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000818
+id: METPO:1000818
 name: obsolete Sulfite reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000819
+id: METPO:1000819
 name: obsolete Thiosulfate reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000820
+id: METPO:1000820
 name: obsolete Sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000821
+id: METPO:1000821
 name: obsolete Dimethyl sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000822
+id: METPO:1000822
 name: obsolete Methionine sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000823
+id: METPO:1000823
 name: obsolete Sulfide oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000824
+id: METPO:1000824
 name: obsolete Thiosulfate oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000825
+id: METPO:1000825
 name: obsolete Sulfite oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000826
+id: METPO:1000826
 name: obsolete Tetrathionate reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000827
+id: METPO:1000827
 name: obsolete Polysulfide reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000828
+id: METPO:1000828
 name: obsolete Metal and metalloid respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000829
+id: METPO:1000829
 name: obsolete Iron reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000830
+id: METPO:1000830
 name: obsolete Iron oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000831
+id: METPO:1000831
 name: obsolete Nitrate-dependent Fe(II) oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000832
+id: METPO:1000832
 name: obsolete Manganese reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000833
+id: METPO:1000833
 name: obsolete Manganese oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000834
+id: METPO:1000834
 name: obsolete Uranium reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000835
+id: METPO:1000835
 name: obsolete Vanadium reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000836
+id: METPO:1000836
 name: obsolete Chromium reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000837
+id: METPO:1000837
 name: obsolete Technetium reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000838
+id: METPO:1000838
 name: obsolete Cobalt reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000839
+id: METPO:1000839
 name: obsolete Arsenate reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000840
+id: METPO:1000840
 name: obsolete Arsenite oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000841
+id: METPO:1000841
 name: obsolete Selenate reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000842
+id: METPO:1000842
 name: obsolete Selenite reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000843
+id: METPO:1000843
 name: obsolete Carbon and organic compound respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000844
+id: METPO:1000844
 name: Methanogenesis
 def: "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions." [] {IAO:0000119="GO:0015948"}
 synonym: "Biological methanation" RELATED []
 synonym: "Biomethanation" RELATED []
 synonym: "Carbonate respiration" RELATED []
 synonym: "methanogenesis" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000845
+id: METPO:1000845
 name: Acetogenesis
 def: "A metabolism that produces acetate as the primary end product through the reduction of carbon dioxide or other carbon compounds using the Wood-Ljungdahl pathway, typically performed by acetogenic bacteria under anaerobic conditions." []
 synonym: "Acetate fermentation" RELATED []
 synonym: "acetogenesis" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000846
+id: METPO:1000846
 name: Homoacetogenesis
 def: "A metabolism in which acetate is produced as the sole reduced end product from reduction of CO2 via the acetyl-CoA pathway." []
 synonym: "Reductive acetyl-CoA pathway" RELATED []
 synonym: "Wood-Ljungdahl pathway" RELATED []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1000847
+id: METPO:1000847
 name: obsolete Fumarate respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000848
+id: METPO:1000848
 name: obsolete Trimethylamine N-oxide respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000849
+id: METPO:1000849
 name: obsolete Humus respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000850
+id: METPO:1000850
 name: obsolete Halogenated compound respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000851
+id: METPO:1000851
 name: obsolete Organohalide respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000852
+id: METPO:1000852
 name: obsolete (Per)chlorate respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000853
+id: METPO:1000853
 name: obsolete Perchlorate respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000854
+id: METPO:1000854
 name: obsolete Chlorate respiration
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000855
+id: METPO:1000855
 name: obsolete Bromate reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000856
+id: METPO:1000856
 name: obsolete Iodate reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000857
+id: METPO:1000857
 name: obsolete Nitrite-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000858
+id: METPO:1000858
 name: obsolete Nitrate-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000859
+id: METPO:1000859
 name: obsolete Hydrogen oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000860
+id: METPO:1000860
 name: obsolete Sulfur oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000861
+id: METPO:1000861
 name: obsolete Nitrification
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005001
+replaced_by: METPO:1005001
 
 [Term]
-id: metpo:1000862
+id: METPO:1000862
 name: obsolete Complete ammonia oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000863
+id: METPO:1000863
 name: obsolete Carbon monoxide oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000864
+id: METPO:1000864
 name: obsolete Hydrogenotrophic methanogenesis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000865
+id: METPO:1000865
 name: obsolete Acetoclastic methanogenesis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000866
+id: METPO:1000866
 name: obsolete Methylotrophic methanogenesis
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000867
+id: METPO:1000867
 name: obsolete Anaerobic methane oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000868
+id: METPO:1000868
 name: obsolete Lanthanide reduction
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000869
+id: METPO:1000869
 name: obsolete Lanthanide oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000870
+id: METPO:1000870
 name: sporulation
 def: "A phenotype that is relating to an organism's ability to form dormant, stress-resistant endospores." [] {IAO:0000119="GO:0043934"}
 synonym: "General.keywords" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "Physiology and metabolism.spore formation.spore formation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "sporulation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "sporulation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000871
+id: METPO:1000871
 name: spore forming
 def: "A sporulation in which an organism has the ability to produce endospores." [] {IAO:0000119="GO:0034301", IAO:0000119="https://purl.dsmz.de/schema/SporeFormation", IAO:0000119="OMP:0000017"}
 synonym: "spore" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "yes" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "yes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000870 ! sporulation
+is_a: METPO:1000870 ! sporulation
 
 [Term]
-id: metpo:1000872
+id: METPO:1000872
 name: non-spore forming
 def: "A sporulation in which an organism lacks the ability to produce endospores." [] {IAO:0000119="OMP:0007236", IAO:0000119="OMP:0007434", IAO:0000119="UPHENO:0083394", IAO:0000119="OMP:0000018", IAO:0000119="OMP:0007232"}
 synonym: "no" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "no" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "no_spore" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000870 ! sporulation
+is_a: METPO:1000870 ! sporulation
 
 [Term]
-id: metpo:1000881
+id: METPO:1000881
 name: cell length
 def: "A phenotype that inheres in a cell by virtue of its longer dimension when viewed on a plane." [] {IAO:0000119="OBA:2040145"}
 synonym: "cell length" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000882
+id: METPO:1000882
 name: cell width
 def: "A phenotype that inheres in a cell by virtue of its shorter dimension when viewed on a plane." [] {IAO:0000119="OBA:2040146"}
 synonym: "cell width" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000883
+id: METPO:1000883
 name: cell length very small
 synonym: "L_<=1.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "1.3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "1.3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000884
+id: METPO:1000884
 name: cell length small
 synonym: "L_1.3_2" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "2" xsd:string
-property_value: metpo:range_min "1.3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "2" xsd:string
+property_value: METPO:range_min "1.3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000885
+id: METPO:1000885
 name: cell length medium
 synonym: "L_2_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "2" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "2" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000886
+id: METPO:1000886
 name: cell length large
 synonym: "L_>3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000887
+id: METPO:1000887
 name: cell width very small
 synonym: "W_<=0.5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.5" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.5" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000888
+id: METPO:1000888
 name: cell width small
 synonym: "W_0.5_0.65" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.65" xsd:string
-property_value: metpo:range_min "0.5" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.65" xsd:string
+property_value: METPO:range_min "0.5" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000889
+id: METPO:1000889
 name: cell width medium
 synonym: "W_0.65_0.9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.9" xsd:string
-property_value: metpo:range_min "0.65" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.9" xsd:string
+property_value: METPO:range_min "0.65" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000890
+id: METPO:1000890
 name: cell width large
 synonym: "W_>0.9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_min "0.9" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_min "0.9" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1001000
+id: METPO:1001000
 name: obsolete observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001001
+id: METPO:1001001
 name: obsolete optimum temperature observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001002
+id: METPO:1001002
 name: obsolete growth temperature observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001003
+id: METPO:1001003
 name: obsolete temperature range observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001004
+id: METPO:1001004
 name: obsolete temperature delta observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001005
+id: METPO:1001005
 name: obsolete culture temperature observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001006
+id: METPO:1001006
 name: obsolete culture NaCl observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001007
+id: METPO:1001007
 name: obsolete growth NaCl observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001008
+id: METPO:1001008
 name: obsolete NaCl delta observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001009
+id: METPO:1001009
 name: obsolete NaCl range observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001010
+id: METPO:1001010
 name: obsolete optimum NaCl observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001011
+id: METPO:1001011
 name: obsolete culture pH observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001012
+id: METPO:1001012
 name: obsolete growth pH observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001013
+id: METPO:1001013
 name: obsolete optimum pH observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001014
+id: METPO:1001014
 name: obsolete pH delta observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001015
+id: METPO:1001015
 name: obsolete pH range observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001016
+id: METPO:1001016
 name: obsolete optimum oxygen observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001017
+id: METPO:1001017
 name: obsolete growth oxygen observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001018
+id: METPO:1001018
 name: obsolete oxygen range observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001019
+id: METPO:1001019
 name: obsolete oxygen delta observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001020
+id: METPO:1001020
 name: obsolete oxygen observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001021
+id: METPO:1001021
 name: obsolete temperature observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001022
+id: METPO:1001022
 name: obsolete NaCl observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001023
+id: METPO:1001023
 name: obsolete pH observation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001101
+id: METPO:1001101
 name: biosafety level
 def: "A quality that categorizes biological agents according to their hazard level and required containment measures." []
 synonym: "biosafety level" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Safety information.risk assessment.biosafety level" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 
 [Term]
-id: metpo:1001102
+id: METPO:1001102
 name: biosafety level 1
 def: "A biosafety level that pose minimal potential hazard to laboratory workers and the environment, requiring only standard microbiological practices." []
 synonym: "1" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1001103
+id: METPO:1001103
 name: biosafety level 2
 def: "A biosafety level that pose moderate risk and are associated with human diseases present in the community." []
 synonym: "2" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1001104
+id: METPO:1001104
 name: biosafety level 3
 def: "A biosafety level that can cause serious or potentially lethal disease through inhalation or other routes, requiring specialized containment facilities with controlled access, directional airflow, and strict safety protocols." []
 synonym: "3" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "3**" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1001105
+id: METPO:1001105
 name: biosafety level 4
 def: "A biosafety level that pose extreme risk of life-threatening disease through aerosol transmission with no available treatment." []
 synonym: "4" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1001106
+id: METPO:1001106
 name: biosafety level 5
 def: "A biosafety level that is proposed as a classification beyond BSL-4 for hypothetical biological agents requiring enhanced containment." []
 synonym: "5" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1002000
+id: METPO:1002000
 name: obsolete Sulfate-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002001
+id: METPO:1002001
 name: obsolete Fe(III)-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002002
+id: METPO:1002002
 name: obsolete Mn(IV)-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002003
+id: METPO:1002003
 name: Cable bacteria metabolism
 def: "A metabolism in which electrons are transferred over centimeter-scale distances through multicellular filaments." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1002005
+id: METPO:1002005
 name: Fermentation
 def: "A metabolism in which energy is generated through the oxidation of organic compounds without using an external electron acceptor, using organic molecules as both electron donors and final electron acceptors." [] {IAO:0000119="GO:0006113"}
 synonym: "fermentation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "fermentation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1002006
+id: METPO:1002006
 name: Syntrophy
 def: "A metabolism in which the metabolism of one species is thermodynamically dependent on the removal of its products by another species." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1002007
+id: METPO:1002007
 name: obsolete Sulfur disproportionation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000806
+replaced_by: METPO:1000806
 
 [Term]
-id: metpo:1002008
+id: METPO:1002008
 name: obsolete Nitrogen fixation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1002009
+id: METPO:1002009
 name: obsolete Nitrate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002010
+id: METPO:1002010
 name: obsolete Anaerobic ammonium-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002011
+id: METPO:1002011
 name: obsolete Nitrous oxide-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002012
+id: METPO:1002012
 name: obsolete Sulfate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002013
+id: METPO:1002013
 name: obsolete Sulfur-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002014
+id: METPO:1002014
 name: obsolete Sulfite-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002015
+id: METPO:1002015
 name: obsolete Thiosulfate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002016
+id: METPO:1002016
 name: obsolete Sulfur-disproportionating
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002017
+id: METPO:1002017
 name: obsolete Sulfide-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002018
+id: METPO:1002018
 name: obsolete Thiosulfate-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002019
+id: METPO:1002019
 name: obsolete Sulfite-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002020
+id: METPO:1002020
 name: obsolete Iron-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002021
+id: METPO:1002021
 name: obsolete Iron-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002022
+id: METPO:1002022
 name: obsolete Nitrate-dependent Fe(II)-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002023
+id: METPO:1002023
 name: obsolete Manganese-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002024
+id: METPO:1002024
 name: obsolete Manganese-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002025
+id: METPO:1002025
 name: obsolete Uranium-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002026
+id: METPO:1002026
 name: obsolete Arsenate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002027
+id: METPO:1002027
 name: obsolete Selenate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002028
+id: METPO:1002028
 name: obsolete Selenite-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002029
+id: METPO:1002029
 name: obsolete Perchlorate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002030
+id: METPO:1002030
 name: obsolete Chlorate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002031
+id: METPO:1002031
 name: obsolete Bromate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002032
+id: METPO:1002032
 name: obsolete Iodate-reducing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002033
+id: METPO:1002033
 name: obsolete Hydrogen-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002034
+id: METPO:1002034
 name: obsolete Sulfur-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002035
+id: METPO:1002035
 name: obsolete Ammonia oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002036
+id: METPO:1002036
 name: obsolete Nitrite oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002037
+id: METPO:1002037
 name: obsolete Complete ammonia-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002038
+id: METPO:1002038
 name: obsolete Methane oxidation
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002039
+id: METPO:1002039
 name: obsolete Carbon monoxide-oxidizing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002040
+id: METPO:1002040
 name: obsolete Nitrogen-fixing
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1003000
+id: METPO:1003000
 name: pH growth preference
 def: "A phenotype that describes how the rate and extent of population growth are affected by environmental pH." [] {IAO:0000119="OMP:0005008"}
 synonym: "pH growth" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1003001
+id: METPO:1003001
 name: neutrophilic
 def: "A pH growth preference characterized by optimal growth at near-neutral pH values, typically between pH 6.5 and 7.5." [] {IAO:0000119="PATO:0070046", IAO:0000119="OMP:0005010"}
 synonym: "neutralophile" EXACT []
 synonym: "neutralophilic" EXACT []
 synonym: "neutrophile" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1003002
+id: METPO:1003002
 name: alkaliphilic
 def: "A pH growth preference in which an organism grows optimally at pH values above 9." [] {IAO:0000119="OMP:0005009", IAO:0000119="MICRO:0001549", IAO:0000119="OMP:0005010", IAO:0000119="ENVO:00002022", IAO:0000119="OMP:0005011"}
 synonym: "alkaliphile" EXACT []
 synonym: "alkaliphilic" EXACT []
 synonym: "alkalophile" EXACT []
 synonym: "alkalophilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003003
+id: METPO:1003003
 name: acidophilic
 def: "A pH growth preference in which an organism grows optimally at pH values below 5." [] {IAO:0000119="OMP:0007945", IAO:0000119="OMP:0005009", IAO:0000119="MICRO:0001549", IAO:0000119="OMP:0005010", IAO:0000119="OMP:0005011"}
 synonym: "acidophil" EXACT []
 synonym: "acidophile" EXACT []
 synonym: "acidophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003004
+id: METPO:1003004
 name: obligately alkaliphilic
 def: "An alkaliphilic phenotype in which an organism requires alkaline conditions (typically pH above 8.5) for growth and cannot grow at neutral or acidic pH." [] {IAO:0000119="OMP:0007947", IAO:0000119="ENVO:00002022", IAO:0000119="MICRO:0001565", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771"}
 synonym: "obligate alkaliphile" EXACT []
 synonym: "obligate alkaphilic" EXACT []
 synonym: "obligately alkaliphilic" EXACT []
-is_a: metpo:1003002 ! alkaliphilic
+is_a: METPO:1003002 ! alkaliphilic
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1003005
+id: METPO:1003005
 name: facultatively alkaliphilic
 def: "A pH growth preference in which an organism can grow at alkaline pH but does not require it." [] {IAO:0000119="MICRO:0001558", IAO:0000119="OMP:0005009", IAO:0000119="OMP:0007947", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771"}
 synonym: "facultative alkaliphile" EXACT []
 synonym: "facultative alkaphilic" EXACT []
 synonym: "facultatively alkaliphilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003006
+id: METPO:1003006
 name: obligately acidophilic
 def: "An acidophilic phenotype in which an organism requires acidic environments (pH below 5.5) for growth, with inability to grow at neutral or alkaline pH values." [] {IAO:0000119="MICRO:0001566"}
 synonym: "obligate acidophile" EXACT []
 synonym: "obligately acidophilic" EXACT []
-is_a: metpo:1003003 ! acidophilic
+is_a: METPO:1003003 ! acidophilic
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003007
+id: METPO:1003007
 name: facultatively acidophilic
 def: "A pH growth preference characterized by optimal growth in acidic environments (pH below 5.5) with the capacity to also grow at near-neutral pH values." [] {IAO:0000119="OMP:0007945", IAO:0000119="OMP:0007009", IAO:0000119="MICRO:0001557", IAO:0000119="OMP:0005009", IAO:0000119="OMP:0005010"}
 synonym: "facultative acidophile" EXACT []
 synonym: "facultatively acidophilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003008
+id: METPO:1003008
 name: acidotolerant
 def: "A pH growth preference characterized by the ability to tolerate acidic environments (typically pH below 5.5) while maintaining optimal growth near neutral pH." [] {IAO:0000119="MICRO:0001555"}
 synonym: "aciduric" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003009
+id: METPO:1003009
 name: alkalotolerant
 def: "A pH growth preference in which an organism can tolerate alkaline pH but grows optimally at neutral pH." [] {IAO:0000119="OMP:0005009", IAO:0000119="OMP:0007947", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771", IAO:0000119="OMP:0007011"}
 synonym: "alkalitolerant" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003021
+id: METPO:1003021
 name: pigmentation
 def: "A phenotype characterized by the color of pigments produced by a microorganism." [] {IAO:0000119="GO:0043473"}
 synonym: "cell color" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1003022
+id: METPO:1003022
 name: black pigmented
 synonym: "Pigment_black" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003023
+id: METPO:1003023
 name: brown pigmented
 synonym: "Pigment_brown" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003024
+id: METPO:1003024
 name: cream pigmented
 synonym: "Pigment_cream" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003025
+id: METPO:1003025
 name: green pigmented
 synonym: "Pigment_green" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003026
+id: METPO:1003026
 name: orange pigmented
 synonym: "Pigment_orange" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003027
+id: METPO:1003027
 name: pink pigmented
 synonym: "Pigment_pink" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003028
+id: METPO:1003028
 name: red pigmented
 synonym: "Pigment_red" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003029
+id: METPO:1003029
 name: white pigmented
 synonym: "Pigment_white" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003030
+id: METPO:1003030
 name: yellow pigmented
 synonym: "cell color: yellow pigment" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Pigment_yellow" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003031
+id: METPO:1003031
 name: carotenoid pigmentation
 synonym: "Pigment_carotenoid" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1004000
+id: METPO:1004000
 name: pathogenic to host
 def: "A phenotype where a microbe is a pathogen of of some host organism." [] {IAO:0000119="OMP:0000068", IAO:0000119="OMP:0007284"}
 synonym: "General.keywords" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "Safety information.risk assessment" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1004002
+id: METPO:1004002
 name: animal pathogen
 def: "A pathogen that infects organisms in the kingdom Metazoa." []
 synonym: "animal pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004003
+id: METPO:1004003
 name: plant pathogen
 def: "A pathogen that infects organisms in the kingdom Viridiplantae." []
 synonym: "plant pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004004
+id: METPO:1004004
 name: human pathogen
 def: "A pathogen that infects organisms of the species Homo sapiens." [] {IAO:0000119="IDO:0000639"}
 synonym: "human pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004005
+id: METPO:1004005
 name: growth medium
 def: "A material entity that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms." [] {IAO:0000119="OBI:0000079"}
 comment: This class is equivalent to OBI:0000079 'culture medium'. It is included in METPO to serve as the range for growth-related object properties.
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: skos:broadMatch https://biolink.github.io/biolink-model/ProcessedMaterial
 
 [Term]
-id: metpo:1005001
+id: METPO:1005001
 name: nitrification
 def: "A biological process in which ammonia is oxidized to nitrite (ammonia oxidation) and nitrite is oxidized to nitrate (nitrite oxidation), in two steps." [] {IAO:0000119="GO:0019332", IAO:0000119="GO:0019329"}
 comment: MetaTraits maps to OMIT:0027217 (wrong ontology). Correct GO terms are GO:0019329 (ammonia oxidation) and GO:0019332 (nitrite oxidation).
 synonym: "nitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005010
+id: METPO:1005010
 name: indole test
 def: "An assay that tests the ability of an organism to produce indole from tryptophan." [] {IAO:0000119="MICRO:0000430"}
 synonym: "indole test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005011
+id: METPO:1005011
 name: indole test positive
 def: "A phenotype in which an organism tests positive in the indole test, indicating it produces indole from tryptophan." []
 synonym: "indole test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005010 ! indole test
+is_a: METPO:1005010 ! indole test
 
 [Term]
-id: metpo:1005012
+id: METPO:1005012
 name: indole test negative
 def: "A phenotype in which an organism tests negative in the indole test, indicating it does not produce indole from tryptophan." []
-is_a: metpo:1005010 ! indole test
+is_a: METPO:1005010 ! indole test
 
 [Term]
-id: metpo:1005013
+id: METPO:1005013
 name: methyl red test
 def: "An assay that tests the ability of an organism to produce and maintain stable acid end products from glucose fermentation." [] {IAO:0000119="SNOMED:5894006"}
 synonym: "methyl red test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005014
+id: METPO:1005014
 name: methyl red test positive
 def: "A phenotype in which an organism tests positive in the methyl red test, indicating mixed acid fermentation." []
 synonym: "methyl red test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005013 ! methyl red test
+is_a: METPO:1005013 ! methyl red test
 
 [Term]
-id: metpo:1005015
+id: METPO:1005015
 name: methyl red test negative
 def: "A phenotype in which an organism tests negative in the methyl red test." []
-is_a: metpo:1005013 ! methyl red test
+is_a: METPO:1005013 ! methyl red test
 
 [Term]
-id: metpo:1005016
+id: METPO:1005016
 name: Voges-Proskauer test
 def: "An assay that tests the ability of an organism to produce acetoin from glucose via the butanediol fermentation pathway." [] {IAO:0000119="SNOMED:66592006"}
 synonym: "voges-proskauer test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005017
+id: METPO:1005017
 name: Voges-Proskauer test positive
 def: "A phenotype in which an organism tests positive in the Voges-Proskauer test, indicating acetoin production." []
 synonym: "voges-proskauer test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005016 ! Voges-Proskauer test
+is_a: METPO:1005016 ! Voges-Proskauer test
 
 [Term]
-id: metpo:1005018
+id: METPO:1005018
 name: Voges-Proskauer test negative
 def: "A phenotype in which an organism tests negative in the Voges-Proskauer test." []
-is_a: metpo:1005016 ! Voges-Proskauer test
+is_a: METPO:1005016 ! Voges-Proskauer test
 
 [Term]
-id: metpo:1005021
+id: METPO:1005021
 name: capnophilic
 def: "A phenotype describing an organism that requires elevated concentrations of carbon dioxide for growth." [] {IAO:0000119="SNOMED:413748004"}
 synonym: "capnophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1005025
+id: METPO:1005025
 name: hemolysis
 def: "A phenotype describing the ability of an organism to lyse red blood cells." [] {IAO:0000119="OMP:0005117"}
 synonym: "presence of hemolysis" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005026
+id: METPO:1005026
 name: hemolytic
 def: "A phenotype in which an organism is capable of lysing red blood cells." []
-is_a: metpo:1005025 ! hemolysis
+is_a: METPO:1005025 ! hemolysis
 
 [Term]
-id: metpo:1005027
+id: METPO:1005027
 name: non-hemolytic
 def: "A phenotype in which an organism does not lyse red blood cells." []
-is_a: metpo:1005025 ! hemolysis
+is_a: METPO:1005025 ! hemolysis
 
 [Term]
-id: metpo:1005031
+id: METPO:1005031
 name: peritrichous flagellation
 def: "A motility phenotype in which flagella are distributed over the entire cell surface." [] {IAO:0000119="OMP:0000078"}
 synonym: "flagellum arrangement" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005032
+id: METPO:1005032
 name: polar flagellation
 def: "A motility phenotype in which one or more flagella are located at one or both poles of the cell." []
 synonym: "flagellum arrangement" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005033
+id: METPO:1005033
 name: amphitrichous flagellation
 def: "A motility phenotype in which a single flagellum is present at each pole of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005034
+id: METPO:1005034
 name: lophotrichous flagellation
 def: "A motility phenotype in which a tuft of flagella is present at one or both poles of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005035
+id: METPO:1005035
 name: monotrichous flagellation
 def: "A motility phenotype in which a single flagellum is present at one pole of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005036
+id: METPO:1005036
 name: lateral flagellation
 def: "A motility phenotype in which flagella emerge from the lateral side of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005037
+id: METPO:1005037
 name: subpolar flagellation
 def: "A motility phenotype in which flagella are located near but not at the cell pole." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005038
+id: METPO:1005038
 name: denitrification
 def: "A biological process in which nitrate or nitrite is reduced to gaseous nitrogen compounds (NO, N2O, or N2) under anaerobic or microaerobic conditions." [] {IAO:0000119="GO:0019333"}
 synonym: "denitrification pathway" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005039
+id: METPO:1005039
 name: nitrogen fixation
 def: "A biological process in which atmospheric dinitrogen is reduced to ammonia, catalyzed by nitrogenase." [] {IAO:0000119="GO:0009399"}
 synonym: "nitrogen fixation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005040
+id: METPO:1005040
 name: generalist
 def: "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources." [] {IAO:0000119="inbio:000022"}
 synonym: "generalist" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1007005
+id: METPO:1007005
 name: flagellar arrangement
 def: "A phenotype characterized by the arrangement pattern of flagella on a bacterial or archaeal cell (e.g. peritrichous, polar, amphitrichous, lophotrichous, monotrichous, lateral, subpolar)." [] {IAO:0000119="OMP:0000078"}
 comment: subset=metpo_proposal_2026_04; priority=HIGH; xrefs=GO:0001539
 synonym: "flagellation pattern" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007006
+id: METPO:1007006
 name: polytrichous flagellation
 def: "A flagellar arrangement in which multiple flagella (typically a tuft) are present per cell, often combined with polar attachment." [] {IAO:0000119="MICRO:0000271"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; observations=4
 synonym: "polytrichous" EXACT []
-is_a: metpo:1007005 ! flagellar arrangement
+is_a: METPO:1007005 ! flagellar arrangement
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007062
+id: METPO:1007062
 name: colony morphology
 def: "A phenotype characterized by macroscopic colony characteristics such as shape, margin, elevation, surface, colour, and size." [] {IAO:0000119="OMP:0000100"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=PATO:0000052
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007063
+id: METPO:1007063
 name: colony shape
 def: "A colony morphology characterized by the overall macroscopic colony outline as observed on solid medium." [] {IAO:0000119="OMP:0000103"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=PATO:0000052
-is_a: metpo:1007062 ! colony morphology
+is_a: METPO:1007062 ! colony morphology
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007064
+id: METPO:1007064
 name: circular colony
 def: "A colony shape that has a regular round outline." [] {IAO:0000119="OMP:0000166"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=2649
 synonym: "round colony" EXACT []
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007065
+id: METPO:1007065
 name: irregular colony
 def: "A colony shape that has an irregular (non-round, non-rhizoid) outline." [] {IAO:0000119="OMP:0000167"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=148
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007066
+id: METPO:1007066
 name: filamentous colony
 def: "A colony shape that has a thread-like or filamentous outline." [] {IAO:0000119="OMP:0000088"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=16
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007067
+id: METPO:1007067
 name: punctiform colony
 def: "A colony shape that is very small (pinpoint), typically <1 mm in diameter." [] {IAO:0000119="OMP:0000240"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=11
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007068
+id: METPO:1007068
 name: rhizoid colony
 def: "A colony shape that has a branching, root-like outline." [] {IAO:0000119="OMP:0000168"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=8
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007069
+id: METPO:1007069
 name: fried-egg-shaped colony
 def: "A colony shape that has a raised opaque centre and a translucent peripheral zone, resembling a fried egg." [] {IAO:0000119="MICRO:0000349"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=6
 synonym: "fried-egg colony" EXACT []
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007070
+id: METPO:1007070
 name: pressure tolerance
 def: "A phenotype characterized by the ability to grow under elevated hydrostatic pressure." [] {IAO:0000119="OMP:0005012"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "barophile" EXACT []
 synonym: "piezophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007071
+id: METPO:1007071
 name: barophile phenotype
 def: "A pressure tolerance in which an organism requires or tolerates elevated hydrostatic pressure for growth." [] {IAO:0000119="MICRO:0001359"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
-is_a: metpo:1007070 ! pressure tolerance
+is_a: METPO:1007070 ! pressure tolerance
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007072
+id: METPO:1007072
 name: radiation tolerance
 def: "A phenotype characterized by the ability to withstand ionizing or UV radiation." [] {IAO:0000119="wikidata:Q2353022"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "radioresistant" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007073
+id: METPO:1007073
 name: osmotic tolerance
 def: "A phenotype characterized by the ability to grow under high osmotic pressure (non-NaCl)." [] {IAO:0000119="OMP:0005015"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "osmophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007074
+id: METPO:1007074
 name: metal tolerance
 def: "A phenotype characterized by the ability to grow in the presence of elevated metal concentrations." [] {IAO:0000119="OMP:0007890"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "metallophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007076
+id: METPO:1007076
 name: capsule presence
 def: "A phenotype characterized by the presence of an extracellular polysaccharide capsule." [] {IAO:0000119="OMP:0000203"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=GO:0042603
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007077
+id: METPO:1007077
 name: biofilm formation capability
 def: "A phenotype characterized by the ability to form surface-attached biofilms." [] {IAO:0000119="OMP:0000176"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0042710
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007080
+id: METPO:1007080
 name: catalase test
 def: "A biochemical test that detects catalase enzyme activity by exposing cells to hydrogen peroxide and observing for visible bubbling. The test outcome (positive or negative) is captured by its child classes; this class itself does not assert that the organism has catalase activity." [] {IAO:0000119="OMP:0000218"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "catalase activity test" EXACT []
 synonym: "catalase assay" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007081
+id: METPO:1007081
 name: oxidase test
 def: "A biochemical test that detects cytochrome c oxidase activity using a redox indicator. The test outcome (positive or negative) is captured by its child classes; this class itself does not assert oxidase activity." [] {IAO:0000119="OMP:0000220"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "cytochrome oxidase test" EXACT []
 synonym: "oxidase activity test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007082
+id: METPO:1007082
 name: urease test
 def: "A biochemical test that detects urease enzyme activity by observing urea hydrolysis (typically via a pH-indicator color change). The test outcome (positive or negative) is captured by its child classes; this class itself does not assert urease activity." [] {IAO:0000119="OMP:0000222"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "urea hydrolysis test" EXACT []
 synonym: "urease activity test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007083
+id: METPO:1007083
 name: catalase positive
 def: "Test-outcome phenotype where the catalase test yields a positive result (visible bubbling on H2O2). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0004096 'catalase activity'." [] {IAO:0000119="OMP:0000194"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0004096
 synonym: "catalase +" EXACT []
 synonym: "catalase test positive" EXACT []
-is_a: metpo:1007080 ! catalase test
+is_a: METPO:1007080 ! catalase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007084
+id: METPO:1007084
 name: catalase negative
 def: "Test-outcome phenotype where the catalase test yields a negative result (no bubbling on H2O2). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0004096 'catalase activity'." [] {IAO:0000119="OMP:0000198"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "catalase -" EXACT []
 synonym: "catalase test negative" EXACT []
-is_a: metpo:1007080 ! catalase test
+is_a: METPO:1007080 ! catalase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007085
+id: METPO:1007085
 name: oxidase positive
 def: "Test-outcome phenotype where the oxidase test yields a positive result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0004129 'cytochrome-c oxidase activity'." [] {IAO:0000119="OMP:0006085"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0004129
 synonym: "oxidase +" EXACT []
 synonym: "oxidase test positive" EXACT []
-is_a: metpo:1007081 ! oxidase test
+is_a: METPO:1007081 ! oxidase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007086
+id: METPO:1007086
 name: oxidase negative
 def: "Test-outcome phenotype where the oxidase test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0004129 'cytochrome-c oxidase activity'." [] {IAO:0000119="OMP:0006084"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "oxidase -" EXACT []
 synonym: "oxidase test negative" EXACT []
-is_a: metpo:1007081 ! oxidase test
+is_a: METPO:1007081 ! oxidase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007087
+id: METPO:1007087
 name: urease positive
 def: "Test-outcome phenotype where the urease test yields a positive result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0009039 'urease activity'." [] {IAO:0000119="OMP:0006089"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0009039
 synonym: "urease +" EXACT []
 synonym: "urease test positive" EXACT []
-is_a: metpo:1007082 ! urease test
+is_a: METPO:1007082 ! urease test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007088
+id: METPO:1007088
 name: urease negative
 def: "Test-outcome phenotype where the urease test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0009039 'urease activity'." [] {IAO:0000119="OMP:0006090"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "urease -" EXACT []
 synonym: "urease test negative" EXACT []
-is_a: metpo:1007082 ! urease test
+is_a: METPO:1007082 ! urease test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007089
+id: METPO:1007089
 name: coagulase activity
 def: "A phenotype characterized by coagulase enzyme activity (clotting of blood plasma); a diagnostic marker, e.g. for Staphylococcus aureus." [] {IAO:0000119="MICRO:0000991"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007090
+id: METPO:1007090
 name: coagulase positive
 def: "Test-outcome phenotype where the coagulase test yields a positive result (plasma clotting). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' <coagulase enzyme term> once a sufficiently specific enzyme term is selected (no GO/EC term currently exists at the bacteriological coagulase test granularity)." [] {IAO:0000119="wikidata:Q98095684"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase +" EXACT []
 synonym: "coagulase test positive" EXACT []
-is_a: metpo:1007089 ! coagulase activity
+is_a: METPO:1007089 ! coagulase activity
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007091
+id: METPO:1007091
 name: coagulase negative
 def: "Test-outcome phenotype where the coagulase test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' <coagulase enzyme term> once a sufficiently specific enzyme term is selected." [] {IAO:0000119="wikidata:Q98095684"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase -" EXACT []
 synonym: "coagulase test negative" EXACT []
-is_a: metpo:1007089 ! coagulase activity
+is_a: METPO:1007089 ! coagulase activity
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007092
+id: METPO:1007092
 name: xerophilic phenotype
 def: "A phenotype characterized by a microbe that thrives in low water-activity environments (typically aw < 0.85), where the limiting factor is water activity (aw) rather than solute concentration; distinct from halophily and osmotic tolerance." [] {IAO:0000119="wikidata:Q980491"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "xerophile" EXACT []
 synonym: "xerotolerant" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007093
+id: METPO:1007093
 name: epibiont phenotype
 def: "A phenotype characterized by a microbe that lives on the external surface of a host organism or substrate, as distinct from endosymbionts (which live inside the host); captures host-association mode, not specific host taxonomy." [] {IAO:0000119="wikidata:Q640114"}
 comment: subset=metpo_proposal_2026_04; priority=LOW
 synonym: "ectosymbiont" EXACT []
 synonym: "epibiont" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:9999999
+id: METPO:9999999
 name: obsolete obsolete
 is_a: oboInOwl:ObsoleteClass
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000000
+id: METPO:2000000
 name: obsolete has susceptibility profile
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000001
+id: METPO:2000001
 name: organism interacts with chemical
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000002
+id: METPO:2000002
 name: assimilates
 synonym: "assimilation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000003
+id: METPO:2000003
 name: builds acid from
 synonym: "builds acid from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000004
+id: METPO:2000004
 name: builds base from
 synonym: "builds base from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000005
+id: METPO:2000005
 name: builds gas from
 synonym: "builds gas from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000006
+id: METPO:2000006
 name: uses as carbon source
 synonym: "carbon source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000007
+id: METPO:2000007
 name: degrades
 synonym: "degradation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000008
+id: METPO:2000008
 name: uses as electron acceptor
 synonym: "electron acceptor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000009
+id: METPO:2000009
 name: uses as electron donor
 synonym: "electron donor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000010
+id: METPO:2000010
 name: uses as energy source
 synonym: "energy source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000011
+id: METPO:2000011
 name: ferments
 synonym: "fermentation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000012
+id: METPO:2000012
 name: uses for growth
 synonym: "growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000013
+id: METPO:2000013
 name: hydrolyzes
 synonym: "hydrolysis" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000014
+id: METPO:2000014
 name: uses as nitrogen source
 synonym: "nitrogen source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000015
+id: METPO:2000015
 name: uses in other way
 synonym: "other" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "utilizes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000016
+id: METPO:2000016
 name: oxidizes
 synonym: "oxidation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000017
+id: METPO:2000017
 name: reduces
 synonym: "reduction" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000018
+id: METPO:2000018
 name: requires for growth
 synonym: "required for growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000019
+id: METPO:2000019
 name: uses for respiration
 synonym: "respiration" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000020
+id: METPO:2000020
 name: uses as sulfur source
 synonym: "sulfur source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000021
+id: METPO:2000021
 name: does not use for aerobic catabolization
 synonym: "aerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000022
+id: METPO:2000022
 name: does not use for aerobic growth
 synonym: "aerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000023
+id: METPO:2000023
 name: does not use for anaerobic catabolization
 synonym: "anaerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000024
+id: METPO:2000024
 name: does not use for anaerobic growth
 synonym: "anaerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000025
+id: METPO:2000025
 name: does not use for anaerobic growth in the dark
 synonym: "anaerobic growth in the dark" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000026
+id: METPO:2000026
 name: does not use for anaerobic growth with light
 synonym: "anaerobic growth with light" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000027
+id: METPO:2000027
 name: does not assimilate
 synonym: "assimilation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000028
+id: METPO:2000028
 name: does not build acid from
 synonym: "builds acid from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000029
+id: METPO:2000029
 name: does not build base from
 synonym: "builds base from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000030
+id: METPO:2000030
 name: does not build gas from
 synonym: "builds gas from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000031
+id: METPO:2000031
 name: does not use as carbon source
 synonym: "carbon source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000032
+id: METPO:2000032
 name: uses for aerobic catabolization
 synonym: "aerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000033
+id: METPO:2000033
 name: does not degrade
 synonym: "degradation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000034
+id: METPO:2000034
 name: does not use as electron acceptor
 synonym: "electron acceptor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000035
+id: METPO:2000035
 name: does not use as electron donor
 synonym: "electron donor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000036
+id: METPO:2000036
 name: does not use as energy source
 synonym: "energy source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000037
+id: METPO:2000037
 name: does not ferment
 synonym: "fermentation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000038
+id: METPO:2000038
 name: does not use for growth
 synonym: "growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000039
+id: METPO:2000039
 name: does not hydrolyze
 synonym: "hydrolysis" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000040
+id: METPO:2000040
 name: does not use as nitrogen source
 synonym: "nitrogen source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000041
+id: METPO:2000041
 name: does not use in other way
 synonym: "other" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "utilizes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000042
+id: METPO:2000042
 name: does not oxidize
 synonym: "oxidation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000043
+id: METPO:2000043
 name: uses for aerobic growth
 synonym: "aerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000044
+id: METPO:2000044
 name: does not reduce
 synonym: "reduction" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000045
+id: METPO:2000045
 name: is not required for growth
 synonym: "required for growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000046
+id: METPO:2000046
 name: does not use for respiration
 synonym: "respiration" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000047
+id: METPO:2000047
 name: does not use as sulfur source
 synonym: "sulfur source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000048
+id: METPO:2000048
 name: uses for anaerobic catabolization
 synonym: "anaerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000049
+id: METPO:2000049
 name: uses for anaerobic growth
 synonym: "anaerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000050
+id: METPO:2000050
 name: uses for anaerobic growth in the dark
 synonym: "anaerobic growth in the dark" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000051
+id: METPO:2000051
 name: uses for anaerobic growth with light
 synonym: "anaerobic growth with light" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000052
+id: METPO:2000052
 name: obsolete has temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000053
+id: METPO:2000053
 name: obsolete has optimum temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000054
+id: METPO:2000054
 name: obsolete has growth temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000055
+id: METPO:2000055
 name: obsolete has range temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000056
+id: METPO:2000056
 name: obsolete has temperature delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000057
+id: METPO:2000057
 name: obsolete has culture temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000064
+id: METPO:2000064
 name: tolerates
 def: "A relation between a microbe and a chemical entity indicating that the microbe's growth is not inhibited by the chemical at the concentration tested. Positive form of the chemical-tolerance pair; the negative form is METPO:2000065 'does not tolerate'." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000065
+id: METPO:2000065
 name: does not tolerate
 def: "A relation between a microbe and a chemical entity indicating that the microbe's growth is inhibited by the chemical at the concentration tested. Negative form of the chemical-tolerance pair; positive form is METPO:2000064 'tolerates'. Equivalent in meaning to 'is susceptible to' and 'is sensitive to'; the canonical label uses the 'does not X' convention so the metatraits pairing logic auto-detects it as the negative member." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000067
+id: METPO:2000067
 name: isolated from host with quality
 def: "A relation between a microbe and a quality of the host from which the microbe was isolated. Examples: a microbe isolated from a juvenile host has the relation `<microbe> METPO:2000067 PATO:0001190 'juvenile'`; a microbe isolated from a female host has the relation `<microbe> METPO:2000067 PATO:0000383 'female'`. The relation is one-directional: it asserts that the host bore the named quality at isolation time, not that the microbe itself has the quality." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000068
+id: METPO:2000068
 name: isolated from environment with quality
 def: "A relation between a microbe and a quality of the environment from which the microbe was isolated. Examples: a microbe isolated from an acidic environment has the relation `<microbe> METPO:2000068 PATO:0001429 'acidic'`; a microbe isolated from an anaerobic environment has `<microbe> METPO:2000068 PATO:0001456 'anaerobic'`. The relation does not by itself entail that the microbe is acidophilic, anaerobic, etc. as a phenotype; it only records the environment's quality at the time of isolation. Microbe phenotype assertions belong on a separate edge (e.g. METPO:1000615 acidophilic via has_phenotype)." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000101
+id: METPO:2000101
 name: has quality
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000102
+id: METPO:2000102
 name: has phenotype
 property_value: skos:closeMatch has:phenotype
-domain: metpo:1000525 ! microbe
-range: metpo:1000059 ! phenotype
-is_a: metpo:2000101 ! has quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000059 ! phenotype
+is_a: METPO:2000101 ! has quality
 
 [Typedef]
-id: metpo:2000103
+id: METPO:2000103
 name: capable of
 property_value: skos:closeMatch capable:of
-domain: metpo:1000525 ! microbe
-range: metpo:1000630 ! biological process
+domain: METPO:1000525 ! microbe
+range: METPO:1000630 ! biological process
 
 [Typedef]
-id: metpo:2000200
+id: METPO:2000200
 name: disproportionates
 synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000201
+id: METPO:2000201
 name: obsolete lyses
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000202
+id: METPO:2000202
 name: produces
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000203
+id: METPO:2000203
 name: obsolete fixes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000204
+id: METPO:2000204
 name: obsolete catabolizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000205
+id: METPO:2000205
 name: obsolete mineralizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000206
+id: METPO:2000206
 name: obsolete conjugates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000207
+id: METPO:2000207
 name: transports
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000208
+id: METPO:2000208
 name: imports
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000207 ! transports
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000207 ! transports
 
 [Typedef]
-id: metpo:2000209
+id: METPO:2000209
 name: exports
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000207 ! transports
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000207 ! transports
 
 [Typedef]
-id: metpo:2000210
+id: METPO:2000210
 name: accumulates
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000211
+id: METPO:2000211
 name: sequesters
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000210 ! accumulates
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000210 ! accumulates
 
 [Typedef]
-id: metpo:2000212
+id: METPO:2000212
 name: compartmentalizes
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000210 ! accumulates
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000210 ! accumulates
 
 [Typedef]
-id: metpo:2000213
+id: METPO:2000213
 name: obsolete binds
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000214
+id: METPO:2000214
 name: obsolete chelates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000215
+id: METPO:2000215
 name: obsolete precipitates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000216
+id: METPO:2000216
 name: obsolete solubilizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000217
+id: METPO:2000217
 name: obsolete volatilizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000218
+id: METPO:2000218
 name: obsolete crystallizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000219
+id: METPO:2000219
 name: obsolete adsorbs
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000220
+id: METPO:2000220
 name: does not disproportionate
 synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000221
+id: METPO:2000221
 name: obsolete does not lyse
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000222
+id: METPO:2000222
 name: does not produce
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000223
+id: METPO:2000223
 name: obsolete does not fix
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000224
+id: METPO:2000224
 name: obsolete does not catabolize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000225
+id: METPO:2000225
 name: obsolete does not mineralize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000226
+id: METPO:2000226
 name: obsolete does not conjugate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000227
+id: METPO:2000227
 name: does not transport
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000228
+id: METPO:2000228
 name: does not import
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000227 ! does not transport
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000227 ! does not transport
 
 [Typedef]
-id: metpo:2000229
+id: METPO:2000229
 name: does not export
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000227 ! does not transport
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000227 ! does not transport
 
 [Typedef]
-id: metpo:2000230
+id: METPO:2000230
 name: does not accumulate
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000231
+id: METPO:2000231
 name: does not sequester
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000230 ! does not accumulate
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000230 ! does not accumulate
 
 [Typedef]
-id: metpo:2000232
+id: METPO:2000232
 name: does not compartmentalize
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000230 ! does not accumulate
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000230 ! does not accumulate
 
 [Typedef]
-id: metpo:2000233
+id: METPO:2000233
 name: obsolete does not bind
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000234
+id: METPO:2000234
 name: obsolete does not chelate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000235
+id: METPO:2000235
 name: obsolete does not precipitate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000236
+id: METPO:2000236
 name: obsolete does not solubilize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000237
+id: METPO:2000237
 name: obsolete does not volatilize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000238
+id: METPO:2000238
 name: obsolete does not crystallize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000239
+id: METPO:2000239
 name: obsolete has pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000301
+id: METPO:2000301
 name: enzyme activity analyzed
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
 
 [Typedef]
-id: metpo:2000302
+id: METPO:2000302
 name: shows activity of
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
-is_a: metpo:2000301 ! enzyme activity analyzed
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
+is_a: METPO:2000301 ! enzyme activity analyzed
 
 [Typedef]
-id: metpo:2000303
+id: METPO:2000303
 name: does not show activity of
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
-is_a: metpo:2000301 ! enzyme activity analyzed
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
+is_a: METPO:2000301 ! enzyme activity analyzed
 
 [Typedef]
-id: metpo:2000501
+id: METPO:2000501
 name: obsolete has optimum pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000502
+id: METPO:2000502
 name: obsolete has growth pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000503
+id: METPO:2000503
 name: obsolete has range pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000504
+id: METPO:2000504
 name: obsolete has pH delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000505
+id: METPO:2000505
 name: obsolete has culture pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000506
+id: METPO:2000506
 name: obsolete has NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000507
+id: METPO:2000507
 name: obsolete has optimum NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000508
+id: METPO:2000508
 name: obsolete has growth NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000509
+id: METPO:2000509
 name: obsolete has range NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000510
+id: METPO:2000510
 name: obsolete has NaCl delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000511
+id: METPO:2000511
 name: obsolete has observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000512
+id: METPO:2000512
 name: obsolete has oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000513
+id: METPO:2000513
 name: obsolete has optimum oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000514
+id: METPO:2000514
 name: obsolete has growth oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000515
+id: METPO:2000515
 name: obsolete has range oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000516
+id: METPO:2000516
 name: obsolete has oxygen delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000517
+id: METPO:2000517
 name: grows in
 def: "A relation between a microbe and a growth medium indicating that the microbe has been demonstrated to grow in that medium under some set of conditions. This relation represents a generalization from experimental observations reported in the literature or databases; it does not imply that the microbe will grow in the medium under all conditions." []
-domain: metpo:1000525 ! microbe
-range: metpo:1004005 ! growth medium
+domain: METPO:1000525 ! microbe
+range: METPO:1004005 ! growth medium
 
 [Typedef]
-id: metpo:2000518
+id: METPO:2000518
 name: does not grow in
 def: "A relation between a microbe and a growth medium indicating that the microbe has been demonstrated to fail to grow in that medium under some set of conditions. This relation represents a generalization from experimental observations reported in the literature or databases; it does not imply that the microbe cannot grow in the medium under any conditions." []
-domain: metpo:1000525 ! microbe
-range: metpo:1004005 ! growth medium
+domain: METPO:1000525 ! microbe
+range: METPO:1004005 ! growth medium
 
 [Typedef]
-id: metpo:2000601
+id: METPO:2000601
 name: denitrifies
 synonym: "denitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000602
+id: METPO:2000602
 name: does not denitrify
 synonym: "denitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000603
+id: METPO:2000603
 name: ammonifies
 synonym: "ammonification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000604
+id: METPO:2000604
 name: does not ammonify
 synonym: "ammonification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000605
+id: METPO:2000605
 name: oxidizes in darkness
 synonym: "oxidation in darkness" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000606
+id: METPO:2000606
 name: does not oxidize in darkness
 synonym: "oxidation in darkness" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 

--- a/metpo-base.owl
+++ b/metpo-base.owl
@@ -11,7 +11,7 @@
      xmlns:qudt="http://qudt.org/schema/qudt/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-     xmlns:metpo="https://w3id.org/metpo/"
+     xmlns:METPO="https://w3id.org/metpo/"
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="https://w3id.org/metpo/metpo-base.owl">
@@ -13863,7 +13863,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_&lt;=42.65</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC low</rdfs:label>
-        <metpo:range_max>42.65</metpo:range_max>
+        <METPO:range_max>42.65</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000429"/>
@@ -13903,8 +13903,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_42.65_57.0</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC mid1</rdfs:label>
-        <metpo:range_max>57</metpo:range_max>
-        <metpo:range_min>42.65</metpo:range_min>
+        <METPO:range_max>57</METPO:range_max>
+        <METPO:range_min>42.65</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000430"/>
@@ -13944,8 +13944,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_57.0_66.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC mid2</rdfs:label>
-        <metpo:range_max>66.3</metpo:range_max>
-        <metpo:range_min>57</metpo:range_min>
+        <METPO:range_max>66.3</METPO:range_max>
+        <METPO:range_min>57</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000431"/>
@@ -13982,7 +13982,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_&gt;66.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC high</rdfs:label>
-        <metpo:range_min>66.3</metpo:range_min>
+        <METPO:range_min>66.3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000432"/>
@@ -14117,7 +14117,7 @@
         <oboInOwl:hasExactSynonym>Psychrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_&lt;=10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum very low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
+        <METPO:range_max>10</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000441"/>
@@ -14160,8 +14160,8 @@
         <oboInOwl:hasExactSynonym>Psychrotolerant</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_10_to_22</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum low</rdfs:label>
-        <metpo:range_max>22</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>22</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000442"/>
@@ -14203,8 +14203,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid1</rdfs:label>
-        <metpo:range_max>27</metpo:range_max>
-        <metpo:range_min>22</metpo:range_min>
+        <METPO:range_max>27</METPO:range_max>
+        <METPO:range_min>22</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000443"/>
@@ -14246,8 +14246,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>27</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>27</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000444"/>
@@ -14289,8 +14289,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid3</rdfs:label>
-        <metpo:range_max>34</metpo:range_max>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_max>34</METPO:range_max>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000445"/>
@@ -14332,8 +14332,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid4</rdfs:label>
-        <metpo:range_max>40</metpo:range_max>
-        <metpo:range_min>34</metpo:range_min>
+        <METPO:range_max>40</METPO:range_max>
+        <METPO:range_min>34</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000446"/>
@@ -14372,7 +14372,7 @@
         <oboInOwl:hasExactSynonym>Thermophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_&gt;40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum high</rdfs:label>
-        <metpo:range_min>40</metpo:range_min>
+        <METPO:range_min>40</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000447"/>
@@ -14411,7 +14411,7 @@
         <oboInOwl:hasExactSynonym>Psychrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_&lt;=10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range very low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
+        <METPO:range_max>10</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000448"/>
@@ -14454,8 +14454,8 @@
         <oboInOwl:hasExactSynonym>Psychrotolerant</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_10_to_22</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range low</rdfs:label>
-        <metpo:range_max>22</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>22</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000449"/>
@@ -14497,8 +14497,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid1</rdfs:label>
-        <metpo:range_max>27</metpo:range_max>
-        <metpo:range_min>22</metpo:range_min>
+        <METPO:range_max>27</METPO:range_max>
+        <METPO:range_min>22</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000450"/>
@@ -14540,8 +14540,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>27</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>27</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000451"/>
@@ -14583,8 +14583,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid3</rdfs:label>
-        <metpo:range_max>34</metpo:range_max>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_max>34</METPO:range_max>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000452"/>
@@ -14626,8 +14626,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid4</rdfs:label>
-        <metpo:range_max>40</metpo:range_max>
-        <metpo:range_min>34</metpo:range_min>
+        <METPO:range_max>40</METPO:range_max>
+        <METPO:range_min>34</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000453"/>
@@ -14666,7 +14666,7 @@
         <oboInOwl:hasExactSynonym>Thermophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_&gt;40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range high</rdfs:label>
-        <metpo:range_min>40</metpo:range_min>
+        <METPO:range_min>40</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000454"/>
@@ -14711,8 +14711,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_0_to_6</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum low</rdfs:label>
-        <metpo:range_max>6</metpo:range_max>
-        <metpo:range_min>0</metpo:range_min>
+        <METPO:range_max>6</METPO:range_max>
+        <METPO:range_min>0</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000455"/>
@@ -14754,8 +14754,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_6_to_7</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum mid1</rdfs:label>
-        <metpo:range_max>7</metpo:range_max>
-        <metpo:range_min>6</metpo:range_min>
+        <METPO:range_max>7</METPO:range_max>
+        <METPO:range_min>6</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000456"/>
@@ -14798,8 +14798,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_7_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>7</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>7</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000457"/>
@@ -14842,8 +14842,8 @@
         <oboInOwl:hasExactSynonym>Extreme Alkaliphile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_8_to_14</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum high</rdfs:label>
-        <metpo:range_max>14</metpo:range_max>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_max>14</METPO:range_max>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000458"/>
@@ -14888,8 +14888,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_0_to_4</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range very low</rdfs:label>
-        <metpo:range_max>4</metpo:range_max>
-        <metpo:range_min>0</metpo:range_min>
+        <METPO:range_max>4</METPO:range_max>
+        <METPO:range_min>0</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000459"/>
@@ -14933,8 +14933,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_4_to_6</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range low</rdfs:label>
-        <metpo:range_max>6</metpo:range_max>
-        <metpo:range_min>4</metpo:range_min>
+        <METPO:range_max>6</METPO:range_max>
+        <METPO:range_min>4</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000460"/>
@@ -14977,8 +14977,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_6_to_7</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid1</rdfs:label>
-        <metpo:range_max>7</metpo:range_max>
-        <metpo:range_min>6</metpo:range_min>
+        <METPO:range_max>7</METPO:range_max>
+        <METPO:range_min>6</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000461"/>
@@ -15022,8 +15022,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_7_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>7</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>7</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000462"/>
@@ -15067,8 +15067,8 @@
         <oboInOwl:hasExactSynonym>Facultative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_8_to_10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid3</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_max>10</METPO:range_max>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000463"/>
@@ -15111,8 +15111,8 @@
         <oboInOwl:hasExactSynonym>Extreme Alkaliphile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>10_to_14</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range high</rdfs:label>
-        <metpo:range_max>14</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>14</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000464"/>
@@ -15152,7 +15152,7 @@
         <oboInOwl:hasExactSynonym>Non-halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000465"/>
@@ -15195,8 +15195,8 @@
         <oboInOwl:hasExactSynonym>Slight halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_1_to_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000466"/>
@@ -15239,8 +15239,8 @@
         <oboInOwl:hasExactSynonym>Moderate halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_3_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000467"/>
@@ -15279,7 +15279,7 @@
         <oboInOwl:hasExactSynonym>Extreme halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000468"/>
@@ -15319,7 +15319,7 @@
         <oboInOwl:hasExactSynonym>Non-halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000469"/>
@@ -15362,8 +15362,8 @@
         <oboInOwl:hasExactSynonym>Slight halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_1_to_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000470"/>
@@ -15406,8 +15406,8 @@
         <oboInOwl:hasExactSynonym>Moderate halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_3_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000471"/>
@@ -15446,7 +15446,7 @@
         <oboInOwl:hasExactSynonym>Extreme halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000472"/>
@@ -15483,7 +15483,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta very low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000473"/>
@@ -15523,8 +15523,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_1_2</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta low</rdfs:label>
-        <metpo:range_max>2</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>2</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000474"/>
@@ -15564,8 +15564,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_2_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>2</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>2</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000475"/>
@@ -15605,8 +15605,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_3_4</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid2</rdfs:label>
-        <metpo:range_max>4</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>4</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000476"/>
@@ -15646,8 +15646,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_4_5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid3</rdfs:label>
-        <metpo:range_max>5</metpo:range_max>
-        <metpo:range_min>4</metpo:range_min>
+        <METPO:range_max>5</METPO:range_max>
+        <METPO:range_min>4</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000477"/>
@@ -15687,8 +15687,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_5_9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta high</rdfs:label>
-        <metpo:range_max>9</metpo:range_max>
-        <metpo:range_min>5</metpo:range_min>
+        <METPO:range_max>9</METPO:range_max>
+        <METPO:range_min>5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000478"/>
@@ -15726,7 +15726,7 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000479"/>
@@ -15767,8 +15767,8 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_1_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000480"/>
@@ -15809,8 +15809,8 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_3_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000481"/>
@@ -15848,7 +15848,7 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000482"/>
@@ -15889,8 +15889,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_1_5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta very low</rdfs:label>
-        <metpo:range_max>5</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>5</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000483"/>
@@ -15931,8 +15931,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_5_10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
-        <metpo:range_min>5</metpo:range_min>
+        <METPO:range_max>10</METPO:range_max>
+        <METPO:range_min>5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000484"/>
@@ -15973,8 +15973,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_10_20</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta mid1</rdfs:label>
-        <metpo:range_max>20</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>20</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000485"/>
@@ -16015,8 +16015,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_20_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>20</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>20</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000486"/>
@@ -16054,7 +16054,7 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_&gt;30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta high</rdfs:label>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000487"/>
@@ -20590,7 +20590,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_&lt;=1.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length very small</rdfs:label>
-        <metpo:range_max>1.3</metpo:range_max>
+        <METPO:range_max>1.3</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000883"/>
@@ -20631,8 +20631,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_1.3_2</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length small</rdfs:label>
-        <metpo:range_max>2</metpo:range_max>
-        <metpo:range_min>1.3</metpo:range_min>
+        <METPO:range_max>2</METPO:range_max>
+        <METPO:range_min>1.3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000884"/>
@@ -20673,8 +20673,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_2_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length medium</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>2</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>2</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000885"/>
@@ -20712,7 +20712,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_&gt;3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length large</rdfs:label>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000886"/>
@@ -20750,7 +20750,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_&lt;=0.5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width very small</rdfs:label>
-        <metpo:range_max>0.5</metpo:range_max>
+        <METPO:range_max>0.5</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000887"/>
@@ -20791,8 +20791,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_0.5_0.65</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width small</rdfs:label>
-        <metpo:range_max>0.65</metpo:range_max>
-        <metpo:range_min>0.5</metpo:range_min>
+        <METPO:range_max>0.65</METPO:range_max>
+        <METPO:range_min>0.5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000888"/>
@@ -20833,8 +20833,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_0.65_0.9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width medium</rdfs:label>
-        <metpo:range_max>0.9</metpo:range_max>
-        <metpo:range_min>0.65</metpo:range_min>
+        <METPO:range_max>0.9</METPO:range_max>
+        <METPO:range_min>0.65</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000889"/>
@@ -20872,7 +20872,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_&gt;0.9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width large</rdfs:label>
-        <metpo:range_min>0.9</metpo:range_min>
+        <METPO:range_min>0.9</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000890"/>

--- a/metpo-full.obo
+++ b/metpo-full.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
 data-version: https://w3id.org/metpo/releases/2026-06-12/metpo-full.owl
 idspace: dcterms http://purl.org/dc/terms/ 
-idspace: metpo https://w3id.org/metpo/ 
+idspace: METPO https://w3id.org/metpo/ 
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
 idspace: qudt http://qudt.org/schema/qudt/ 
 idspace: skos http://www.w3.org/2004/02/skos/core# 
@@ -18,7566 +18,7566 @@ property_value: seeAlso https://bioregistry.io/registry/metpo
 property_value: seeAlso https://github.com/berkeleybop/metpo
 
 [Term]
-id: metpo:0000001
+id: METPO:0000001
 name: obsolete Temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000002
+id: METPO:0000002
 name: obsolete Salinity
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000003
+id: METPO:0000003
 name: obsolete pH
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000004
+id: METPO:0000004
 name: obsolete Oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000005
+id: METPO:0000005
 name: obsolete Trophic type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000631
+replaced_by: METPO:1000631
 
 [Term]
-id: metpo:0000006
+id: METPO:0000006
 name: obsolete Motility
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000701
+replaced_by: METPO:1000701
 
 [Term]
-id: metpo:0000007
+id: METPO:0000007
 name: obsolete Sporulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:0000008
+id: METPO:0000008
 name: obsolete Pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000009
+id: METPO:0000009
 name: obsolete GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:000001
+id: METPO:000001
 name: obsolete Temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000010
+id: METPO:0000010
 name: obsolete Cell Width
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000011
+id: METPO:0000011
 name: obsolete Cell Length
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000012
+id: METPO:0000012
 name: obsolete Temperature Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000304
+replaced_by: METPO:1000304
 
 [Term]
-id: metpo:0000013
+id: METPO:0000013
 name: obsolete Temperature Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000306
+replaced_by: METPO:1000306
 
 [Term]
-id: metpo:0000014
+id: METPO:0000014
 name: obsolete pH Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000331
+replaced_by: METPO:1000331
 
 [Term]
-id: metpo:0000015
+id: METPO:0000015
 name: obsolete pH Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000332
+replaced_by: METPO:1000332
 
 [Term]
-id: metpo:0000016
+id: METPO:0000016
 name: obsolete NaCl Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000333
+replaced_by: METPO:1000333
 
 [Term]
-id: metpo:0000017
+id: METPO:0000017
 name: obsolete NaCl Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000334
+replaced_by: METPO:1000334
 
 [Term]
-id: metpo:0000018
+id: METPO:0000018
 name: obsolete pH delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000232
+replaced_by: METPO:1000232
 
 [Term]
-id: metpo:0000019
+id: METPO:0000019
 name: obsolete NaCl delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000335
+replaced_by: METPO:1000335
 
 [Term]
-id: metpo:000002
+id: METPO:000002
 name: obsolete Salinity
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000020
+id: METPO:0000020
 name: obsolete Temperature Delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000303
+replaced_by: METPO:1000303
 
 [Term]
-id: metpo:0000021
+id: METPO:0000021
 name: obsolete METPO Morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000022
+id: METPO:0000022
 name: obsolete Psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:0000023
+id: METPO:0000023
 name: obsolete Psychrotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:0000024
+id: METPO:0000024
 name: obsolete Mesophilie
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000025
+id: METPO:0000025
 name: obsolete Thermotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:0000026
+id: METPO:0000026
 name: obsolete Thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:0000027
+id: METPO:0000027
 name: obsolete Extreme thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:0000028
+id: METPO:0000028
 name: obsolete Hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:0000029
+id: METPO:0000029
 name: obsolete Extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:000003
+id: METPO:000003
 name: obsolete pH
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000030
+id: METPO:0000030
 name: obsolete Halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:0000031
+id: METPO:0000031
 name: obsolete Non-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:0000032
+id: METPO:0000032
 name: obsolete Slight halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:0000033
+id: METPO:0000033
 name: obsolete Moderate halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:0000034
+id: METPO:0000034
 name: obsolete Extreme halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:0000035
+id: METPO:0000035
 name: obsolete Halotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:0000036
+id: METPO:0000036
 name: obsolete Haloalkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:0000037
+id: METPO:0000037
 name: obsolete Extreme Acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000038
+id: METPO:0000038
 name: obsolete Acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:0000039
+id: METPO:0000039
 name: obsolete Neutrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:000004
+id: METPO:000004
 name: obsolete Oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000040
+id: METPO:0000040
 name: obsolete Alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:0000041
+id: METPO:0000041
 name: obsolete Acid Tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000042
+id: METPO:0000042
 name: obsolete Alkali Tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000043
+id: METPO:0000043
 name: obsolete Extreme Alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000044
+id: METPO:0000044
 name: obsolete Facultative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:0000045
+id: METPO:0000045
 name: obsolete Obligative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:0000046
+id: METPO:0000046
 name: obsolete Aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000047
+id: METPO:0000047
 name: obsolete Anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:0000048
+id: METPO:0000048
 name: obsolete Facultative anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:0000049
+id: METPO:0000049
 name: obsolete Facultative aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:000005
+id: METPO:000005
 name: obsolete Trophic type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000631
+replaced_by: METPO:1000631
 
 [Term]
-id: metpo:0000050
+id: METPO:0000050
 name: obsolete Microaerophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:0000051
+id: METPO:0000051
 name: obsolete Aerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:0000052
+id: METPO:0000052
 name: obsolete Microaerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:0000053
+id: METPO:0000053
 name: obsolete Aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000054
+id: METPO:0000054
 name: obsolete Obligate aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:0000055
+id: METPO:0000055
 name: obsolete Obligate anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:0000056
+id: METPO:0000056
 name: obsolete Oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000057
+id: METPO:0000057
 name: obsolete Anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000058
+id: METPO:0000058
 name: obsolete Autotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:0000059
+id: METPO:0000059
 name: obsolete Photoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:000006
+id: METPO:000006
 name: obsolete Motility
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000701
+replaced_by: METPO:1000701
 
 [Term]
-id: metpo:0000060
+id: METPO:0000060
 name: obsolete Chemoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:0000061
+id: METPO:0000061
 name: obsolete Heterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:0000062
+id: METPO:0000062
 name: obsolete Photoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:0000063
+id: METPO:0000063
 name: obsolete Chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:0000064
+id: METPO:0000064
 name: obsolete Lithotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:0000065
+id: METPO:0000065
 name: obsolete Organotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:0000066
+id: METPO:0000066
 name: obsolete Phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:0000067
+id: METPO:0000067
 name: obsolete Chemotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:0000068
+id: METPO:0000068
 name: obsolete Oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:0000069
+id: METPO:0000069
 name: obsolete Copiotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:000007
+id: METPO:000007
 name: obsolete Sporulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:0000070
+id: METPO:0000070
 name: obsolete Lithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:0000071
+id: METPO:0000071
 name: obsolete Mixotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:0000072
+id: METPO:0000072
 name: obsolete Lithoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:0000073
+id: METPO:0000073
 name: obsolete Chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:0000074
+id: METPO:0000074
 name: obsolete Chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:0000075
+id: METPO:0000075
 name: obsolete Methylotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:0000076
+id: METPO:0000076
 name: obsolete Methanotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:0000077
+id: METPO:0000077
 name: obsolete Carboxydotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:0000078
+id: METPO:0000078
 name: obsolete Hydrogenotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:0000079
+id: METPO:0000079
 name: obsolete Hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000008
+id: METPO:000008
 name: obsolete Pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000080
+id: METPO:0000080
 name: obsolete Hydrogen producer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000081
+id: METPO:0000081
 name: obsolete Nitrogen fixer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000082
+id: METPO:0000082
 name: obsolete Methanogen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000083
+id: METPO:0000083
 name: obsolete Sulfate reducer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000084
+id: METPO:0000084
 name: obsolete Sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000085
+id: METPO:0000085
 name: obsolete Denitrifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000086
+id: METPO:0000086
 name: obsolete Capnophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:0000087
+id: METPO:0000087
 name: obsolete Motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:0000088
+id: METPO:0000088
 name: obsolete Non-motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:0000089
+id: METPO:0000089
 name: obsolete Flagellated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:000009
+id: METPO:000009
 name: obsolete GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:0000090
+id: METPO:0000090
 name: obsolete Peritrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000091
+id: METPO:0000091
 name: obsolete Lophotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000092
+id: METPO:0000092
 name: obsolete Monotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000093
+id: METPO:0000093
 name: obsolete Ciliated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000094
+id: METPO:0000094
 name: obsolete Gliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:0000095
+id: METPO:0000095
 name: obsolete Twitching
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000096
+id: METPO:0000096
 name: obsolete Sliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000097
+id: METPO:0000097
 name: obsolete Swarming
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000098
+id: METPO:0000098
 name: obsolete Endospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000099
+id: METPO:0000099
 name: obsolete Exospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000010
+id: METPO:000010
 name: obsolete Cell Width
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000100
+id: METPO:0000100
 name: obsolete Myxospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000101
+id: METPO:0000101
 name: obsolete Arthrospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000102
+id: METPO:0000102
 name: obsolete Conidia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000103
+id: METPO:0000103
 name: obsolete Sporangiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000104
+id: METPO:0000104
 name: obsolete Zygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000105
+id: METPO:0000105
 name: obsolete Akinetes
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000106
+id: METPO:0000106
 name: obsolete Chlamydospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000107
+id: METPO:0000107
 name: obsolete Sporocysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000108
+id: METPO:0000108
 name: obsolete Hypnospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000109
+id: METPO:0000109
 name: obsolete Gemmae
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000011
+id: METPO:000011
 name: obsolete Cell Length
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000110
+id: METPO:0000110
 name: obsolete Oospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000111
+id: METPO:0000111
 name: obsolete Azygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000112
+id: METPO:0000112
 name: obsolete Cysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000113
+id: METPO:0000113
 name: obsolete Ascospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000114
+id: METPO:0000114
 name: obsolete Basidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000115
+id: METPO:0000115
 name: obsolete Aleuriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000116
+id: METPO:0000116
 name: obsolete Stylospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000117
+id: METPO:0000117
 name: obsolete Sclerotia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000118
+id: METPO:0000118
 name: obsolete Zoospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000119
+id: METPO:0000119
 name: obsolete Teliospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000012
+id: METPO:000012
 name: obsolete Temperature Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000304
+replaced_by: METPO:1000304
 
 [Term]
-id: metpo:0000120
+id: METPO:0000120
 name: obsolete Urediniospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000121
+id: METPO:0000121
 name: obsolete Pycnidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000122
+id: METPO:0000122
 name: obsolete Acriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000123
+id: METPO:0000123
 name: obsolete Aplanospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000124
+id: METPO:0000124
 name: obsolete Statismospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000125
+id: METPO:0000125
 name: obsolete Barotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000126
+id: METPO:0000126
 name: obsolete Piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000127
+id: METPO:0000127
 name: obsolete Piezotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000128
+id: METPO:0000128
 name: obsolete Piezosensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000129
+id: METPO:0000129
 name: obsolete Obligate barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000013
+id: METPO:000013
 name: obsolete Temperature Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000306
+replaced_by: METPO:1000306
 
 [Term]
-id: metpo:0000130
+id: METPO:0000130
 name: obsolete Facultative barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000131
+id: METPO:0000131
 name: obsolete Hyperbarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000132
+id: METPO:0000132
 name: obsolete Hypobarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000133
+id: METPO:0000133
 name: obsolete Atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000134
+id: METPO:0000134
 name: obsolete Moderate piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000135
+id: METPO:0000135
 name: obsolete Extreme piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000136
+id: METPO:0000136
 name: obsolete Stenopiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000137
+id: METPO:0000137
 name: obsolete Eurypiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000138
+id: METPO:0000138
 name: obsolete Pressure-sensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000139
+id: METPO:0000139
 name: obsolete Pressure-resistant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000014
+id: METPO:000014
 name: obsolete pH Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000331
+replaced_by: METPO:1000331
 
 [Term]
-id: metpo:0000140
+id: METPO:0000140
 name: obsolete Pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000141
+id: METPO:0000141
 name: obsolete Piezo-acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000142
+id: METPO:0000142
 name: obsolete Piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000143
+id: METPO:0000143
 name: obsolete Piezo-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000144
+id: METPO:0000144
 name: obsolete Piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000145
+id: METPO:0000145
 name: obsolete Piezo-thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000146
+id: METPO:0000146
 name: obsolete Piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000147
+id: METPO:0000147
 name: obsolete Piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:0000148
+id: METPO:0000148
 name: obsolete Piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000149
+id: METPO:0000149
 name: obsolete Piezo-endolithic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000015
+id: METPO:000015
 name: obsolete pH Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000332
+replaced_by: METPO:1000332
 
 [Term]
-id: metpo:0000150
+id: METPO:0000150
 name: obsolete Piezo-tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000151
+id: METPO:0000151
 name: obsolete GC low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000429
+replaced_by: METPO:1000429
 
 [Term]
-id: metpo:0000152
+id: METPO:0000152
 name: obsolete GC mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000430
+replaced_by: METPO:1000430
 
 [Term]
-id: metpo:0000153
+id: METPO:0000153
 name: obsolete GC mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000431
+replaced_by: METPO:1000431
 
 [Term]
-id: metpo:0000154
+id: METPO:0000154
 name: obsolete GC high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000432
+replaced_by: METPO:1000432
 
 [Term]
-id: metpo:0000155
+id: METPO:0000155
 name: obsolete Cell width very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000887
+replaced_by: METPO:1000887
 
 [Term]
-id: metpo:0000156
+id: METPO:0000156
 name: obsolete Cell width low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000157
+id: METPO:0000157
 name: obsolete Cell width mid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000889
+replaced_by: METPO:1000889
 
 [Term]
-id: metpo:0000158
+id: METPO:0000158
 name: obsolete Cell width high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000159
+id: METPO:0000159
 name: obsolete Cell length very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000883
+replaced_by: METPO:1000883
 
 [Term]
-id: metpo:000016
+id: METPO:000016
 name: obsolete NaCl Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000333
+replaced_by: METPO:1000333
 
 [Term]
-id: metpo:0000160
+id: METPO:0000160
 name: obsolete Cell length low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000161
+id: METPO:0000161
 name: obsolete Cell length mid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000885
+replaced_by: METPO:1000885
 
 [Term]
-id: metpo:0000162
+id: METPO:0000162
 name: obsolete Cell length high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000163
+id: METPO:0000163
 name: obsolete Temperature Optimum very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000441
+replaced_by: METPO:1000441
 
 [Term]
-id: metpo:0000164
+id: METPO:0000164
 name: obsolete Temperature Optimum low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000442
+replaced_by: METPO:1000442
 
 [Term]
-id: metpo:0000165
+id: METPO:0000165
 name: obsolete Temperature Optimum mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000443
+replaced_by: METPO:1000443
 
 [Term]
-id: metpo:0000166
+id: METPO:0000166
 name: obsolete Temperature Optimum mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000444
+replaced_by: METPO:1000444
 
 [Term]
-id: metpo:0000167
+id: METPO:0000167
 name: obsolete Temperature Optimum mid3
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:0000168
+id: METPO:0000168
 name: obsolete Temperature Optimum mid4
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000446
+replaced_by: METPO:1000446
 
 [Term]
-id: metpo:0000169
+id: METPO:0000169
 name: obsolete Temperature Optimum high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000447
+replaced_by: METPO:1000447
 
 [Term]
-id: metpo:000017
+id: METPO:000017
 name: obsolete NaCl Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000334
+replaced_by: METPO:1000334
 
 [Term]
-id: metpo:0000170
+id: METPO:0000170
 name: obsolete Temperature Range very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000448
+replaced_by: METPO:1000448
 
 [Term]
-id: metpo:0000171
+id: METPO:0000171
 name: obsolete Temperature Range low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000449
+replaced_by: METPO:1000449
 
 [Term]
-id: metpo:0000172
+id: METPO:0000172
 name: obsolete Temperature Range mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000450
+replaced_by: METPO:1000450
 
 [Term]
-id: metpo:0000173
+id: METPO:0000173
 name: obsolete Temperature Range mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000451
+replaced_by: METPO:1000451
 
 [Term]
-id: metpo:0000174
+id: METPO:0000174
 name: obsolete Temperature Range mid3
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000452
+replaced_by: METPO:1000452
 
 [Term]
-id: metpo:0000175
+id: METPO:0000175
 name: obsolete Temperature Range mid4
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000453
+replaced_by: METPO:1000453
 
 [Term]
-id: metpo:0000176
+id: METPO:0000176
 name: obsolete Temperature Range high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000454
+replaced_by: METPO:1000454
 
 [Term]
-id: metpo:0000177
+id: METPO:0000177
 name: obsolete pH Optimum low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000455
+replaced_by: METPO:1000455
 
 [Term]
-id: metpo:0000178
+id: METPO:0000178
 name: obsolete pH Optimum mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000456
+replaced_by: METPO:1000456
 
 [Term]
-id: metpo:0000179
+id: METPO:0000179
 name: obsolete pH Optimum mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000457
+replaced_by: METPO:1000457
 
 [Term]
-id: metpo:000018
+id: METPO:000018
 name: obsolete pH delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000232
+replaced_by: METPO:1000232
 
 [Term]
-id: metpo:0000180
+id: METPO:0000180
 name: obsolete pH Optimum high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000458
+replaced_by: METPO:1000458
 
 [Term]
-id: metpo:0000181
+id: METPO:0000181
 name: obsolete pH Range very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000459
+replaced_by: METPO:1000459
 
 [Term]
-id: metpo:0000182
+id: METPO:0000182
 name: obsolete pH Range low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000460
+replaced_by: METPO:1000460
 
 [Term]
-id: metpo:0000183
+id: METPO:0000183
 name: obsolete pH Range mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000461
+replaced_by: METPO:1000461
 
 [Term]
-id: metpo:0000184
+id: METPO:0000184
 name: obsolete pH Range mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000462
+replaced_by: METPO:1000462
 
 [Term]
-id: metpo:0000185
+id: METPO:0000185
 name: obsolete pH Range mid3
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000463
+replaced_by: METPO:1000463
 
 [Term]
-id: metpo:0000186
+id: METPO:0000186
 name: obsolete pH Range high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000464
+replaced_by: METPO:1000464
 
 [Term]
-id: metpo:0000187
+id: METPO:0000187
 name: obsolete NaCl Optimum low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000465
+replaced_by: METPO:1000465
 
 [Term]
-id: metpo:0000188
+id: METPO:0000188
 name: obsolete NaCl Optimum mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000466
+replaced_by: METPO:1000466
 
 [Term]
-id: metpo:0000189
+id: METPO:0000189
 name: obsolete NaCl Optimum mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000467
+replaced_by: METPO:1000467
 
 [Term]
-id: metpo:000019
+id: METPO:000019
 name: obsolete NaCl delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000335
+replaced_by: METPO:1000335
 
 [Term]
-id: metpo:0000190
+id: METPO:0000190
 name: obsolete NaCl Optimum high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000468
+replaced_by: METPO:1000468
 
 [Term]
-id: metpo:0000191
+id: METPO:0000191
 name: obsolete NaCl Range low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000469
+replaced_by: METPO:1000469
 
 [Term]
-id: metpo:0000192
+id: METPO:0000192
 name: obsolete NaCl Range mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000470
+replaced_by: METPO:1000470
 
 [Term]
-id: metpo:0000193
+id: METPO:0000193
 name: obsolete NaCl Range mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000471
+replaced_by: METPO:1000471
 
 [Term]
-id: metpo:0000194
+id: METPO:0000194
 name: obsolete NaCl Range high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000472
+replaced_by: METPO:1000472
 
 [Term]
-id: metpo:0000195
+id: METPO:0000195
 name: obsolete pH Delta very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000473
+replaced_by: METPO:1000473
 
 [Term]
-id: metpo:0000196
+id: METPO:0000196
 name: obsolete pH Delta low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000474
+replaced_by: METPO:1000474
 
 [Term]
-id: metpo:0000197
+id: METPO:0000197
 name: obsolete pH Delta mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000475
+replaced_by: METPO:1000475
 
 [Term]
-id: metpo:0000198
+id: METPO:0000198
 name: obsolete pH Delta mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000476
+replaced_by: METPO:1000476
 
 [Term]
-id: metpo:0000199
+id: METPO:0000199
 name: obsolete pH Delta mid3
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000477
+replaced_by: METPO:1000477
 
 [Term]
-id: metpo:000020
+id: METPO:000020
 name: obsolete Temperature Delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000303
+replaced_by: METPO:1000303
 
 [Term]
-id: metpo:0000200
+id: METPO:0000200
 name: obsolete pH Delta high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000478
+replaced_by: METPO:1000478
 
 [Term]
-id: metpo:0000201
+id: METPO:0000201
 name: obsolete NaCl Delta low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000479
+replaced_by: METPO:1000479
 
 [Term]
-id: metpo:0000202
+id: METPO:0000202
 name: obsolete NaCl Delta mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000481
+replaced_by: METPO:1000481
 
 [Term]
-id: metpo:0000203
+id: METPO:0000203
 name: obsolete NaCl Delta mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000481
+replaced_by: METPO:1000481
 
 [Term]
-id: metpo:0000204
+id: METPO:0000204
 name: obsolete NaCl Delta high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000482
+replaced_by: METPO:1000482
 
 [Term]
-id: metpo:0000205
+id: METPO:0000205
 name: obsolete Temperature Delta very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000483
+replaced_by: METPO:1000483
 
 [Term]
-id: metpo:0000206
+id: METPO:0000206
 name: obsolete Temperature Delta low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000484
+replaced_by: METPO:1000484
 
 [Term]
-id: metpo:0000207
+id: METPO:0000207
 name: obsolete Temperature Delta mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000485
+replaced_by: METPO:1000485
 
 [Term]
-id: metpo:0000208
+id: METPO:0000208
 name: obsolete Temperature Delta mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000486
+replaced_by: METPO:1000486
 
 [Term]
-id: metpo:0000209
+id: METPO:0000209
 name: obsolete Temperature Delta high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000487
+replaced_by: METPO:1000487
 
 [Term]
-id: metpo:000021
+id: METPO:000021
 name: obsolete Morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000210
+id: METPO:0000210
 name: obsolete Bacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000211
+id: METPO:0000211
 name: obsolete Branced
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000212
+id: METPO:0000212
 name: obsolete Coccobacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000213
+id: METPO:0000213
 name: obsolete Coccus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000214
+id: METPO:0000214
 name: obsolete Crescent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000215
+id: METPO:0000215
 name: obsolete Curved
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000216
+id: METPO:0000216
 name: obsolete Curved Spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000217
+id: METPO:0000217
 name: obsolete Diplococcus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000218
+id: METPO:0000218
 name: obsolete Disc
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000219
+id: METPO:0000219
 name: obsolete Dumbbell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000022
+id: METPO:000022
 name: obsolete Other
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000220
+id: METPO:0000220
 name: obsolete Ellipsoidal
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:0000221
+id: METPO:0000221
 name: obsolete Filament
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000222
+id: METPO:0000222
 name: obsolete Flask
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000223
+id: METPO:0000223
 name: obsolete Fusiform
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000224
+id: METPO:0000224
 name: obsolete Helical
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000225
+id: METPO:0000225
 name: obsolete Irregular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000226
+id: METPO:0000226
 name: obsolete Oval
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000227
+id: METPO:0000227
 name: obsolete Ovoid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000228
+id: METPO:0000228
 name: obsolete Pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000229
+id: METPO:0000229
 name: obsolete Ring
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000023
+id: METPO:000023
 name: obsolete Psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:0000230
+id: METPO:0000230
 name: obsolete Rod
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000231
+id: METPO:0000231
 name: obsolete Sphere
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000232
+id: METPO:0000232
 name: obsolete Spindle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000233
+id: METPO:0000233
 name: obsolete Spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000234
+id: METPO:0000234
 name: obsolete Spirochete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000235
+id: METPO:0000235
 name: obsolete Spore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000236
+id: METPO:0000236
 name: obsolete Square
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000237
+id: METPO:0000237
 name: obsolete Star
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000238
+id: METPO:0000238
 name: obsolete Star - Dumbbell - Pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000239
+id: METPO:0000239
 name: obsolete Tailed
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000024
+id: METPO:000024
 name: obsolete Psychrotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:0000240
+id: METPO:0000240
 name: obsolete Triangular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000241
+id: METPO:0000241
 name: obsolete Vibrio
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000242
+id: METPO:0000242
 name: obsolete Environmental Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000243
+id: METPO:0000243
 name: obsolete Growth Condition
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000244
+id: METPO:0000244
 name: obsolete Physiological Trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000245
+id: METPO:0000245
 name: obsolete Metabolic Classification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000246
+id: METPO:0000246
 name: obsolete Cellular Characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000247
+id: METPO:0000247
 name: obsolete Taxonomic Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000248
+id: METPO:0000248
 name: obsolete Microbial Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000249
+id: METPO:0000249
 name: obsolete Growth Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000025
+id: METPO:000025
 name: obsolete Mesophilie
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000250
+id: METPO:0000250
 name: obsolete Structural Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000251
+id: METPO:0000251
 name: obsolete Temperature Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000252
+id: METPO:0000252
 name: obsolete Salinity Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000253
+id: METPO:0000253
 name: obsolete pH Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000254
+id: METPO:0000254
 name: obsolete Oxygen Requirement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000255
+id: METPO:0000255
 name: obsolete Carbon Source Utilization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000256
+id: METPO:0000256
 name: obsolete Energy Acquisition Mode
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000257
+id: METPO:0000257
 name: obsolete Electron Donor Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000258
+id: METPO:0000258
 name: obsolete Motility Mechanism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000259
+id: METPO:0000259
 name: obsolete Motility Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000026
+id: METPO:000026
 name: obsolete Thermotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:0000260
+id: METPO:0000260
 name: obsolete Bacterial Spore Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000261
+id: METPO:0000261
 name: obsolete Fungal Spore Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000262
+id: METPO:0000262
 name: obsolete Reproductive Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000263
+id: METPO:0000263
 name: obsolete Dormancy Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000264
+id: METPO:0000264
 name: obsolete Pressure Adaptation Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000265
+id: METPO:0000265
 name: obsolete Pressure Tolerance Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:0000266
+id: METPO:0000266
 name: obsolete Genomic Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000267
+id: METPO:0000267
 name: obsolete Cell Dimension
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000268
+id: METPO:0000268
 name: obsolete Optimal Growth Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000269
+id: METPO:0000269
 name: obsolete Growth Range Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000027
+id: METPO:000027
 name: obsolete Thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:0000270
+id: METPO:0000270
 name: obsolete Growth Tolerance Metric
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000271
+id: METPO:0000271
 name: obsolete Cell Shape
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:0000272
+id: METPO:0000272
 name: obsolete Cell Arrangement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:0000273
+id: METPO:0000273
 name: obsolete Colony Morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:0000274
+id: METPO:0000274
 name: obsolete Physical Property
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000275
+id: METPO:0000275
 name: obsolete Environmental Context
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000276
+id: METPO:0000276
 name: obsolete Biological Property
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:0000277
+id: METPO:0000277
 name: obsolete Functional Classification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000278
+id: METPO:0000278
 name: obsolete Classification Property
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000279
+id: METPO:0000279
 name: obsolete METPO Biological Process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:000028
+id: METPO:000028
 name: obsolete Extreme thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:0000280
+id: METPO:0000280
 name: obsolete Measurable Property
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000281
+id: METPO:0000281
 name: obsolete Gram-stain negative
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000699
+replaced_by: METPO:1000699
 
 [Term]
-id: metpo:0000282
+id: METPO:0000282
 name: obsolete Gram-stain positive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000698
+replaced_by: METPO:1000698
 
 [Term]
-id: metpo:000029
+id: METPO:000029
 name: obsolete Hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:000030
+id: METPO:000030
 name: obsolete Extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:000031
+id: METPO:000031
 name: obsolete Halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:000032
+id: METPO:000032
 name: obsolete Non-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:000033
+id: METPO:000033
 name: obsolete Slight halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:000034
+id: METPO:000034
 name: obsolete Moderate halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:000035
+id: METPO:000035
 name: obsolete Extreme halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:000036
+id: METPO:000036
 name: obsolete Halotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:000037
+id: METPO:000037
 name: obsolete Haloalkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:000038
+id: METPO:000038
 name: obsolete Extreme Acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000039
+id: METPO:000039
 name: obsolete Acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:000040
+id: METPO:000040
 name: obsolete Neutrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:000041
+id: METPO:000041
 name: obsolete Alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:000042
+id: METPO:000042
 name: obsolete Acid Tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000043
+id: METPO:000043
 name: obsolete Alkali Tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000044
+id: METPO:000044
 name: obsolete Extreme Alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000045
+id: METPO:000045
 name: obsolete Facultative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:000046
+id: METPO:000046
 name: obsolete Obligative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:000047
+id: METPO:000047
 name: obsolete Aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000048
+id: METPO:000048
 name: obsolete Anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:000049
+id: METPO:000049
 name: obsolete Facultative anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:000050
+id: METPO:000050
 name: obsolete Facultative aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:000051
+id: METPO:000051
 name: obsolete Microaerophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:000052
+id: METPO:000052
 name: obsolete Aerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:000053
+id: METPO:000053
 name: obsolete Microaerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:000054
+id: METPO:000054
 name: obsolete Aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000055
+id: METPO:000055
 name: obsolete Obligate aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:000056
+id: METPO:000056
 name: obsolete Obligate anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:000057
+id: METPO:000057
 name: obsolete Oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000058
+id: METPO:000058
 name: obsolete Anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000059
+id: METPO:000059
 name: obsolete Autotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:000060
+id: METPO:000060
 name: obsolete Photoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:000061
+id: METPO:000061
 name: obsolete Chemoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:000062
+id: METPO:000062
 name: obsolete Heterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:000063
+id: METPO:000063
 name: obsolete Photoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:000064
+id: METPO:000064
 name: obsolete Chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:000065
+id: METPO:000065
 name: obsolete Lithotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:000066
+id: METPO:000066
 name: obsolete Organotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:000067
+id: METPO:000067
 name: obsolete Phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:000068
+id: METPO:000068
 name: obsolete Chemotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:000069
+id: METPO:000069
 name: obsolete Oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:000070
+id: METPO:000070
 name: obsolete Copiotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:000071
+id: METPO:000071
 name: obsolete Lithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:000072
+id: METPO:000072
 name: obsolete Mixotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:000073
+id: METPO:000073
 name: obsolete Lithoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:000074
+id: METPO:000074
 name: obsolete Chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:000075
+id: METPO:000075
 name: obsolete Chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:000076
+id: METPO:000076
 name: obsolete Methylotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:000077
+id: METPO:000077
 name: obsolete Methanotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:000078
+id: METPO:000078
 name: obsolete Carboxydotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:000079
+id: METPO:000079
 name: obsolete Hydrogenotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:000080
+id: METPO:000080
 name: obsolete Hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000081
+id: METPO:000081
 name: obsolete Hydrogen producer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000082
+id: METPO:000082
 name: obsolete Nitrogen fixer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000083
+id: METPO:000083
 name: obsolete Methanogen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000084
+id: METPO:000084
 name: obsolete Sulfate reducer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000085
+id: METPO:000085
 name: obsolete Sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000086
+id: METPO:000086
 name: obsolete Denitrifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000087
+id: METPO:000087
 name: obsolete Capnophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:000088
+id: METPO:000088
 name: obsolete Motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:000089
+id: METPO:000089
 name: obsolete Non-motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:000090
+id: METPO:000090
 name: obsolete Flagellated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:000091
+id: METPO:000091
 name: obsolete Peritrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000092
+id: METPO:000092
 name: obsolete Lophotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000093
+id: METPO:000093
 name: obsolete Monotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000094
+id: METPO:000094
 name: obsolete Ciliated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000095
+id: METPO:000095
 name: obsolete Gliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:000096
+id: METPO:000096
 name: obsolete Twitching
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000097
+id: METPO:000097
 name: obsolete Sliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000098
+id: METPO:000098
 name: obsolete Swarming
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000099
+id: METPO:000099
 name: obsolete Endospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000100
+id: METPO:000100
 name: obsolete Exospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001000
+id: METPO:0001000
 name: obsolete sensitivity to oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001001
+id: METPO:0001001
 name: obsolete sensitivity toward
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001002
+id: METPO:0001002
 name: obsolete 'organismal quality'
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001003
+id: METPO:0001003
 name: obsolete 'physicial object quality'
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001004
+id: METPO:0001004
 name: obsolete 'quality'
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000188
+replaced_by: METPO:1000188
 
 [Term]
-id: metpo:0001006
+id: METPO:0001006
 name: obsolete size
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001007
+id: METPO:0001007
 name: obsolete 1-D extent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001008
+id: METPO:0001008
 name: obsolete width
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001009
+id: METPO:0001009
 name: obsolete length
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000101
+id: METPO:000101
 name: obsolete Myxospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001010
+id: METPO:0001010
 name: obsolete 'prokaryotic metabolically differentiated cell'
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001012
+id: METPO:0001012
 name: obsolete heterotrophy
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001013
+id: METPO:0001013
 name: obsolete structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001014
+id: METPO:0001014
 name: obsolete spore type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001016
+id: METPO:0001016
 name: obsolete sensitivity toward pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001017
+id: METPO:0001017
 name: obsolete sensitivity toward NaCl
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001018
+id: METPO:0001018
 name: obsolete sensitivity toward pH
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001019
+id: METPO:0001019
 name: obsolete sensitivity toward temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000102
+id: METPO:000102
 name: obsolete Arthrospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001020
+id: METPO:0001020
 name: obsolete metabolic constraints
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001021
+id: METPO:0001021
 name: obsolete cell by chemical produced
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000103
+id: METPO:000103
 name: obsolete Conidia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000104
+id: METPO:000104
 name: obsolete Sporangiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000105
+id: METPO:000105
 name: obsolete Zygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000106
+id: METPO:000106
 name: obsolete Akinetes
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000107
+id: METPO:000107
 name: obsolete Chlamydospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000108
+id: METPO:000108
 name: obsolete Sporocysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000109
+id: METPO:000109
 name: obsolete Hypnospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000110
+id: METPO:000110
 name: obsolete Gemmae
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000111
+id: METPO:000111
 name: obsolete Oospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000112
+id: METPO:000112
 name: obsolete Azygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000113
+id: METPO:000113
 name: obsolete Cysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000114
+id: METPO:000114
 name: obsolete Ascospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000115
+id: METPO:000115
 name: obsolete Basidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000116
+id: METPO:000116
 name: obsolete Aleuriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000117
+id: METPO:000117
 name: obsolete Stylospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000118
+id: METPO:000118
 name: obsolete Sclerotia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000119
+id: METPO:000119
 name: obsolete Zoospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000120
+id: METPO:000120
 name: obsolete Teliospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000121
+id: METPO:000121
 name: obsolete Urediniospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000122
+id: METPO:000122
 name: obsolete Pycnidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000123
+id: METPO:000123
 name: obsolete Acriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000124
+id: METPO:000124
 name: obsolete Aplanospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000125
+id: METPO:000125
 name: obsolete Statismospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000126
+id: METPO:000126
 name: obsolete Barotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000127
+id: METPO:000127
 name: obsolete Piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000128
+id: METPO:000128
 name: obsolete Piezotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000129
+id: METPO:000129
 name: obsolete Piezosensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000130
+id: METPO:000130
 name: obsolete Obligate barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000131
+id: METPO:000131
 name: obsolete Facultative barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000132
+id: METPO:000132
 name: obsolete Hyperbarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000133
+id: METPO:000133
 name: obsolete Hypobarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000134
+id: METPO:000134
 name: obsolete Atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000135
+id: METPO:000135
 name: obsolete Moderate piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000136
+id: METPO:000136
 name: obsolete Extreme piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000137
+id: METPO:000137
 name: obsolete Stenopiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000138
+id: METPO:000138
 name: obsolete Eurypiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000139
+id: METPO:000139
 name: obsolete Pressure-sensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000140
+id: METPO:000140
 name: obsolete Pressure-resistant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000141
+id: METPO:000141
 name: obsolete Pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000142
+id: METPO:000142
 name: obsolete Piezo-acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000143
+id: METPO:000143
 name: obsolete Piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000144
+id: METPO:000144
 name: obsolete Piezo-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000145
+id: METPO:000145
 name: obsolete Piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000146
+id: METPO:000146
 name: obsolete Piezo-thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000147
+id: METPO:000147
 name: obsolete Piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000148
+id: METPO:000148
 name: obsolete Piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:000149
+id: METPO:000149
 name: obsolete Piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000150
+id: METPO:000150
 name: obsolete Piezo-endolithic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000151
+id: METPO:000151
 name: obsolete Piezo-tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000152
+id: METPO:000152
 name: obsolete GC% low ( < 42.65)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000153
+id: METPO:000153
 name: obsolete GC% mid1 (42.65 - 57)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000154
+id: METPO:000154
 name: obsolete GC% mid2 (57 - 66.3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000155
+id: METPO:000155
 name: obsolete GC% high ( > 66.3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000156
+id: METPO:000156
 name: obsolete Cell width uM very low (< 0.5)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000157
+id: METPO:000157
 name: obsolete Cell width uM low (0.5 - 0.65)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000158
+id: METPO:000158
 name: obsolete Cell width uM mid (0.65 - 0.9)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000159
+id: METPO:000159
 name: obsolete Cell width uM high (> 0.9)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000160
+id: METPO:000160
 name: obsolete Cell length uM very low (<= 1.3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000161
+id: METPO:000161
 name: obsolete Cell length uM low (1.3 - 2)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000162
+id: METPO:000162
 name: obsolete Cell length uM mid (2 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000163
+id: METPO:000163
 name: obsolete Cell length uM high (> 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000164
+id: METPO:000164
 name: obsolete Temperature Optimum C very low (<= 10)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000441
+replaced_by: METPO:1000441
 
 [Term]
-id: metpo:000165
+id: METPO:000165
 name: obsolete Temperature Optimum C low (10 - 22)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000166
+id: METPO:000166
 name: obsolete Temperature Optimum C mid1 (22 - 27)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000443
+replaced_by: METPO:1000443
 
 [Term]
-id: metpo:000167
+id: METPO:000167
 name: obsolete Temperature Optimum C mid2 (27 - 30)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000444
+replaced_by: METPO:1000444
 
 [Term]
-id: metpo:000168
+id: METPO:000168
 name: obsolete Temperature Optimum C mid3 (30 - 34)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:000169
+id: METPO:000169
 name: obsolete Temperature Optimum C mid4 (34 - 40)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:000170
+id: METPO:000170
 name: obsolete Temperature Optimum C high (> 40)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000447
+replaced_by: METPO:1000447
 
 [Term]
-id: metpo:000171
+id: METPO:000171
 name: obsolete Temperature Range C very low (<= 10)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000448
+replaced_by: METPO:1000448
 
 [Term]
-id: metpo:000172
+id: METPO:000172
 name: obsolete Temperature Range C low (10 - 22)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000173
+id: METPO:000173
 name: obsolete Temperature Range C mid1 (22 - 27)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000174
+id: METPO:000174
 name: obsolete Temperature Range C mid2 (27 - 30)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000175
+id: METPO:000175
 name: obsolete Temperature Range C mid3 (30 - 34)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000176
+id: METPO:000176
 name: obsolete Temperature Range C mid4 (34 - 40)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000177
+id: METPO:000177
 name: obsolete Temperature Range C high (> 40)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000454
+replaced_by: METPO:1000454
 
 [Term]
-id: metpo:000178
+id: METPO:000178
 name: obsolete pH Optimum low (0 - 6)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000179
+id: METPO:000179
 name: obsolete pH Optimum mid1 (6 - 7)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000180
+id: METPO:000180
 name: obsolete pH Optimum mid2 (7 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000181
+id: METPO:000181
 name: obsolete pH Optimum high (8 - 14)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000182
+id: METPO:000182
 name: obsolete pH Range very low (0 - 4)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000459
+replaced_by: METPO:1000459
 
 [Term]
-id: metpo:000183
+id: METPO:000183
 name: obsolete pH Range low (4 - 6)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000184
+id: METPO:000184
 name: obsolete pH Range mid1 (6 - 7)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000185
+id: METPO:000185
 name: obsolete pH Range mid2 (7 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000186
+id: METPO:000186
 name: obsolete pH Range mid3 (8 - 10)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000187
+id: METPO:000187
 name: obsolete pH Range high (10 - 14)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000188
+id: METPO:000188
 name: obsolete % NaCl Optimum low (<= 1)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000189
+id: METPO:000189
 name: obsolete % NaCl Optimum mid1 (1 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000190
+id: METPO:000190
 name: obsolete % NaCl Optimum mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000191
+id: METPO:000191
 name: obsolete % NaCl Optimum high (> 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000468
+replaced_by: METPO:1000468
 
 [Term]
-id: metpo:000192
+id: METPO:000192
 name: obsolete % NaCl Range low (<= 1)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000193
+id: METPO:000193
 name: obsolete % NaCl Range mid1 (1 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000194
+id: METPO:000194
 name: obsolete % NaCl Range mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000195
+id: METPO:000195
 name: obsolete % NaCl Range high (> 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000196
+id: METPO:000196
 name: obsolete pH delta very low (<= 1)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000473
+replaced_by: METPO:1000473
 
 [Term]
-id: metpo:000197
+id: METPO:000197
 name: obsolete pH delta low (1 - 2)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000198
+id: METPO:000198
 name: obsolete pH delta mid1 (2 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000199
+id: METPO:000199
 name: obsolete pH delta mid2 (3 - 4)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000200
+id: METPO:000200
 name: obsolete pH delta mid3 (4 - 5)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000201
+id: METPO:000201
 name: obsolete pH delta high (5 - 9)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000202
+id: METPO:000202
 name: obsolete % NaCl delta low (<= 1)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000203
+id: METPO:000203
 name: obsolete % NaCl delta mid2 (1 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000204
+id: METPO:000204
 name: obsolete % NaCl delta mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000205
+id: METPO:000205
 name: obsolete % NaCl delta high (>= 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000206
+id: METPO:000206
 name: obsolete Temperature C delta very low (1 - 5)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000483
+replaced_by: METPO:1000483
 
 [Term]
-id: metpo:000207
+id: METPO:000207
 name: obsolete Temperature C delta low (5 - 10)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000208
+id: METPO:000208
 name: obsolete Temperature C delta mid1 (10 - 20)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000209
+id: METPO:000209
 name: obsolete Temperature C delta mid2 (20 - 30)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000210
+id: METPO:000210
 name: obsolete Temperature C delta high (>= 30)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000487
+replaced_by: METPO:1000487
 
 [Term]
-id: metpo:000211
+id: METPO:000211
 name: obsolete bacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000212
+id: METPO:000212
 name: obsolete branced
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000213
+id: METPO:000213
 name: obsolete coccobacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000214
+id: METPO:000214
 name: obsolete coccus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000215
+id: METPO:000215
 name: obsolete crescent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000216
+id: METPO:000216
 name: obsolete curved
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000217
+id: METPO:000217
 name: obsolete curved spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000218
+id: METPO:000218
 name: obsolete diplococcus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000219
+id: METPO:000219
 name: obsolete disc
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000220
+id: METPO:000220
 name: obsolete dumbbell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000221
+id: METPO:000221
 name: obsolete ellipsoidal
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:000222
+id: METPO:000222
 name: obsolete filament
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000223
+id: METPO:000223
 name: obsolete flask
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000224
+id: METPO:000224
 name: obsolete fusiform
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000225
+id: METPO:000225
 name: obsolete helical
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000226
+id: METPO:000226
 name: obsolete irregular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000227
+id: METPO:000227
 name: obsolete oval
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000228
+id: METPO:000228
 name: obsolete ovoid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000229
+id: METPO:000229
 name: obsolete pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000230
+id: METPO:000230
 name: obsolete ring
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000231
+id: METPO:000231
 name: obsolete rod
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000232
+id: METPO:000232
 name: obsolete sphere
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000233
+id: METPO:000233
 name: obsolete spindle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000234
+id: METPO:000234
 name: obsolete spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000235
+id: METPO:000235
 name: obsolete spirochete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000236
+id: METPO:000236
 name: obsolete spore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000237
+id: METPO:000237
 name: obsolete square
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000238
+id: METPO:000238
 name: obsolete star
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000239
+id: METPO:000239
 name: obsolete star - dumbbell - pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000240
+id: METPO:000240
 name: obsolete tailed
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000241
+id: METPO:000241
 name: obsolete triangular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000242
+id: METPO:000242
 name: obsolete vibrio
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000243
+id: METPO:000243
 name: obsolete Environmental Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000244
+id: METPO:000244
 name: obsolete Growth Condition
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000245
+id: METPO:000245
 name: obsolete Physiological Trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000246
+id: METPO:000246
 name: obsolete Metabolic Classification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000247
+id: METPO:000247
 name: obsolete Cellular Characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000248
+id: METPO:000248
 name: obsolete Taxonomic Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000249
+id: METPO:000249
 name: obsolete Microbial Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000250
+id: METPO:000250
 name: obsolete Growth Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000251
+id: METPO:000251
 name: obsolete Structural Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000252
+id: METPO:000252
 name: obsolete Temperature Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000253
+id: METPO:000253
 name: obsolete Salinity Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000254
+id: METPO:000254
 name: obsolete pH Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000255
+id: METPO:000255
 name: obsolete Oxygen Requirement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000256
+id: METPO:000256
 name: obsolete Carbon Source Utilization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000257
+id: METPO:000257
 name: obsolete Energy Acquisition Mode
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000258
+id: METPO:000258
 name: obsolete Electron Donor Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000259
+id: METPO:000259
 name: obsolete Motility Mechanism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000260
+id: METPO:000260
 name: obsolete Motility Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000261
+id: METPO:000261
 name: obsolete Bacterial Spore Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000262
+id: METPO:000262
 name: obsolete Fungal Spore Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000263
+id: METPO:000263
 name: obsolete Reproductive Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000264
+id: METPO:000264
 name: obsolete Dormancy Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000265
+id: METPO:000265
 name: obsolete Pressure Adaptation Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000266
+id: METPO:000266
 name: obsolete Pressure Tolerance Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:000267
+id: METPO:000267
 name: obsolete GenomicFeature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000268
+id: METPO:000268
 name: obsolete Cell Dimension
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000269
+id: METPO:000269
 name: obsolete Optimal Growth Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000270
+id: METPO:000270
 name: obsolete Growth Range Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000271
+id: METPO:000271
 name: obsolete Growth Tolerance Metric
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000272
+id: METPO:000272
 name: obsolete Cell Shape
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:000273
+id: METPO:000273
 name: obsolete Cell Arrangement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:000274
+id: METPO:000274
 name: obsolete Colony Morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:1000001
+id: METPO:1000001
 name: obsolete acid-fast
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000002
+id: METPO:1000002
 name: obsolete acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:1000003
+id: METPO:1000003
 name: obsolete active transport
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000004
+id: METPO:1000004
 name: obsolete adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000005
+id: METPO:1000005
 name: obsolete adaptive trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000006
+id: METPO:1000006
 name: obsolete adhesin
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000007
+id: METPO:1000007
 name: obsolete adhesion structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000008
+id: METPO:1000008
 name: obsolete aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000009
+id: METPO:1000009
 name: obsolete aerobic respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000801
+replaced_by: METPO:1000801
 
 [Term]
-id: metpo:1000010
+id: METPO:1000010
 name: obsolete aerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:1000011
+id: METPO:1000011
 name: obsolete aggregate
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000012
+id: METPO:1000012
 name: obsolete akinete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000013
+id: METPO:1000013
 name: obsolete alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:1000014
+id: METPO:1000014
 name: obsolete ammonification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000015
+id: METPO:1000015
 name: obsolete amylolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000016
+id: METPO:1000016
 name: obsolete anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:1000017
+id: METPO:1000017
 name: obsolete anaerobic respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000802
+replaced_by: METPO:1000802
 
 [Term]
-id: metpo:1000018
+id: METPO:1000018
 name: obsolete anoxygenic photosynthesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000019
+id: METPO:1000019
 name: obsolete antibiotic production
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000020
+id: METPO:1000020
 name: obsolete antibiotic resistance
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000021
+id: METPO:1000021
 name: obsolete antimicrobial resistance
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000022
+id: METPO:1000022
 name: obsolete appendage
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000023
+id: METPO:1000023
 name: obsolete arthrospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000024
+id: METPO:1000024
 name: obsolete ascospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000025
+id: METPO:1000025
 name: obsolete autotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:1000026
+id: METPO:1000026
 name: obsolete autotrophic process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000027
+id: METPO:1000027
 name: obsolete auxotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000028
+id: METPO:1000028
 name: obsolete axial filament
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000029
+id: METPO:1000029
 name: obsolete bacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000030
+id: METPO:1000030
 name: obsolete barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000031
+id: METPO:1000031
 name: obsolete barotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000032
+id: METPO:1000032
 name: obsolete basidiospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000033
+id: METPO:1000033
 name: obsolete binary fission
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000034
+id: METPO:1000034
 name: obsolete biofilm
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000035
+id: METPO:1000035
 name: obsolete biofilm component
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000036
+id: METPO:1000036
 name: obsolete biofilm formation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000037
+id: METPO:1000037
 name: obsolete biogeochemical cycling
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000038
+id: METPO:1000038
 name: obsolete bioluminescence
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000039
+id: METPO:1000039
 name: obsolete budding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000040
+id: METPO:1000040
 name: obsolete buoyancy structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000041
+id: METPO:1000041
 name: obsolete capnophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:1000042
+id: METPO:1000042
 name: obsolete capsule
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000043
+id: METPO:1000043
 name: obsolete carbon fixation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000044
+id: METPO:1000044
 name: obsolete carbon source
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000045
+id: METPO:1000045
 name: obsolete carboxydotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:1000046
+id: METPO:1000046
 name: obsolete cell arrangement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:1000047
+id: METPO:1000047
 name: obsolete cell envelope
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000048
+id: METPO:1000048
 name: obsolete cell length category
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000049
+id: METPO:1000049
 name: obsolete cell shape
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:1000050
+id: METPO:1000050
 name: obsolete cell size
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000051
+id: METPO:1000051
 name: obsolete cell wall characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000052
+id: METPO:1000052
 name: obsolete cell wall component
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000053
+id: METPO:1000053
 name: obsolete cell width category
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000054
+id: METPO:1000054
 name: obsolete cellular characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000055
+id: METPO:1000055
 name: obsolete cellular component
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000056
+id: METPO:1000056
 name: obsolete cellular process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000057
+id: METPO:1000057
 name: obsolete cellular product
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000058
+id: METPO:1000058
 name: obsolete cellulolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000059
+id: METPO:1000059
 name: phenotype
 def: "A quality that differentiates specific instances of a species from other instances of the same species." [] {IAO:0000119="PHIPO:0000505"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/PhenotypicQuality
 
 [Term]
-id: metpo:1000060
+id: METPO:1000060
 name: metabolism
 def: "A biological process that maintain life in an organism." [] {IAO:0000119="https://purl.dsmz.de/schema/MetabolicProcess", IAO:0000119="GO:0008152"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000061
+id: METPO:1000061
 name: obsolete chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000062
+id: METPO:1000062
 name: obsolete chemotaxis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000063
+id: METPO:1000063
 name: obsolete chlamydospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000064
+id: METPO:1000064
 name: obsolete class
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000065
+id: METPO:1000065
 name: obsolete clinically relevant feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000066
+id: METPO:1000066
 name: obsolete coccus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000067
+id: METPO:1000067
 name: obsolete cold shock protein
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000068
+id: METPO:1000068
 name: obsolete cold shock response
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000069
+id: METPO:1000069
 name: obsolete colonization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000070
+id: METPO:1000070
 name: obsolete colony elevation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000071
+id: METPO:1000071
 name: obsolete colony margin
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000072
+id: METPO:1000072
 name: obsolete colony morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:1000073
+id: METPO:1000073
 name: obsolete colony texture
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000074
+id: METPO:1000074
 name: obsolete commensalism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000075
+id: METPO:1000075
 name: obsolete community behavior
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000076
+id: METPO:1000076
 name: obsolete community structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000077
+id: METPO:1000077
 name: obsolete compatible solute
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000078
+id: METPO:1000078
 name: obsolete competence
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000079
+id: METPO:1000079
 name: obsolete component
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000080
+id: METPO:1000080
 name: obsolete conidium
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000081
+id: METPO:1000081
 name: obsolete conjugation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000082
+id: METPO:1000082
 name: obsolete CRISPR
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000083
+id: METPO:1000083
 name: obsolete culturability
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000084
+id: METPO:1000084
 name: obsolete cyst
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000085
+id: METPO:1000085
 name: obsolete death phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000086
+id: METPO:1000086
 name: obsolete denitrification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005038
+replaced_by: METPO:1005038
 
 [Term]
-id: metpo:1000087
+id: METPO:1000087
 name: obsolete developmental process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000088
+id: METPO:1000088
 name: obsolete diagnostic enzyme
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000089
+id: METPO:1000089
 name: obsolete diagnostic feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000090
+id: METPO:1000090
 name: obsolete diazotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000091
+id: METPO:1000091
 name: obsolete differentiation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000092
+id: METPO:1000092
 name: obsolete dimorphism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000093
+id: METPO:1000093
 name: obsolete disc-shaped cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000094
+id: METPO:1000094
 name: obsolete domain
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000095
+id: METPO:1000095
 name: obsolete dormancy
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000096
+id: METPO:1000096
 name: obsolete dormancy structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000097
+id: METPO:1000097
 name: obsolete dumbbell-shaped cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000672
+replaced_by: METPO:1000672
 
 [Term]
-id: metpo:1000098
+id: METPO:1000098
 name: obsolete ecological niche
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000099
+id: METPO:1000099
 name: obsolete ecological process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:1000100
+id: METPO:1000100
 name: obsolete ecological trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000101
+id: METPO:1000101
 name: obsolete ectosymbiosis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000102
+id: METPO:1000102
 name: obsolete electron acceptor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000103
+id: METPO:1000103
 name: obsolete electron donor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000104
+id: METPO:1000104
 name: obsolete endospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000105
+id: METPO:1000105
 name: obsolete endosymbiosis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000106
+id: METPO:1000106
 name: obsolete energy metabolism process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000107
+id: METPO:1000107
 name: obsolete enzyme activity
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000108
+id: METPO:1000108
 name: obsolete epigenetic modification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000109
+id: METPO:1000109
 name: obsolete evolutionary process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000110
+id: METPO:1000110
 name: obsolete exospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000111
+id: METPO:1000111
 name: obsolete exponential phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000112
+id: METPO:1000112
 name: obsolete extracellular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000113
+id: METPO:1000113
 name: obsolete extracellular polysaccharide
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000114
+id: METPO:1000114
 name: obsolete extreme halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:1000115
+id: METPO:1000115
 name: obsolete extremophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000116
+id: METPO:1000116
 name: obsolete facultative
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000117
+id: METPO:1000117
 name: obsolete facultative anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:1000118
+id: METPO:1000118
 name: obsolete family
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000119
+id: METPO:1000119
 name: obsolete fastidious
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000120
+id: METPO:1000120
 name: obsolete fermentation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1002005
+replaced_by: METPO:1002005
 
 [Term]
-id: metpo:1000121
+id: METPO:1000121
 name: obsolete filamentous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000122
+id: METPO:1000122
 name: obsolete fimbriae
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000123
+id: METPO:1000123
 name: obsolete flagellum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000124
+id: METPO:1000124
 name: obsolete flask-shaped cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000125
+id: METPO:1000125
 name: obsolete fungal spore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000126
+id: METPO:1000126
 name: obsolete gas vesicle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000127
+id: METPO:1000127
 name: GC content
 def: "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs." [] {IAO:0000119="https://purl.dsmz.de/schema/GCContent"}
 synonym: "GC percentage" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000128
+id: METPO:1000128
 name: obsolete high GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:1000129
+id: METPO:1000129
 name: obsolete low GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:1000130
+id: METPO:1000130
 name: obsolete lower-mid GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000131
+id: METPO:1000131
 name: obsolete upper-mid GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000132
+id: METPO:1000132
 name: obsolete generation time
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000133
+id: METPO:1000133
 name: obsolete genetic element
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000134
+id: METPO:1000134
 name: obsolete genetic exchange
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000135
+id: METPO:1000135
 name: obsolete genetic process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000136
+id: METPO:1000136
 name: obsolete genome size
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000137
+id: METPO:1000137
 name: obsolete genomic element
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000138
+id: METPO:1000138
 name: obsolete genomic island
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000139
+id: METPO:1000139
 name: obsolete genomic trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000140
+id: METPO:1000140
 name: obsolete genus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000141
+id: METPO:1000141
 name: obsolete gliding motility
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000142
+id: METPO:1000142
 name: obsolete global regulator
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000143
+id: METPO:1000143
 name: obsolete Gram-negative
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000699
+replaced_by: METPO:1000699
 
 [Term]
-id: metpo:1000144
+id: METPO:1000144
 name: obsolete Gram-positive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000698
+replaced_by: METPO:1000698
 
 [Term]
-id: metpo:1000145
+id: METPO:1000145
 name: obsolete Gram stain
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000697
+replaced_by: METPO:1000697
 
 [Term]
-id: metpo:1000146
+id: METPO:1000146
 name: obsolete growth characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000147
+id: METPO:1000147
 name: obsolete growth conditions constraints
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000148
+id: METPO:1000148
 name: obsolete growth pattern
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000149
+id: METPO:1000149
 name: obsolete growth rate
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000150
+id: METPO:1000150
 name: obsolete habitat
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000151
+id: METPO:1000151
 name: obsolete halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:1000152
+id: METPO:1000152
 name: obsolete halotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:1000153
+id: METPO:1000153
 name: obsolete heat shock protein
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000154
+id: METPO:1000154
 name: obsolete heat shock response
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000155
+id: METPO:1000155
 name: obsolete hemolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005025
+replaced_by: METPO:1005025
 
 [Term]
-id: metpo:1000156
+id: METPO:1000156
 name: obsolete heterocyst
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000157
+id: METPO:1000157
 name: obsolete heterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:1000158
+id: METPO:1000158
 name: obsolete holdfast
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000159
+id: METPO:1000159
 name: obsolete horizontal gene transfer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000160
+id: METPO:1000160
 name: obsolete hydrolase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000161
+id: METPO:1000161
 name: obsolete hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:1000162
+id: METPO:1000162
 name: obsolete inclusion body
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000163
+id: METPO:1000163
 name: obsolete infection
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000164
+id: METPO:1000164
 name: obsolete interaction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000165
+id: METPO:1000165
 name: obsolete interaction with a phage
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000166
+id: METPO:1000166
 name: obsolete interaction with an environment
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000167
+id: METPO:1000167
 name: obsolete interaction with host
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000168
+id: METPO:1000168
 name: obsolete interaction within a community
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000169
+id: METPO:1000169
 name: obsolete intracellular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000170
+id: METPO:1000170
 name: obsolete invasion
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000171
+id: METPO:1000171
 name: obsolete laboratory characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000172
+id: METPO:1000172
 name: obsolete lag phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000173
+id: METPO:1000173
 name: obsolete life cycle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000174
+id: METPO:1000174
 name: obsolete life cycle phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000175
+id: METPO:1000175
 name: obsolete lipolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000176
+id: METPO:1000176
 name: obsolete lipopolysaccharide
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000177
+id: METPO:1000177
 name: obsolete localization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000178
+id: METPO:1000178
 name: obsolete lysogeny
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000179
+id: METPO:1000179
 name: obsolete macroscopic trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000180
+id: METPO:1000180
 name: obsolete magnetotaxis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000181
+id: METPO:1000181
 name: obsolete mesophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000615
+replaced_by: METPO:1000615
 
 [Term]
-id: metpo:1000182
+id: METPO:1000182
 name: obsolete metabolic partner
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000183
+id: METPO:1000183
 name: obsolete metabolic trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000184
+id: METPO:1000184
 name: obsolete methanogenesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000844
+replaced_by: METPO:1000844
 
 [Term]
-id: metpo:1000185
+id: METPO:1000185
 name: obsolete methylation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000186
+id: METPO:1000186
 name: material entity
 def: "An object or portion of a substance or mixture of substances that consists of matter" [] {IAO:0000119="BFO:0000040"}
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000187
+id: METPO:1000187
 name: obsolete process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000188
+id: METPO:1000188
 name: quality
 def: "A characteristic of an entity that depends on the entity's existence, size, color, and physiological traits." []
 
 [Term]
-id: metpo:1000189
+id: METPO:1000189
 name: obsolete system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000190
+id: METPO:1000190
 name: obsolete microaerophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:1000191
+id: METPO:1000191
 name: obsolete mobile genetic element
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000192
+id: METPO:1000192
 name: obsolete moderate halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:1000193
+id: METPO:1000193
 name: obsolete morphological trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000194
+id: METPO:1000194
 name: obsolete motility process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000195
+id: METPO:1000195
 name: obsolete motility structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000196
+id: METPO:1000196
 name: obsolete mutualism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000197
+id: METPO:1000197
 name: obsolete mycolic acid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000198
+id: METPO:1000198
 name: obsolete mycorrhization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000199
+id: METPO:1000199
 name: obsolete neutrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:1000200
+id: METPO:1000200
 name: obsolete nitrification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005001
+replaced_by: METPO:1005001
 
 [Term]
-id: metpo:1000201
+id: METPO:1000201
 name: obsolete nitrogen fixation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1000202
+id: METPO:1000202
 name: obsolete nodulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000203
+id: METPO:1000203
 name: obsolete nucleoid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000204
+id: METPO:1000204
 name: obsolete nutrient utilization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000205
+id: METPO:1000205
 name: obsolete obligate
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000206
+id: METPO:1000206
 name: obsolete obligate aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:1000207
+id: METPO:1000207
 name: obsolete obligate anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:1000208
+id: METPO:1000208
 name: obsolete oospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000209
+id: METPO:1000209
 name: obsolete order
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000210
+id: METPO:1000210
 name: obsolete microbe characterized by growth conditions
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000211
+id: METPO:1000211
 name: obsolete microbe characterized by nutritional requirement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000212
+id: METPO:1000212
 name: obsolete microbe characterized by product produced
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000213
+id: METPO:1000213
 name: obsolete microbe characterized by relation to oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000214
+id: METPO:1000214
 name: obsolete microbe characterized by relation to ph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000215
+id: METPO:1000215
 name: obsolete microbe characterized by relation to pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000216
+id: METPO:1000216
 name: obsolete microbe characterized by relation to salt concentration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000217
+id: METPO:1000217
 name: obsolete microbe characterized by relation to temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000218
+id: METPO:1000218
 name: obsolete microbe characterized by shape
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000219
+id: METPO:1000219
 name: obsolete microbe characterized by trophic type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000220
+id: METPO:1000220
 name: obsolete osmophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000221
+id: METPO:1000221
 name: obsolete osmoregulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000222
+id: METPO:1000222
 name: obsolete oxidative stress response
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000223
+id: METPO:1000223
 name: obsolete oxidoreductase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000224
+id: METPO:1000224
 name: obsolete oxygen requirement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000225
+id: METPO:1000225
 name: obsolete oxygenic photosynthesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000226
+id: METPO:1000226
 name: obsolete pan-genome
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000227
+id: METPO:1000227
 name: obsolete parasitism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000228
+id: METPO:1000228
 name: obsolete passive transport
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000229
+id: METPO:1000229
 name: obsolete pathogenicity
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000230
+id: METPO:1000230
 name: obsolete pathogenicity island
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000231
+id: METPO:1000231
 name: obsolete peptidoglycan
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000232
+id: METPO:1000232
 name: pH delta
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000233
+id: METPO:1000233
 name: obsolete pH optimum (growth range)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000234
+id: METPO:1000234
 name: obsolete pH preference
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000235
+id: METPO:1000235
 name: obsolete pH range (growth tolerance)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000236
+id: METPO:1000236
 name: obsolete pH tolerance
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000237
+id: METPO:1000237
 name: obsolete phage defense
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000238
+id: METPO:1000238
 name: obsolete photoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:1000239
+id: METPO:1000239
 name: obsolete photoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:1000240
+id: METPO:1000240
 name: obsolete photosynthesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000241
+id: METPO:1000241
 name: obsolete phototaxis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000242
+id: METPO:1000242
 name: obsolete phylum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000243
+id: METPO:1000243
 name: obsolete physiological process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:1000244
+id: METPO:1000244
 name: obsolete physiological state
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000245
+id: METPO:1000245
 name: obsolete physiological trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000246
+id: METPO:1000246
 name: obsolete piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000247
+id: METPO:1000247
 name: obsolete pigment
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000248
+id: METPO:1000248
 name: obsolete pigmentation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003021
+replaced_by: METPO:1003021
 
 [Term]
-id: metpo:1000249
+id: METPO:1000249
 name: obsolete pilus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000250
+id: METPO:1000250
 name: obsolete plant growth promotion
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000251
+id: METPO:1000251
 name: obsolete plasmid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000252
+id: METPO:1000252
 name: obsolete pleomorphism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000253
+id: METPO:1000253
 name: obsolete process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000254
+id: METPO:1000254
 name: obsolete prophage
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000255
+id: METPO:1000255
 name: obsolete prostheca
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000256
+id: METPO:1000256
 name: obsolete protein synthesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000257
+id: METPO:1000257
 name: obsolete proteolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000258
+id: METPO:1000258
 name: obsolete prototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000259
+id: METPO:1000259
 name: obsolete psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:1000260
+id: METPO:1000260
 name: obsolete qualifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000261
+id: METPO:1000261
 name: obsolete quorum sensing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000262
+id: METPO:1000262
 name: obsolete regulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000263
+id: METPO:1000263
 name: obsolete regulatory mechanism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000264
+id: METPO:1000264
 name: obsolete reproductive process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000265
+id: METPO:1000265
 name: obsolete reproductive structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000266
+id: METPO:1000266
 name: obsolete resistance mechanism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000267
+id: METPO:1000267
 name: obsolete respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000800
+replaced_by: METPO:1000800
 
 [Term]
-id: metpo:1000268
+id: METPO:1000268
 name: obsolete restriction-modification system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000269
+id: METPO:1000269
 name: obsolete ribosome
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000270
+id: METPO:1000270
 name: obsolete S-layer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000271
+id: METPO:1000271
 name: obsolete salinity delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000272
+id: METPO:1000272
 name: obsolete salinity preference
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000273
+id: METPO:1000273
 name: obsolete secondary metabolite
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000274
+id: METPO:1000274
 name: obsolete secretion
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000275
+id: METPO:1000275
 name: obsolete secretion system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000276
+id: METPO:1000276
 name: obsolete sheathed
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000277
+id: METPO:1000277
 name: obsolete siderophore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000278
+id: METPO:1000278
 name: obsolete sigma factor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000279
+id: METPO:1000279
 name: obsolete signaling
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000280
+id: METPO:1000280
 name: obsolete slime layer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000281
+id: METPO:1000281
 name: obsolete specialized cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000282
+id: METPO:1000282
 name: obsolete species
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000283
+id: METPO:1000283
 name: obsolete spirillum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000284
+id: METPO:1000284
 name: obsolete spirochete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000285
+id: METPO:1000285
 name: obsolete sporangiospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000286
+id: METPO:1000286
 name: obsolete sporulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:1000287
+id: METPO:1000287
 name: obsolete square cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000288
+id: METPO:1000288
 name: obsolete stalk
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000289
+id: METPO:1000289
 name: obsolete star-shaped cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000290
+id: METPO:1000290
 name: obsolete stationary phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000291
+id: METPO:1000291
 name: obsolete storage structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000292
+id: METPO:1000292
 name: obsolete strain
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000293
+id: METPO:1000293
 name: obsolete stress response
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000294
+id: METPO:1000294
 name: obsolete structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000295
+id: METPO:1000295
 name: obsolete sulfate reducer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000296
+id: METPO:1000296
 name: obsolete swarming
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000297
+id: METPO:1000297
 name: obsolete symbiosis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000298
+id: METPO:1000298
 name: obsolete symbiotic process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000299
+id: METPO:1000299
 name: obsolete syntrophy
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1002006
+replaced_by: METPO:1002006
 
 [Term]
-id: metpo:1000300
+id: METPO:1000300
 name: obsolete taxonomic identifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000301
+id: METPO:1000301
 name: obsolete taxonomic rank
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000302
+id: METPO:1000302
 name: obsolete teichoic acid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000303
+id: METPO:1000303
 name: temperature delta
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000304
+id: METPO:1000304
 name: temperature optimum
 def: "A temperature phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction." [] {IAO:0000119="https://purl.dsmz.de/schema/OptimumTemperature"}
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000305
+id: METPO:1000305
 name: obsolete temperature preference
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000613
+replaced_by: METPO:1000613
 
 [Term]
-id: metpo:1000306
+id: METPO:1000306
 name: temperature range
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 
 [Term]
-id: metpo:1000307
+id: METPO:1000307
 name: obsolete thermal tolerance
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000308
+id: METPO:1000308
 name: obsolete thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:1000309
+id: METPO:1000309
 name: obsolete toxin
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000310
+id: METPO:1000310
 name: obsolete transcription factor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000311
+id: METPO:1000311
 name: obsolete transduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000312
+id: METPO:1000312
 name: obsolete transferase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000313
+id: METPO:1000313
 name: obsolete transformation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000314
+id: METPO:1000314
 name: obsolete transport system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000315
+id: METPO:1000315
 name: obsolete transposon
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000316
+id: METPO:1000316
 name: obsolete triangular cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000317
+id: METPO:1000317
 name: obsolete trichome
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000318
+id: METPO:1000318
 name: obsolete twitching motility
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000319
+id: METPO:1000319
 name: obsolete two-component system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000320
+id: METPO:1000320
 name: obsolete viable but non-culturable
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000321
+id: METPO:1000321
 name: obsolete vibrio
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000322
+id: METPO:1000322
 name: obsolete virulence
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000323
+id: METPO:1000323
 name: obsolete virulence factor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000324
+id: METPO:1000324
 name: obsolete virulence process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000325
+id: METPO:1000325
 name: obsolete xylanolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000326
+id: METPO:1000326
 name: obsolete zoospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000327
+id: METPO:1000327
 name: obsolete zygospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000328
+id: METPO:1000328
 name: obsolete pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000329
+id: METPO:1000329
 name: obsolete temperature optimum (metabolic activity)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000330
+id: METPO:1000330
 name: obsolete temperature range (metabolic viability)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000331
+id: METPO:1000331
 name: pH optimum
 def: "A pH phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction." []
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 
 [Term]
-id: metpo:1000332
+id: METPO:1000332
 name: pH range
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000333
+id: METPO:1000333
 name: NaCl optimum
 def: "A salinity phenotype with numerical limits that supports the most efficient growth and reproduction of an organism." [] {IAO:0000119="https://purl.dsmz.de/schema/OptimumSalinity"}
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000334
+id: METPO:1000334
 name: NaCl range
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000335
+id: METPO:1000335
 name: NaCl delta
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000336
+id: METPO:1000336
 name: obsolete psychrotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:1000337
+id: METPO:1000337
 name: obsolete thermotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:1000338
+id: METPO:1000338
 name: obsolete extreme thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:1000339
+id: METPO:1000339
 name: obsolete extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:1000340
+id: METPO:1000340
 name: obsolete non-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:1000341
+id: METPO:1000341
 name: obsolete slight halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:1000342
+id: METPO:1000342
 name: obsolete haloalkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:1000343
+id: METPO:1000343
 name: obsolete extreme acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000344
+id: METPO:1000344
 name: obsolete acid tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000345
+id: METPO:1000345
 name: obsolete alkali tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000346
+id: METPO:1000346
 name: obsolete extreme alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000347
+id: METPO:1000347
 name: obsolete facultative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:1000348
+id: METPO:1000348
 name: obsolete obligative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:1000349
+id: METPO:1000349
 name: obsolete facultative aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:1000350
+id: METPO:1000350
 name: obsolete microaerophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:1000351
+id: METPO:1000351
 name: obsolete microaerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:1000352
+id: METPO:1000352
 name: obsolete aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000353
+id: METPO:1000353
 name: obsolete obligate aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:1000354
+id: METPO:1000354
 name: obsolete obligate anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:1000355
+id: METPO:1000355
 name: obsolete oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000356
+id: METPO:1000356
 name: obsolete anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000357
+id: METPO:1000357
 name: obsolete chemoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:1000358
+id: METPO:1000358
 name: obsolete chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000359
+id: METPO:1000359
 name: obsolete lithotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:1000360
+id: METPO:1000360
 name: obsolete organotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:1000361
+id: METPO:1000361
 name: obsolete phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:1000362
+id: METPO:1000362
 name: obsolete chemotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:1000363
+id: METPO:1000363
 name: obsolete oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:1000364
+id: METPO:1000364
 name: obsolete copiotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:1000365
+id: METPO:1000365
 name: obsolete lithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:1000366
+id: METPO:1000366
 name: obsolete mixotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:1000367
+id: METPO:1000367
 name: obsolete lithoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:1000368
+id: METPO:1000368
 name: obsolete chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:1000369
+id: METPO:1000369
 name: obsolete chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:1000370
+id: METPO:1000370
 name: obsolete methylotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:1000371
+id: METPO:1000371
 name: obsolete methanotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:1000372
+id: METPO:1000372
 name: obsolete hydrogenotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:1000373
+id: METPO:1000373
 name: obsolete hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000374
+id: METPO:1000374
 name: obsolete hydrogen producer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000375
+id: METPO:1000375
 name: obsolete nitrogen fixer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000376
+id: METPO:1000376
 name: obsolete methanogen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000377
+id: METPO:1000377
 name: obsolete sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000378
+id: METPO:1000378
 name: obsolete denitrifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000379
+id: METPO:1000379
 name: obsolete motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:1000380
+id: METPO:1000380
 name: obsolete non-motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:1000381
+id: METPO:1000381
 name: obsolete flagellated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:1000382
+id: METPO:1000382
 name: obsolete peritrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000383
+id: METPO:1000383
 name: obsolete lophotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000384
+id: METPO:1000384
 name: obsolete monotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000385
+id: METPO:1000385
 name: obsolete ciliated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000386
+id: METPO:1000386
 name: obsolete gliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:1000387
+id: METPO:1000387
 name: obsolete twitching
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000388
+id: METPO:1000388
 name: obsolete sliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000389
+id: METPO:1000389
 name: obsolete myxospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000390
+id: METPO:1000390
 name: obsolete conidia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000391
+id: METPO:1000391
 name: obsolete chlamydospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000392
+id: METPO:1000392
 name: obsolete sporocysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000393
+id: METPO:1000393
 name: obsolete hypnospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000394
+id: METPO:1000394
 name: obsolete gemmae
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000395
+id: METPO:1000395
 name: obsolete azygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000396
+id: METPO:1000396
 name: obsolete aleuriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000397
+id: METPO:1000397
 name: obsolete stylospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000398
+id: METPO:1000398
 name: obsolete sclerotia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000399
+id: METPO:1000399
 name: obsolete teliospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000400
+id: METPO:1000400
 name: obsolete urediniospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000401
+id: METPO:1000401
 name: obsolete pycnidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000402
+id: METPO:1000402
 name: obsolete acriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000403
+id: METPO:1000403
 name: obsolete aplanospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000404
+id: METPO:1000404
 name: obsolete statismospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000405
+id: METPO:1000405
 name: obsolete piezotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000406
+id: METPO:1000406
 name: obsolete piezosensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000407
+id: METPO:1000407
 name: obsolete obligate barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000408
+id: METPO:1000408
 name: obsolete facultative barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000409
+id: METPO:1000409
 name: obsolete hyperbarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000410
+id: METPO:1000410
 name: obsolete hypobarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000411
+id: METPO:1000411
 name: obsolete atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000412
+id: METPO:1000412
 name: obsolete moderate piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000413
+id: METPO:1000413
 name: obsolete extreme piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000414
+id: METPO:1000414
 name: obsolete stenopiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000415
+id: METPO:1000415
 name: obsolete eurypiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000416
+id: METPO:1000416
 name: obsolete pressure-sensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000417
+id: METPO:1000417
 name: obsolete pressure-resistant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000418
+id: METPO:1000418
 name: obsolete pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000419
+id: METPO:1000419
 name: obsolete piezo-acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000420
+id: METPO:1000420
 name: obsolete piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000421
+id: METPO:1000421
 name: obsolete piezo-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000422
+id: METPO:1000422
 name: obsolete piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000423
+id: METPO:1000423
 name: obsolete piezo-thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000424
+id: METPO:1000424
 name: obsolete piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000425
+id: METPO:1000425
 name: obsolete piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000426
+id: METPO:1000426
 name: obsolete piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000427
+id: METPO:1000427
 name: obsolete piezo-endolithic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000428
+id: METPO:1000428
 name: obsolete piezo-tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000429
+id: METPO:1000429
 name: GC low
 synonym: "GC_<=42.65" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "42.65" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "42.65" xsd:string
 
 [Term]
-id: metpo:1000430
+id: METPO:1000430
 name: GC mid1
 synonym: "GC_42.65_57.0" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "57" xsd:string
-property_value: metpo:range_min "42.65" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "57" xsd:string
+property_value: METPO:range_min "42.65" xsd:string
 
 [Term]
-id: metpo:1000431
+id: METPO:1000431
 name: GC mid2
 synonym: "GC_57.0_66.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "66.3" xsd:string
-property_value: metpo:range_min "57" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "66.3" xsd:string
+property_value: METPO:range_min "57" xsd:string
 
 [Term]
-id: metpo:1000432
+id: METPO:1000432
 name: GC high
 synonym: "GC_>66.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_min "66.3" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_min "66.3" xsd:string
 
 [Term]
-id: metpo:1000433
+id: METPO:1000433
 name: obsolete cell width very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000887
+replaced_by: METPO:1000887
 
 [Term]
-id: metpo:1000434
+id: METPO:1000434
 name: obsolete cell width low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:1000435
+id: METPO:1000435
 name: obsolete cell width mid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000889
+replaced_by: METPO:1000889
 
 [Term]
-id: metpo:1000436
+id: METPO:1000436
 name: obsolete cell width high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:1000437
+id: METPO:1000437
 name: obsolete cell length very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000883
+replaced_by: METPO:1000883
 
 [Term]
-id: metpo:1000438
+id: METPO:1000438
 name: obsolete cell length low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:1000439
+id: METPO:1000439
 name: obsolete cell length mid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000885
+replaced_by: METPO:1000885
 
 [Term]
-id: metpo:1000440
+id: METPO:1000440
 name: obsolete cell length high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:1000441
+id: METPO:1000441
 name: temperature optimum very low
 synonym: "Psychrophile" EXACT []
 synonym: "TO_<=10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "10" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000442
+id: METPO:1000442
 name: temperature optimum low
 synonym: "Psychrophile" EXACT []
 synonym: "Psychrotolerant" EXACT []
 synonym: "TO_10_to_22" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "22" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "22" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000443
+id: METPO:1000443
 name: temperature optimum mid1
 synonym: "mesophilic" EXACT []
 synonym: "TO_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "27" xsd:string
-property_value: metpo:range_min "22" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "27" xsd:string
+property_value: METPO:range_min "22" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000444
+id: METPO:1000444
 name: temperature optimum mid2
 synonym: "mesophilic" EXACT []
 synonym: "TO_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "27" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "27" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000445
+id: METPO:1000445
 name: temperature optimum mid3
 synonym: "mesophilic" EXACT []
 synonym: "TO_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "34" xsd:string
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "34" xsd:string
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000446
+id: METPO:1000446
 name: temperature optimum mid4
 synonym: "mesophilic" EXACT []
 synonym: "TO_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "40" xsd:string
-property_value: metpo:range_min "34" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "40" xsd:string
+property_value: METPO:range_min "34" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000447
+id: METPO:1000447
 name: temperature optimum high
 synonym: "Thermophile" EXACT []
 synonym: "TO_>40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_min "40" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_min "40" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000448
+id: METPO:1000448
 name: temperature range very low
 synonym: "Psychrophile" EXACT []
 synonym: "TR_<=10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "10" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000449
+id: METPO:1000449
 name: temperature range low
 synonym: "Psychrophile" EXACT []
 synonym: "Psychrotolerant" EXACT []
 synonym: "TR_10_to_22" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "22" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "22" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000450
+id: METPO:1000450
 name: temperature range mid1
 synonym: "mesophilic" EXACT []
 synonym: "TR_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "27" xsd:string
-property_value: metpo:range_min "22" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "27" xsd:string
+property_value: METPO:range_min "22" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000451
+id: METPO:1000451
 name: temperature range mid2
 synonym: "mesophilic" EXACT []
 synonym: "TR_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "27" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "27" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000452
+id: METPO:1000452
 name: temperature range mid3
 synonym: "mesophilic" EXACT []
 synonym: "TR_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "34" xsd:string
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "34" xsd:string
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000453
+id: METPO:1000453
 name: temperature range mid4
 synonym: "mesophilic" EXACT []
 synonym: "TR_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "40" xsd:string
-property_value: metpo:range_min "34" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "40" xsd:string
+property_value: METPO:range_min "34" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000454
+id: METPO:1000454
 name: temperature range high
 synonym: "Thermophile" EXACT []
 synonym: "TR_>40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_min "40" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_min "40" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000455
+id: METPO:1000455
 name: pH optimum low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
@@ -7585,44 +7585,44 @@ synonym: "Extreme Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHO_0_to_6" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "6" xsd:string
-property_value: metpo:range_min "0" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "6" xsd:string
+property_value: METPO:range_min "0" xsd:string
 
 [Term]
-id: metpo:1000456
+id: METPO:1000456
 name: pH optimum mid1
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHO_6_to_7" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "7" xsd:string
-property_value: metpo:range_min "6" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "7" xsd:string
+property_value: METPO:range_min "6" xsd:string
 
 [Term]
-id: metpo:1000457
+id: METPO:1000457
 name: pH optimum mid2
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHO_7_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "7" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "7" xsd:string
 
 [Term]
-id: metpo:1000458
+id: METPO:1000458
 name: pH optimum high
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
 synonym: "pHO_8_to_14" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "14" xsd:string
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "14" xsd:string
+property_value: METPO:range_min "8" xsd:string
 
 [Term]
-id: metpo:1000459
+id: METPO:1000459
 name: pH range very low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
@@ -7630,1054 +7630,1054 @@ synonym: "Extreme Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHR_0_to_4" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "4" xsd:string
-property_value: metpo:range_min "0" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "4" xsd:string
+property_value: METPO:range_min "0" xsd:string
 
 [Term]
-id: metpo:1000460
+id: METPO:1000460
 name: pH range low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHR_4_to_6" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "6" xsd:string
-property_value: metpo:range_min "4" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "6" xsd:string
+property_value: METPO:range_min "4" xsd:string
 
 [Term]
-id: metpo:1000461
+id: METPO:1000461
 name: pH range mid1
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHR_6_to_7" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "7" xsd:string
-property_value: metpo:range_min "6" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "7" xsd:string
+property_value: METPO:range_min "6" xsd:string
 
 [Term]
-id: metpo:1000462
+id: METPO:1000462
 name: pH range mid2
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHR_7_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "7" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "7" xsd:string
 
 [Term]
-id: metpo:1000463
+id: METPO:1000463
 name: pH range mid3
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "pHR_8_to_10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "10" xsd:string
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "10" xsd:string
+property_value: METPO:range_min "8" xsd:string
 
 [Term]
-id: metpo:1000464
+id: METPO:1000464
 name: pH range high
 synonym: "10_to_14" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "14" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "14" xsd:string
+property_value: METPO:range_min "10" xsd:string
 
 [Term]
-id: metpo:1000465
+id: METPO:1000465
 name: NaCl optimum low
 synonym: "Halotolerant" EXACT []
 synonym: "NaO_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Non-halophile" EXACT []
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000466
+id: METPO:1000466
 name: NaCl optimum mid1
 synonym: "Halotolerant" EXACT []
 synonym: "NaO_1_to_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Slight halophile" EXACT []
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000467
+id: METPO:1000467
 name: NaCl optimum mid2
 synonym: "Halotolerant" EXACT []
 synonym: "Moderate halophile" EXACT []
 synonym: "NaO_3_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000468
+id: METPO:1000468
 name: NaCl optimum high
 synonym: "Extreme halophile" EXACT []
 synonym: "NaO_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000469
+id: METPO:1000469
 name: NaCl range low
 synonym: "Halotolerant" EXACT []
 synonym: "NaR_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Non-halophile" EXACT []
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000470
+id: METPO:1000470
 name: NaCl range mid1
 synonym: "Halotolerant" EXACT []
 synonym: "NaR_1_to_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Slight halophile" EXACT []
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000471
+id: METPO:1000471
 name: NaCl range mid2
 synonym: "Halotolerant" EXACT []
 synonym: "Moderate halophile" EXACT []
 synonym: "NaR_3_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000472
+id: METPO:1000472
 name: NaCl range high
 synonym: "Extreme halophile" EXACT []
 synonym: "NaR_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000473
+id: METPO:1000473
 name: pH delta very low
 synonym: "pHd_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "1" xsd:string
 
 [Term]
-id: metpo:1000474
+id: METPO:1000474
 name: pH delta low
 synonym: "pHd_1_2" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "2" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "2" xsd:string
+property_value: METPO:range_min "1" xsd:string
 
 [Term]
-id: metpo:1000475
+id: METPO:1000475
 name: pH delta mid1
 synonym: "pHd_2_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "2" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "2" xsd:string
 
 [Term]
-id: metpo:1000476
+id: METPO:1000476
 name: pH delta mid2
 synonym: "pHd_3_4" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "4" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "4" xsd:string
+property_value: METPO:range_min "3" xsd:string
 
 [Term]
-id: metpo:1000477
+id: METPO:1000477
 name: pH delta mid3
 synonym: "pHd_4_5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "5" xsd:string
-property_value: metpo:range_min "4" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "5" xsd:string
+property_value: METPO:range_min "4" xsd:string
 
 [Term]
-id: metpo:1000478
+id: METPO:1000478
 name: pH delta high
 synonym: "pHd_5_9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "9" xsd:string
-property_value: metpo:range_min "5" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "9" xsd:string
+property_value: METPO:range_min "5" xsd:string
 
 [Term]
-id: metpo:1000479
+id: METPO:1000479
 name: NaCl delta low
 synonym: "Nad_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000480
+id: METPO:1000480
 name: NaCl delta mid1
 synonym: "Nad_1_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000481
+id: METPO:1000481
 name: NaCl delta mid2
 synonym: "Nad_3_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000482
+id: METPO:1000482
 name: NaCl delta high
 synonym: "Nad_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000483
+id: METPO:1000483
 name: temperature delta very low
 synonym: "Td_1_5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "5" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "5" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000484
+id: METPO:1000484
 name: temperature delta low
 synonym: "Td_5_10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "10" xsd:string
-property_value: metpo:range_min "5" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "10" xsd:string
+property_value: METPO:range_min "5" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000485
+id: METPO:1000485
 name: temperature delta mid1
 synonym: "Td_10_20" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "20" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "20" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000486
+id: METPO:1000486
 name: temperature delta mid2
 synonym: "Td_20_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "20" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "20" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000487
+id: METPO:1000487
 name: temperature delta high
 synonym: "Td_>30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000488
+id: METPO:1000488
 name: obsolete branched
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000489
+id: METPO:1000489
 name: obsolete coccobacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000490
+id: METPO:1000490
 name: obsolete crescent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000491
+id: METPO:1000491
 name: obsolete curved
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000492
+id: METPO:1000492
 name: obsolete curved spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000493
+id: METPO:1000493
 name: obsolete diplococcus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000494
+id: METPO:1000494
 name: obsolete ellipsoidal
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:1000495
+id: METPO:1000495
 name: obsolete filament
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000496
+id: METPO:1000496
 name: obsolete fusiform
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000497
+id: METPO:1000497
 name: obsolete helical
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000498
+id: METPO:1000498
 name: obsolete irregular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000499
+id: METPO:1000499
 name: obsolete oval
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000500
+id: METPO:1000500
 name: obsolete ovoid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000501
+id: METPO:1000501
 name: obsolete pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000502
+id: METPO:1000502
 name: obsolete ring
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000503
+id: METPO:1000503
 name: obsolete rod
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000504
+id: METPO:1000504
 name: obsolete sphere
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000505
+id: METPO:1000505
 name: obsolete spindle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000506
+id: METPO:1000506
 name: obsolete spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000507
+id: METPO:1000507
 name: obsolete star - dumbbell - pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000508
+id: METPO:1000508
 name: obsolete tailed
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000509
+id: METPO:1000509
 name: obsolete temperature adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000510
+id: METPO:1000510
 name: obsolete salinity adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000511
+id: METPO:1000511
 name: obsolete pH adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000512
+id: METPO:1000512
 name: obsolete bacterial spore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000513
+id: METPO:1000513
 name: obsolete pressure adaptation type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000514
+id: METPO:1000514
 name: obsolete pressure tolerance range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:1000515
+id: METPO:1000515
 name: obsolete sensitivity to oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000516
+id: METPO:1000516
 name: obsolete sensitivity toward
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000517
+id: METPO:1000517
 name: obsolete size
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000518
+id: METPO:1000518
 name: obsolete 1-D extent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000519
+id: METPO:1000519
 name: obsolete width
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000520
+id: METPO:1000520
 name: obsolete length
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000521
+id: METPO:1000521
 name: obsolete sensitivity toward pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000522
+id: METPO:1000522
 name: obsolete sensitivity toward nacl
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000523
+id: METPO:1000523
 name: obsolete sensitivity toward ph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000524
+id: METPO:1000524
 name: obsolete sensitivity toward temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000525
+id: METPO:1000525
 name: microbe
 def: "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation." [] {IAO:0000119="OHMI:0000460"}
 comment: METPO is primarily concerned with unicellular, prokaryotic life forms, i.e. bacteria and archaea, including the cases of giant bacteria like Thiomargarita
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: IAO:0000117 "Luke Wang" xsd:string
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/OrganismTaxon
 
 [Term]
-id: metpo:1000526
+id: METPO:1000526
 name: chemical entity
 def: "A material entity that is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances." [] {IAO:0000119="CHEBI:24431"}
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/ChemicalEntity
 
 [Term]
-id: metpo:1000527
+id: METPO:1000527
 name: enzyme
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 
 [Term]
-id: metpo:1000528
+id: METPO:1000528
 name: obsolete structured susceptibility detail
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000529
+id: METPO:1000529
 name: obsolete facultative psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000720
+replaced_by: METPO:1000720
 
 [Term]
-id: metpo:1000531
+id: METPO:1000531
 name: pH phenotype with numerical limits
 def: "A phenotype characterized by specific pH values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000532
+id: METPO:1000532
 name: salinity phenotype with numerical limits
 def: "A phenotype characterized by specific salt concentration values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000533
+id: METPO:1000533
 name: temperature phenotype with numerical limits
 def: "A phenotype characterized by specific temperature values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000534
+id: METPO:1000534
 name: delta phenotype with numerical limits
 def: "A phenotype characterized by the difference between maximum and minimum values of a growth parameter." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000535
+id: METPO:1000535
 name: growth range phenotype with numerical limits
 def: "A phenotype characterized by the span of values within which an organism can maintain growth." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000536
+id: METPO:1000536
 name: optimum phenotype with numerical limits
 def: "A phenotype characterized by the value at which an organism exhibits maximum growth rate or activity." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000601
+id: METPO:1000601
 name: oxygen preference
 def: "A phenotype that is relating to an organism's oxygen requirements or tolerance for growth." [] {IAO:0000119="UPHENO:0049673", IAO:0000119="https://purl.dsmz.de/schema/OxygenTolerance"}
 synonym: "metabolism" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "oxygen preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Physiology and metabolism.oxygen tolerance.oxygen tolerance" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000602
+id: METPO:1000602
 name: aerobic
 def: "An oxygen preference in which growth occurs in the presence of molecular oxygen (O2), typically using O2 as the terminal electron acceptor." [] {IAO:0000119="ECOCORE:00000173", IAO:0000119="OMP:0005253"}
 synonym: "aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "aerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_aerobic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000603
+id: METPO:1000603
 name: anaerobic
 def: "An oxygen preference in which growth occurs in the absence of molecular oxygen (O2)." [] {IAO:0000119="MICRO:0000495"}
 synonym: "anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_anaerobic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000604
+id: METPO:1000604
 name: microaerophilic
 def: "An oxygen preference that requires molecular oxygen (O2) at concentrations lower than atmospheric." [] {IAO:0000119="ECOCORE:00000180", IAO:0000119="OMP:0005254", IAO:0000119="MICRO:0000515"}
 synonym: "microaerophile" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "microaerophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_microerophile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000605
+id: METPO:1000605
 name: facultatively anaerobic
 def: "An oxygen preference in which growth can occur with or without molecular oxygen (O2)." [] {IAO:0000119="OMP:0000087", IAO:0000119="MICRO:0001520"}
 synonym: "facultative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "facultative anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "facultative anaerobe" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000606
+id: METPO:1000606
 name: obligately aerobic
 def: "An aerobic phenotype that requires molecular oxygen (O2) for growth." [] {IAO:0000119="MICRO:0000516"}
 synonym: "obligate aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "obligate aerobic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "obligate aerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000602 ! aerobic
+is_a: METPO:1000602 ! aerobic
 
 [Term]
-id: metpo:1000607
+id: METPO:1000607
 name: obligately anaerobic
 def: "An anaerobic phenotype in which molecular oxygen (O2) inhibits or prevents growth." [] {IAO:0000119="MICRO:0000504"}
 synonym: "obligate anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "obligate anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000603 ! anaerobic
+is_a: METPO:1000603 ! anaerobic
 
 [Term]
-id: metpo:1000608
+id: METPO:1000608
 name: facultatively aerobic
 def: "An oxygen preference in which growth can occur without oxygen but is capable of aerobic growth." [] {IAO:0000119="OMP:0000087", IAO:0000119="ECOCORE:00000177"}
 synonym: "facultative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "facultative aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000609
+id: METPO:1000609
 name: aerotolerant
 def: "An oxygen preference that does not use O2 for growth but tolerates its presence." [] {IAO:0000119="MICRO:0000502"}
 synonym: "aerotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "aerotolerant" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000610
+id: METPO:1000610
 name: microaerotolerant
 def: "An oxygen preference that tolerates low levels of molecular oxygen (O2) without requiring it." [] {IAO:0000119="ECOCORE:00000180", IAO:0000119="ECOCORE:00000181", IAO:0000119="OMP:0000087", IAO:0000119="OMP:0000105"}
 synonym: "microaerotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000611
+id: METPO:1000611
 name: strictly anaerobic
 def: "An obligately anaerobic where a microorganism does not grow in the presence of oxygen gas (O2)." [] {IAO:0000119="OMP:0000184"}
 synonym: "obligate anaerobic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "strictly anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000607 ! obligately anaerobic
+is_a: METPO:1000607 ! obligately anaerobic
 
 [Term]
-id: metpo:1000612
+id: METPO:1000612
 name: facultative oxygen preference
 def: "An oxygen preference that describes a microorganism that can grow with or without molecular oxygen." [] {IAO:0000119="OMP:0000087"}
 synonym: "Ox_facultative_aerobe_anaerobe" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000613
+id: METPO:1000613
 name: temperature preference
 def: "A phenotype that describes characteristic growth with respect to environmental temperature." [] {IAO:0000119="OMP:0005002"}
 synonym: "Physiology and metabolism.culture temp.temperature" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "range_tmp" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "temperature preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000614
+id: METPO:1000614
 name: psychrophilic
 def: "A temperature preference in which growth is favored at low temperatures, typically near or below ~15 C." [] {IAO:0000119="MICRO:0001306"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000615
+id: METPO:1000615
 name: mesophilic
 def: "A temperature preference in which growth is favored at intermediate temperatures, typically ~20-45 C." [] {IAO:0000119="MICRO:0000111"}
 synonym: "mesophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "mesophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000616
+id: METPO:1000616
 name: thermophilic
 def: "A temperature preference in which growth is favored at elevated temperatures, typically >=45 C." [] {IAO:0000119="OMP:0005003", IAO:0000119="OMP:0005004", IAO:0000119="MICRO:0000118"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000617
+id: METPO:1000617
 name: hyperthermophilic
 def: "A temperature preference in which growth is favored at very high temperatures, typically >=80 C." [] {IAO:0000119="MICRO:0001538"}
 synonym: "extreme thermophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "hyperthermophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000618
+id: METPO:1000618
 name: psychrotolerant
 def: "A temperature preference in which growth can occur at low temperatures without an obligate low-temperature preference." [] {IAO:0000119="MICRO:0001310", IAO:0000119="OMP:0005007", IAO:0000119="OMP:0005006"}
 synonym: "psychrotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000619
+id: METPO:1000619
 name: thermotolerant
 def: "A temperature preference in which growth can occur at elevated temperatures without an obligate high-temperature preference." [] {IAO:0000119="MICRO:0001286"}
 synonym: "thermotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000620
+id: METPO:1000620
 name: halophilic
 def: "A halophily preference in which an organism requires high concentrations of salt for growth and survival." [] {IAO:0000119="GO:0170002", IAO:0000119="OMP:0005016", IAO:0000119="MICRO:0001315", IAO:0000119="MICRO:0001314"}
 synonym: "halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000621
+id: METPO:1000621
 name: haloalkaliphilic
 def: "A halophily preference in which an organism requires both high salt concentrations and alkaline pH for optimal growth." [] {IAO:0000119="MICRO:0001392", IAO:0000119="MICRO:0001554", IAO:0000119="OMP:0005011", IAO:0000119="MICRO:0001314"}
 synonym: "haloalkaliphilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000622
+id: METPO:1000622
 name: halotolerant
 def: "A halophily preference in which an organism can tolerate high salt concentrations but does not require them for growth." [] {IAO:0000119="MICRO:0001316"}
 synonym: "halotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "halotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000623
+id: METPO:1000623
 name: moderately halophilic
 def: "A halophilic phenotype in which an organism requires high levels of sodium chloride, usually above or about 0.2 M." [] {IAO:0000119="OMP:0005016"}
 synonym: "moderate-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "moderately halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000624
+id: METPO:1000624
 name: non halophilic
 def: "A halophily preference in which an organism does not require or prefer elevated salt concentrations for growth." []
 synonym: "non-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "non-halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000625
+id: METPO:1000625
 name: slightly halophilic
 def: "A halophilic phenotype in which an organism requires low to moderate salt concentrations (0.3 to 0.8 M NaCl) for optimal growth." [] {IAO:0000119="OMP:0005016"}
 synonym: "slightly halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 
 [Term]
-id: metpo:1000626
+id: METPO:1000626
 name: stenohaline
 def: "A halophily preference in which an organism can only tolerate a narrow range of salinity concentrations and cannot survive significant changes in environmental salt levels." [] {IAO:0000119="https://purl.dsmz.de/schema/SaltTolerance"}
 synonym: "stenohaline" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000627
+id: METPO:1000627
 name: euryhaline
 def: "A halophily preference in which an organism can tolerate a wide range of salinity conditions." []
 synonym: "euryhaline" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000628
+id: METPO:1000628
 name: extremely halophilic
 def: "A halophilic phenotype in which an organism requires very high salt concentrations (typically 15-30% NaCl or higher) for optimal growth and cannot grow at salt concentrations below approximately 12%." [] {IAO:0000119="OMP:0005016", IAO:0000119="MICRO:0001314"}
 synonym: "extreme-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "extremely halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000629
+id: METPO:1000629
 name: halophily preference
 def: "A phenotype that is relating to an organism's salt concentration requirements or tolerance for growth." [] {IAO:0000119="https://purl.dsmz.de/schema/SaltTolerance", IAO:0000119="OMP:0005016"}
 synonym: "Physiology and metabolism.halophily.halophily level" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "range_salinity" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "salinity preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000630
+id: METPO:1000630
 name: biological process
 def: "A execution of a genetically-encoded biological module or program. It consists of all the steps required to achieve the specific biological objective of the module. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence." []
 
 [Term]
-id: metpo:1000631
+id: METPO:1000631
 name: trophic type
 def: "A phenotype that is describing how an organism obtains carbon and energy for growth and metabolism." []
 synonym: "nutritional type" RELATED []
 synonym: "pathways" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Physiology and metabolism.nutrition type.type" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000632
+id: METPO:1000632
 name: autotrophic
 def: "A trophic type in which an organism produces organic compounds from inorganic carbon sources (primarily carbon dioxide or bicarbonate) using energy from light (photoautotrophy) or from the oxidation of inorganic compounds (chemoautotrophy)." [] {IAO:0000119="ECOCORE:00000009", IAO:0000119="MICRO:0001456"}
 synonym: "autotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "autotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_autotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000633
+id: METPO:1000633
 name: carboxydotrophic
 def: "A trophic type in which an organism derives energy from the oxidation of carbon monoxide." []
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000634
+id: METPO:1000634
 name: chemoautolithotrophic
 def: "A trophic type in which an organism uses chemical oxidation of inorganic compounds as the energy source and carbon dioxide as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000129", IAO:0000119="ECOCORE:00000124", IAO:0000119="ECOCORE:00000123", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110"}
 synonym: "chemoautolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000635
+id: METPO:1000635
 name: chemoautotrophic
 def: "A trophic type in which an organism obtains energy from oxidation of inorganic compounds and carbon from carbon dioxide." [] {IAO:0000119="ECOCORE:00000129", IAO:0000119="MICRO:0001480", IAO:0000119="ECOCORE:00000123", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110"}
 synonym: "chemoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000636
+id: METPO:1000636
 name: chemoheterotrophic
 def: "A trophic type in which an organism obtains both energy and carbon from organic compounds." [] {IAO:0000119="ECOCORE:00000012", IAO:0000119="ECOCORE:00000132", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110", IAO:0000119="ECOCORE:00000127"}
 synonym: "aerobic_chemo_heterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "chemoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000637
+id: METPO:1000637
 name: chemolithoautotrophic
 def: "A trophic type in which an organism obtains energy from oxidation of inorganic compounds (lithotrophy) and carbon from carbon dioxide." [] {IAO:0000119="MICRO:0000511"}
 synonym: "chemolithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000638
+id: METPO:1000638
 name: chemolithoheterotrophic
 def: "A trophic type characterized by the use of inorganic chemical compounds as electron donors for energy generation while utilizing organic compounds as the primary carbon source." [] {IAO:0000119="MICRO:0001478", IAO:0000119="MICRO:0000512"}
 synonym: "chemolithoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000639
+id: METPO:1000639
 name: chemolithotrophic
 def: "A trophic type characterized by the use of inorganic chemical compounds as electron donors and carbon dioxide as the primary carbon source for energy generation and biosynthesis." [] {IAO:0000119="MICRO:0001499", IAO:0000119="OMP:0007110"}
 synonym: "chemolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000640
+id: METPO:1000640
 name: chemoorganoheterotrophic
 def: "A trophic type in which an organism obtains both energy and carbon from organic compounds through oxidation." [] {IAO:0000119="MICRO:0001481", IAO:0000119="MICRO:0000514", IAO:0000119="OMP:0007111", IAO:0000119="ECOCORE:00000127", IAO:0000119="MICRO:0001479"}
 synonym: "chemoorganoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000641
+id: METPO:1000641
 name: chemotrophic
 def: "A trophic type in which an organism obtains energy from chemical oxidation of either inorganic or organic compounds." [] {IAO:0000119="MICRO:0001458"}
 synonym: "chemotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_chemotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000642
+id: METPO:1000642
 name: copiotrophic
 def: "A nutrient adaptation in which an organism thrives in environments with high nutrient concentrations, typically exhibiting rapid growth rates and utilizing diverse carbon sources." []
 synonym: "copiotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000731 ! nutrient adaptation
+is_a: METPO:1000731 ! nutrient adaptation
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000643
+id: METPO:1000643
 name: obsolete denitrifying
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000644
+id: METPO:1000644
 name: heterotrophic
 def: "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide." [] {IAO:0000119="MICRO:0001474"}
 synonym: "aerobic_heterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "heterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "heterotrophic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_heterotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000645
+id: METPO:1000645
 name: obsolete hydrogen-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000646
+id: METPO:1000646
 name: hydrogenotrophic
 def: "A trophic type in which an organism uses molecular hydrogen as an electron donor for energy generation and carbon dioxide as the primary carbon source." []
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000647
+id: METPO:1000647
 name: lithoautotrophic
 def: "A trophic type in which an organism obtains energy from inorganic electron donors and carbon from carbon dioxide." [] {IAO:0000119="ECOCORE:00000009", IAO:0000119="MICRO:0001483", IAO:0000119="ECOCORE:00000122", IAO:0000119="ECOCORE:00000014", IAO:0000119="MICRO:0001477"}
 synonym: "lithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000648
+id: METPO:1000648
 name: lithoheterotrophic
 def: "A trophic type in which an organism obtains energy from the oxidation of inorganic compounds while using organic compounds as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="MICRO:0001459", IAO:0000119="ECOCORE:00000014", IAO:0000119="MICRO:0001478", IAO:0000119="OMP:0007110"}
 synonym: "lithoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000649
+id: METPO:1000649
 name: lithotrophic
 def: "A trophic type in which an organism uses inorganic compounds as electron donors for energy generation." [] {IAO:0000119="MICRO:0001459"}
 synonym: "lithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_lithotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000650
+id: METPO:1000650
 name: methanotrophic
 def: "A trophic type in which an organism uses methane as the primary carbon and energy source through oxidation of methane to carbon dioxide." []
 synonym: "methanotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000651
+id: METPO:1000651
 name: methylotrophic
 def: "A trophic type in which an organism obtains energy and carbon from reduced one-carbon compounds." []
 synonym: "methylotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "methylotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_methylotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000652
+id: METPO:1000652
 name: mixotrophic
 def: "A trophic type in which an organism can use both organic and inorganic carbon sources for growth." [] {IAO:0000119="MICRO:0001475"}
 synonym: "mixotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000653
+id: METPO:1000653
 name: obsolete nitrogen-fixing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1000654
+id: METPO:1000654
 name: oligotrophic
 def: "A nutrient adaptation characterized by the ability to thrive in environments with very low nutrient concentrations, typically possessing efficient nutrient uptake and utilization systems." [] {IAO:0000119="ENVO:01000774", IAO:0000119="ENVO:00002223"}
 synonym: "oligotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_oligotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000731 ! nutrient adaptation
+is_a: METPO:1000731 ! nutrient adaptation
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000655
+id: METPO:1000655
 name: organotrophic
 def: "A trophic type in which an organism obtains energy from the oxidation of organic compounds." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="OMP:0007111"}
 synonym: "organotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_organotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000656
+id: METPO:1000656
 name: photoautotrophic
 def: "A trophic type characterized by the use of light as the energy source and carbon dioxide as the primary carbon source for biosynthesis." [] {IAO:0000119="MICRO:0001483", IAO:0000119="OMP:0006008", IAO:0000119="ECOCORE:00000121", IAO:0000119="ECOCORE:00000017", IAO:0000119="MICRO:0001457"}
 synonym: "anoxygenic_photoautotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
@@ -8686,2191 +8686,2191 @@ synonym: "anoxygenic_photoautotrophy_iron_oxidation" RELATED [] {IAO:0000119="ht
 synonym: "anoxygenic_photoautotrophy_sulfur_oxidation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "photoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "photoautotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000657
+id: METPO:1000657
 name: photoheterotrophic
 def: "A trophic type in which an organism uses light as the energy source and organic compounds as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000131"}
 synonym: "photoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "photoheterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000658
+id: METPO:1000658
 name: photolithotrophic
 def: "A trophic type in which an organism uses light as the energy source and inorganic compounds as electron donors, typically with carbon dioxide as the primary carbon source." [] {IAO:0000119="MICRO:0001482"}
 synonym: "photolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000659
+id: METPO:1000659
 name: photoorganoheterotrophic
 def: "A trophic type in which an organism obtains energy from light and carbon from organic compounds." [] {IAO:0000119="MICRO:0000510"}
 synonym: "photoorganoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000660
+id: METPO:1000660
 name: phototrophic
 def: "A trophic type characterized by the use of light as the primary energy source for metabolic processes, regardless of carbon source." [] {IAO:0000119="OMP:0007064", IAO:0000119="MICRO:0001457"}
 synonym: "aerobic_anoxygenic_phototrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "phototroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_phototroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000661
+id: METPO:1000661
 name: obsolete sulfate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000662
+id: METPO:1000662
 name: obsolete sulfur-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000663
+id: METPO:1000663
 name: chemoorganotrophic
 def: "A trophic type in which an organism obtains energy through chemical oxidation of organic compounds that also serve as the carbon source for biosynthesis." [] {IAO:0000119="OMP:0007111"}
 synonym: "chemoorganotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000664
+id: METPO:1000664
 name: organoheterotrophic
 def: "A trophic type characterized by the use of organic compounds as both electron donors and primary carbon sources for energy generation and biosynthesis." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="ECOCORE:00000121", IAO:0000119="ECOCORE:00000126", IAO:0000119="ECOCORE:00000125", IAO:0000119="ECOCORE:00000127"}
 synonym: "organoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000665
+id: METPO:1000665
 name: photolithoautotrophic
 def: "A trophic type in which an organism obtains energy from light and carbon from carbon dioxide using inorganic electron donors." [] {IAO:0000119="MICRO:0000500"}
 synonym: "photolithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000666
+id: METPO:1000666
 name: cell shape
 def: "A phenotype that describes the characteristic three-dimensional morphological form of a microbial cell, determined by cell wall structure, cytoskeletal elements, and environmental factors." [] {IAO:0000119="OMP:0000073"}
 synonym: "cell shape" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "cell_shape" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Morphology.cell morphology.cell shape" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000667
+id: METPO:1000667
 name: bacillus shaped
 def: "A cell shape characterized by an elongated, rod cylindrical morphology with relatively parallel sides and rounded ends." [] {IAO:0000119="OMP:0000076"}
 synonym: "bacillus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000668
+id: METPO:1000668
 name: coccus shaped
 def: "A cell shape in which an organism has a spherical or nearly spherical morphology, with roughly equal dimensions in all directions." [] {IAO:0000119="OMP:0000075", IAO:0000119="OMP:0000123", IAO:0000119="MICRO:0000402"}
 synonym: "coccus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "coccus-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000669
+id: METPO:1000669
 name: crescent shaped
 synonym: "crescent-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000670
+id: METPO:1000670
 name: curved shaped
 synonym: "curved-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_curved_spiral" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000671
+id: METPO:1000671
 name: diplococcus shaped
 def: "A cell shape in which spherical cells remain attached in pairs following cell division, forming characteristic doublets." [] {IAO:0000119="OMP:0000117"}
 synonym: "diplococcus-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000672
+id: METPO:1000672
 name: dumbbell shaped
 synonym: "dumbbell-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000673
+id: METPO:1000673
 name: ellipsoidal
 def: "A cell shape in which an organism has an oval or ellipse morphology, elongated along one axis with rounded ends, intermediate between spherical and rod-shaped." [] {IAO:0000119="PATO:0000947"}
 synonym: "ellipsoidal" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000674
+id: METPO:1000674
 name: filament shaped
 synonym: "filament" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "filament-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_filament" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000675
+id: METPO:1000675
 name: flask shaped
 synonym: "flask" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "flask-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000676
+id: METPO:1000676
 name: helical shaped
 synonym: "helical-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000677
+id: METPO:1000677
 name: ovoid shaped
 def: "A cell shape in which an organism has an oval morphology, rounded at both ends with one end often slightly broader than the other." [] {IAO:0000119="PATO:0001891"}
 synonym: "ovoid-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_ovoid" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000678
+id: METPO:1000678
 name: oval shaped
 def: "A cell shape characterized by an ellipsoidal morphology with rounded ends, resembling an elongated sphere." [] {IAO:0000119="OMP:0007100"}
 synonym: "oval-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000679
+id: METPO:1000679
 name: pleomorphic shaped
 def: "A cell shape characterized by variable and irregular morphology, where individual cells within a population exhibit multiple distinct shapes." [] {IAO:0000119="OMP:0000132"}
 synonym: "pleomorphic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "pleomorphic-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000680
+id: METPO:1000680
 name: ring shaped
 def: "A cell shape in which an organism forms circular or toroidal structures." [] {IAO:0000119="PATO:0002539"}
 synonym: "ring" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "ring-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000681
+id: METPO:1000681
 name: rod shaped
 def: "A cell shape in which an organism has an elongated, cylindrical morphology with relatively straight sides and rounded or flat ends." [] {IAO:0000119="OMP:0000076"}
 synonym: "rod-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_rod" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000682
+id: METPO:1000682
 name: spore shaped
 synonym: "spore-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000683
+id: METPO:1000683
 name: sphere shaped
 synonym: "S_sphere" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "sphere-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000684
+id: METPO:1000684
 name: spiral shaped
 synonym: "S_curved_spiral" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "spiral" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "spiral-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000685
+id: METPO:1000685
 name: star shaped
 def: "A cell shape in which an organism has multiple radiating projections from a central body." [] {IAO:0000119="OMP:0000130", IAO:0000119="PATO:0002065"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "star" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "star-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000686
+id: METPO:1000686
 name: vibrio shaped
 def: "A cell shape in which an organism has a curved rod or comma morphology, characterized by a short curved cylindrical form with a single arc." [] {IAO:0000119="OMP:0000086", IAO:0000119="OMP:0000077"}
 synonym: "vibrio" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "vibrio-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000687
+id: METPO:1000687
 name: branched shaped
 synonym: "branced" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000688
+id: METPO:1000688
 name: coccobacillus shaped
 synonym: "coccobacillus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000689
+id: METPO:1000689
 name: disc shaped
 def: "A cell shape in which an organism is flat and circular." []
 synonym: "disc" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000690
+id: METPO:1000690
 name: fusiform shaped
 def: "A cell shape that is wide in the middle and tapers at both ends." [] {IAO:0000119="PATO:0002400"}
 synonym: "fusiform" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000691
+id: METPO:1000691
 name: irregular shaped
 synonym: "irregular" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000692
+id: METPO:1000692
 name: spindle shaped
 synonym: "spindle" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000693
+id: METPO:1000693
 name: spirochete shaped
 def: "A cell shape in which an organism has an elongated, tightly coiled helical morphology with periplasmic flagella (endoflagella) located between the cell wall and outer membrane." [] {IAO:0000119="OMP:0000086", IAO:0000119="OMP:0000124", IAO:0000119="OMP:0000125"}
 synonym: "spirochete" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000694
+id: METPO:1000694
 name: square shaped
 synonym: "square" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000695
+id: METPO:1000695
 name: tailed shaped
 synonym: "tailed" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000696
+id: METPO:1000696
 name: triangular shaped
 synonym: "triangular" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000697
+id: METPO:1000697
 name: gram stain
 def: "A phenotype where microorganisms are grouped based on their ability to retain crystal violet dye in the Gram staining procedure." [] {IAO:0000119="OMP:0000191"}
 synonym: "gram_stain" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Morphology.cell morphology.gram stain" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000698
+id: METPO:1000698
 name: gram positive
 def: "A gram stain in which an organism retains crystal violet dye and appears purple under microscopy due to a thick peptidoglycan cell wall." [] {IAO:0000119="OMP:0000188", IAO:0000119="https://purl.dsmz.de/schema/GramPositiveBacteria"}
 synonym: "G_positive" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "gram positive" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "positive" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "positive" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 
 [Term]
-id: metpo:1000699
+id: METPO:1000699
 name: gram negative
 def: "A gram stain in which bacteria do not retain crystal violet dye and appear pink or red after staining, indicating a thin peptidoglycan layer and presence of an outer membrane." []
 synonym: "G_negative" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "gram negative" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "negative" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "negative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000700
+id: METPO:1000700
 name: gram variable
 def: "A gram stain in which bacteria from the same culture show both gram-positive and gram-negative staining characteristics, often due to age of culture or cell wall degradation." [] {IAO:0000119="OMP:0000190"}
 synonym: "variable" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000701
+id: METPO:1000701
 name: motility
 def: "A phenotype in which an organism has the capability to move independently through its environment, typically by means of flagella, pili, gliding mechanisms, or other locomotory structures." [] {IAO:0000119="OMP:0000001"}
 synonym: "Morphology.cell morphology.motility" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "motility" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "presence of motility" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000702
+id: METPO:1000702
 name: motile
 def: "A motility in which an organism has the ability to move independently using metabolic energy." [] {IAO:0000119="CL:0000219", IAO:0000119="OMP:0000005"}
 synonym: "motile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "yes" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "yes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000701 ! motility
+is_a: METPO:1000701 ! motility
 
 [Term]
-id: metpo:1000703
+id: METPO:1000703
 name: non motile
 def: "A motility in which an organism lacks the ability to move independently under its own power." [] {IAO:0000119="OMP:0007489", IAO:0000119="OMP:0007488", IAO:0000119="OMP:0000133", IAO:0000119="UPHENO:0034076", IAO:0000119="OMP:0007490"}
 synonym: "no" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "no" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "non-motile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000701 ! motility
+is_a: METPO:1000701 ! motility
 
 [Term]
-id: metpo:1000704
+id: METPO:1000704
 name: flagellated
 def: "A motile in which an organism possesses flagella for locomotion." [] {IAO:0000119="MICRO:0000272", IAO:0000119="CL:0011016", IAO:0000119="OMP:0000029", IAO:0000119="GO:0030317"}
 synonym: "flagella" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 
 [Term]
-id: metpo:1000705
+id: METPO:1000705
 name: axially filamented
 def: "A motile in which the flagellum filament of an organism is located in the periplasm and does not extend past the cell envelope." [] {IAO:0000119="OMP:0000023", IAO:0000119="GO:0055040"}
 synonym: "axial filament" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000706
+id: METPO:1000706
 name: gliding
 def: "A motile in which an organism moves smoothly along solid surfaces without flagella or pili." [] {IAO:0000119="OMP:0000112", IAO:0000119="GO:0071976", IAO:0000119="MICRO:0000437"}
 synonym: "gliding" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 
 [Term]
-id: metpo:1000720
+id: METPO:1000720
 name: facultative psychrophilic
 def: "A temperature preference characterized by the ability to grow at low temperatures (typically below 20C) while maintaining optimal growth at moderate temperatures." [] {IAO:0000119="OMP:0005007", IAO:0000119="MICRO:0001306", IAO:0000119="MICRO:0001417"}
 synonym: "facultative psychrophile" RELATED []
 synonym: "facultative psychrophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000721
+id: METPO:1000721
 name: extreme hyperthermophilic
 def: "A hyperthermophilic phenotype in which an organism grows optimally at temperatures above 90 C." [] {IAO:0000119="ENVO:00002027", IAO:0000119="OMP:0005003", IAO:0000119="MICRO:0001294", IAO:0000119="MICRO:0001538"}
 synonym: "extreme hyperthermophile" RELATED []
 synonym: "extremely hyperthermophilic" RELATED []
-is_a: metpo:1000617 ! hyperthermophilic
+is_a: METPO:1000617 ! hyperthermophilic
 
 [Term]
-id: metpo:1000731
+id: METPO:1000731
 name: nutrient adaptation
 def: "A trophic type that involves an organism's physiological and metabolic adaptations to specific nutrient availability." [] {IAO:0000119="PHIPO:0001216"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000800
+id: METPO:1000800
 name: respiration
 def: "A metabolism that is characterized by the method of performing cellular respiration, distinguished primarily by the specific terminal electron acceptor utilized for producing cellular energy." [] {IAO:0000119="GO:0045333", IAO:0000119="GO:0009060"}
 synonym: "pathways" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "respiration" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000801
+id: METPO:1000801
 name: Aerobic respiration
 def: "A respiration in which molecular oxygen serves as the terminal electron acceptor in the electron transport chain, generating ATP through oxidative phosphorylation with water as the final product." [] {IAO:0000119="GO:0009060"}
 synonym: "Oxic respiration" RELATED []
 synonym: "Oxygen respiration" RELATED []
-is_a: metpo:1000800 ! respiration
+is_a: METPO:1000800 ! respiration
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000802
+id: METPO:1000802
 name: Anaerobic respiration
 def: "A respiration in which an organism uses electron acceptors other than oxygen for energy production." [] {IAO:0000119="GO:0009061"}
 synonym: "Anoxic respiration" RELATED []
 synonym: "Dissimilatory respiration (non-O2)" RELATED []
-is_a: metpo:1000800 ! respiration
+is_a: METPO:1000800 ! respiration
 
 [Term]
-id: metpo:1000803
+id: METPO:1000803
 name: Oxidative phosphorylation
 def: "A metabolism that generates ATP through the transfer of electrons from electron donors to electron acceptors via redox reactions, coupled to the pumping of protons across a membrane to create an electrochemical gradient." [] {IAO:0000119="GO:0006119"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000804
+id: METPO:1000804
 name: Substrate-level phosphorylation
 def: "A metabolism in which ATP is formed directly by transfer of a phosphoryl group from a substrate to ADP." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1000805
+id: METPO:1000805
 name: Electron transfer
 def: "A metabolism in which electrons are transferred from an electron donor to an electron acceptor." [] {IAO:0000119="GO:0009055"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000806
+id: METPO:1000806
 name: Disproportionation
 def: "A metabolism in which a single substrate simultaneously undergoes both oxidation and reduction reactions, with part of the substrate serving as the electron donor and another part serving as the electron acceptor." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000807
+id: METPO:1000807
 name: obsolete Nitrogen compound respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000808
+id: METPO:1000808
 name: obsolete Nitrate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000809
+id: METPO:1000809
 name: obsolete Denitrification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005038
+replaced_by: METPO:1005038
 
 [Term]
-id: metpo:1000810
+id: METPO:1000810
 name: obsolete Dissimilatory nitrate reduction to ammonium
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000811
+id: METPO:1000811
 name: obsolete Nitrite reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000812
+id: METPO:1000812
 name: obsolete Anaerobic ammonium oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000813
+id: METPO:1000813
 name: obsolete Nitric oxide reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000814
+id: METPO:1000814
 name: obsolete Nitrous oxide reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000815
+id: METPO:1000815
 name: obsolete Sulfur and sulfoxide compound respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000816
+id: METPO:1000816
 name: obsolete Sulfate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000817
+id: METPO:1000817
 name: obsolete Sulfur reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000818
+id: METPO:1000818
 name: obsolete Sulfite reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000819
+id: METPO:1000819
 name: obsolete Thiosulfate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000820
+id: METPO:1000820
 name: obsolete Sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000821
+id: METPO:1000821
 name: obsolete Dimethyl sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000822
+id: METPO:1000822
 name: obsolete Methionine sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000823
+id: METPO:1000823
 name: obsolete Sulfide oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000824
+id: METPO:1000824
 name: obsolete Thiosulfate oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000825
+id: METPO:1000825
 name: obsolete Sulfite oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000826
+id: METPO:1000826
 name: obsolete Tetrathionate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000827
+id: METPO:1000827
 name: obsolete Polysulfide reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000828
+id: METPO:1000828
 name: obsolete Metal and metalloid respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000829
+id: METPO:1000829
 name: obsolete Iron reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000830
+id: METPO:1000830
 name: obsolete Iron oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000831
+id: METPO:1000831
 name: obsolete Nitrate-dependent Fe(II) oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000832
+id: METPO:1000832
 name: obsolete Manganese reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000833
+id: METPO:1000833
 name: obsolete Manganese oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000834
+id: METPO:1000834
 name: obsolete Uranium reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000835
+id: METPO:1000835
 name: obsolete Vanadium reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000836
+id: METPO:1000836
 name: obsolete Chromium reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000837
+id: METPO:1000837
 name: obsolete Technetium reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000838
+id: METPO:1000838
 name: obsolete Cobalt reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000839
+id: METPO:1000839
 name: obsolete Arsenate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000840
+id: METPO:1000840
 name: obsolete Arsenite oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000841
+id: METPO:1000841
 name: obsolete Selenate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000842
+id: METPO:1000842
 name: obsolete Selenite reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000843
+id: METPO:1000843
 name: obsolete Carbon and organic compound respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000844
+id: METPO:1000844
 name: Methanogenesis
 def: "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions." [] {IAO:0000119="GO:0015948"}
 synonym: "Biological methanation" RELATED []
 synonym: "Biomethanation" RELATED []
 synonym: "Carbonate respiration" RELATED []
 synonym: "methanogenesis" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000845
+id: METPO:1000845
 name: Acetogenesis
 def: "A metabolism that produces acetate as the primary end product through the reduction of carbon dioxide or other carbon compounds using the Wood-Ljungdahl pathway, typically performed by acetogenic bacteria under anaerobic conditions." []
 synonym: "Acetate fermentation" RELATED []
 synonym: "acetogenesis" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000846
+id: METPO:1000846
 name: Homoacetogenesis
 def: "A metabolism in which acetate is produced as the sole reduced end product from reduction of CO2 via the acetyl-CoA pathway." []
 synonym: "Reductive acetyl-CoA pathway" RELATED []
 synonym: "Wood-Ljungdahl pathway" RELATED []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1000847
+id: METPO:1000847
 name: obsolete Fumarate respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000848
+id: METPO:1000848
 name: obsolete Trimethylamine N-oxide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000849
+id: METPO:1000849
 name: obsolete Humus respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000850
+id: METPO:1000850
 name: obsolete Halogenated compound respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000851
+id: METPO:1000851
 name: obsolete Organohalide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000852
+id: METPO:1000852
 name: obsolete (Per)chlorate respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000853
+id: METPO:1000853
 name: obsolete Perchlorate respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000854
+id: METPO:1000854
 name: obsolete Chlorate respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000855
+id: METPO:1000855
 name: obsolete Bromate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000856
+id: METPO:1000856
 name: obsolete Iodate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000857
+id: METPO:1000857
 name: obsolete Nitrite-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000858
+id: METPO:1000858
 name: obsolete Nitrate-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000859
+id: METPO:1000859
 name: obsolete Hydrogen oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000860
+id: METPO:1000860
 name: obsolete Sulfur oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000861
+id: METPO:1000861
 name: obsolete Nitrification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005001
+replaced_by: METPO:1005001
 
 [Term]
-id: metpo:1000862
+id: METPO:1000862
 name: obsolete Complete ammonia oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000863
+id: METPO:1000863
 name: obsolete Carbon monoxide oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000864
+id: METPO:1000864
 name: obsolete Hydrogenotrophic methanogenesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000865
+id: METPO:1000865
 name: obsolete Acetoclastic methanogenesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000866
+id: METPO:1000866
 name: obsolete Methylotrophic methanogenesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000867
+id: METPO:1000867
 name: obsolete Anaerobic methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000868
+id: METPO:1000868
 name: obsolete Lanthanide reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000869
+id: METPO:1000869
 name: obsolete Lanthanide oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000870
+id: METPO:1000870
 name: sporulation
 def: "A phenotype that is relating to an organism's ability to form dormant, stress-resistant endospores." [] {IAO:0000119="GO:0043934"}
 synonym: "General.keywords" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "Physiology and metabolism.spore formation.spore formation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "sporulation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "sporulation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000871
+id: METPO:1000871
 name: spore forming
 def: "A sporulation in which an organism has the ability to produce endospores." [] {IAO:0000119="GO:0034301", IAO:0000119="https://purl.dsmz.de/schema/SporeFormation", IAO:0000119="OMP:0000017"}
 synonym: "spore" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "yes" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "yes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000870 ! sporulation
+is_a: METPO:1000870 ! sporulation
 
 [Term]
-id: metpo:1000872
+id: METPO:1000872
 name: non-spore forming
 def: "A sporulation in which an organism lacks the ability to produce endospores." [] {IAO:0000119="OMP:0007236", IAO:0000119="OMP:0007434", IAO:0000119="UPHENO:0083394", IAO:0000119="OMP:0000018", IAO:0000119="OMP:0007232"}
 synonym: "no" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "no" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "no_spore" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000870 ! sporulation
+is_a: METPO:1000870 ! sporulation
 
 [Term]
-id: metpo:1000881
+id: METPO:1000881
 name: cell length
 def: "A phenotype that inheres in a cell by virtue of its longer dimension when viewed on a plane." [] {IAO:0000119="OBA:2040145"}
 synonym: "cell length" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000882
+id: METPO:1000882
 name: cell width
 def: "A phenotype that inheres in a cell by virtue of its shorter dimension when viewed on a plane." [] {IAO:0000119="OBA:2040146"}
 synonym: "cell width" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000883
+id: METPO:1000883
 name: cell length very small
 synonym: "L_<=1.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "1.3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "1.3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000884
+id: METPO:1000884
 name: cell length small
 synonym: "L_1.3_2" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "2" xsd:string
-property_value: metpo:range_min "1.3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "2" xsd:string
+property_value: METPO:range_min "1.3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000885
+id: METPO:1000885
 name: cell length medium
 synonym: "L_2_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "2" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "2" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000886
+id: METPO:1000886
 name: cell length large
 synonym: "L_>3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000887
+id: METPO:1000887
 name: cell width very small
 synonym: "W_<=0.5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.5" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.5" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000888
+id: METPO:1000888
 name: cell width small
 synonym: "W_0.5_0.65" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.65" xsd:string
-property_value: metpo:range_min "0.5" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.65" xsd:string
+property_value: METPO:range_min "0.5" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000889
+id: METPO:1000889
 name: cell width medium
 synonym: "W_0.65_0.9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.9" xsd:string
-property_value: metpo:range_min "0.65" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.9" xsd:string
+property_value: METPO:range_min "0.65" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000890
+id: METPO:1000890
 name: cell width large
 synonym: "W_>0.9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_min "0.9" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_min "0.9" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1001000
+id: METPO:1001000
 name: obsolete observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001001
+id: METPO:1001001
 name: obsolete optimum temperature observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001002
+id: METPO:1001002
 name: obsolete growth temperature observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001003
+id: METPO:1001003
 name: obsolete temperature range observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001004
+id: METPO:1001004
 name: obsolete temperature delta observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001005
+id: METPO:1001005
 name: obsolete culture temperature observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001006
+id: METPO:1001006
 name: obsolete culture NaCl observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001007
+id: METPO:1001007
 name: obsolete growth NaCl observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001008
+id: METPO:1001008
 name: obsolete NaCl delta observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001009
+id: METPO:1001009
 name: obsolete NaCl range observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001010
+id: METPO:1001010
 name: obsolete optimum NaCl observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001011
+id: METPO:1001011
 name: obsolete culture pH observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001012
+id: METPO:1001012
 name: obsolete growth pH observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001013
+id: METPO:1001013
 name: obsolete optimum pH observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001014
+id: METPO:1001014
 name: obsolete pH delta observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001015
+id: METPO:1001015
 name: obsolete pH range observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001016
+id: METPO:1001016
 name: obsolete optimum oxygen observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001017
+id: METPO:1001017
 name: obsolete growth oxygen observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001018
+id: METPO:1001018
 name: obsolete oxygen range observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001019
+id: METPO:1001019
 name: obsolete oxygen delta observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001020
+id: METPO:1001020
 name: obsolete oxygen observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001021
+id: METPO:1001021
 name: obsolete temperature observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001022
+id: METPO:1001022
 name: obsolete NaCl observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001023
+id: METPO:1001023
 name: obsolete pH observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001101
+id: METPO:1001101
 name: biosafety level
 def: "A quality that categorizes biological agents according to their hazard level and required containment measures." []
 synonym: "biosafety level" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Safety information.risk assessment.biosafety level" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 
 [Term]
-id: metpo:1001102
+id: METPO:1001102
 name: biosafety level 1
 def: "A biosafety level that pose minimal potential hazard to laboratory workers and the environment, requiring only standard microbiological practices." []
 synonym: "1" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1001103
+id: METPO:1001103
 name: biosafety level 2
 def: "A biosafety level that pose moderate risk and are associated with human diseases present in the community." []
 synonym: "2" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1001104
+id: METPO:1001104
 name: biosafety level 3
 def: "A biosafety level that can cause serious or potentially lethal disease through inhalation or other routes, requiring specialized containment facilities with controlled access, directional airflow, and strict safety protocols." []
 synonym: "3" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "3**" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1001105
+id: METPO:1001105
 name: biosafety level 4
 def: "A biosafety level that pose extreme risk of life-threatening disease through aerosol transmission with no available treatment." []
 synonym: "4" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1001106
+id: METPO:1001106
 name: biosafety level 5
 def: "A biosafety level that is proposed as a classification beyond BSL-4 for hypothetical biological agents requiring enhanced containment." []
 synonym: "5" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1002000
+id: METPO:1002000
 name: obsolete Sulfate-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002001
+id: METPO:1002001
 name: obsolete Fe(III)-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002002
+id: METPO:1002002
 name: obsolete Mn(IV)-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002003
+id: METPO:1002003
 name: Cable bacteria metabolism
 def: "A metabolism in which electrons are transferred over centimeter-scale distances through multicellular filaments." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1002005
+id: METPO:1002005
 name: Fermentation
 def: "A metabolism in which energy is generated through the oxidation of organic compounds without using an external electron acceptor, using organic molecules as both electron donors and final electron acceptors." [] {IAO:0000119="GO:0006113"}
 synonym: "fermentation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "fermentation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1002006
+id: METPO:1002006
 name: Syntrophy
 def: "A metabolism in which the metabolism of one species is thermodynamically dependent on the removal of its products by another species." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1002007
+id: METPO:1002007
 name: obsolete Sulfur disproportionation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000806
+replaced_by: METPO:1000806
 
 [Term]
-id: metpo:1002008
+id: METPO:1002008
 name: obsolete Nitrogen fixation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1002009
+id: METPO:1002009
 name: obsolete Nitrate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002010
+id: METPO:1002010
 name: obsolete Anaerobic ammonium-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002011
+id: METPO:1002011
 name: obsolete Nitrous oxide-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002012
+id: METPO:1002012
 name: obsolete Sulfate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002013
+id: METPO:1002013
 name: obsolete Sulfur-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002014
+id: METPO:1002014
 name: obsolete Sulfite-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002015
+id: METPO:1002015
 name: obsolete Thiosulfate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002016
+id: METPO:1002016
 name: obsolete Sulfur-disproportionating
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002017
+id: METPO:1002017
 name: obsolete Sulfide-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002018
+id: METPO:1002018
 name: obsolete Thiosulfate-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002019
+id: METPO:1002019
 name: obsolete Sulfite-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002020
+id: METPO:1002020
 name: obsolete Iron-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002021
+id: METPO:1002021
 name: obsolete Iron-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002022
+id: METPO:1002022
 name: obsolete Nitrate-dependent Fe(II)-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002023
+id: METPO:1002023
 name: obsolete Manganese-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002024
+id: METPO:1002024
 name: obsolete Manganese-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002025
+id: METPO:1002025
 name: obsolete Uranium-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002026
+id: METPO:1002026
 name: obsolete Arsenate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002027
+id: METPO:1002027
 name: obsolete Selenate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002028
+id: METPO:1002028
 name: obsolete Selenite-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002029
+id: METPO:1002029
 name: obsolete Perchlorate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002030
+id: METPO:1002030
 name: obsolete Chlorate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002031
+id: METPO:1002031
 name: obsolete Bromate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002032
+id: METPO:1002032
 name: obsolete Iodate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002033
+id: METPO:1002033
 name: obsolete Hydrogen-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002034
+id: METPO:1002034
 name: obsolete Sulfur-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002035
+id: METPO:1002035
 name: obsolete Ammonia oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002036
+id: METPO:1002036
 name: obsolete Nitrite oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002037
+id: METPO:1002037
 name: obsolete Complete ammonia-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002038
+id: METPO:1002038
 name: obsolete Methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002039
+id: METPO:1002039
 name: obsolete Carbon monoxide-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002040
+id: METPO:1002040
 name: obsolete Nitrogen-fixing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1003000
+id: METPO:1003000
 name: pH growth preference
 def: "A phenotype that describes how the rate and extent of population growth are affected by environmental pH." [] {IAO:0000119="OMP:0005008"}
 synonym: "pH growth" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1003001
+id: METPO:1003001
 name: neutrophilic
 def: "A pH growth preference characterized by optimal growth at near-neutral pH values, typically between pH 6.5 and 7.5." [] {IAO:0000119="PATO:0070046", IAO:0000119="OMP:0005010"}
 synonym: "neutralophile" EXACT []
 synonym: "neutralophilic" EXACT []
 synonym: "neutrophile" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1003002
+id: METPO:1003002
 name: alkaliphilic
 def: "A pH growth preference in which an organism grows optimally at pH values above 9." [] {IAO:0000119="OMP:0005009", IAO:0000119="MICRO:0001549", IAO:0000119="OMP:0005010", IAO:0000119="ENVO:00002022", IAO:0000119="OMP:0005011"}
 synonym: "alkaliphile" EXACT []
 synonym: "alkaliphilic" EXACT []
 synonym: "alkalophile" EXACT []
 synonym: "alkalophilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003003
+id: METPO:1003003
 name: acidophilic
 def: "A pH growth preference in which an organism grows optimally at pH values below 5." [] {IAO:0000119="OMP:0007945", IAO:0000119="OMP:0005009", IAO:0000119="MICRO:0001549", IAO:0000119="OMP:0005010", IAO:0000119="OMP:0005011"}
 synonym: "acidophil" EXACT []
 synonym: "acidophile" EXACT []
 synonym: "acidophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003004
+id: METPO:1003004
 name: obligately alkaliphilic
 def: "An alkaliphilic phenotype in which an organism requires alkaline conditions (typically pH above 8.5) for growth and cannot grow at neutral or acidic pH." [] {IAO:0000119="OMP:0007947", IAO:0000119="ENVO:00002022", IAO:0000119="MICRO:0001565", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771"}
 synonym: "obligate alkaliphile" EXACT []
 synonym: "obligate alkaphilic" EXACT []
 synonym: "obligately alkaliphilic" EXACT []
-is_a: metpo:1003002 ! alkaliphilic
+is_a: METPO:1003002 ! alkaliphilic
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1003005
+id: METPO:1003005
 name: facultatively alkaliphilic
 def: "A pH growth preference in which an organism can grow at alkaline pH but does not require it." [] {IAO:0000119="MICRO:0001558", IAO:0000119="OMP:0005009", IAO:0000119="OMP:0007947", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771"}
 synonym: "facultative alkaliphile" EXACT []
 synonym: "facultative alkaphilic" EXACT []
 synonym: "facultatively alkaliphilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003006
+id: METPO:1003006
 name: obligately acidophilic
 def: "An acidophilic phenotype in which an organism requires acidic environments (pH below 5.5) for growth, with inability to grow at neutral or alkaline pH values." [] {IAO:0000119="MICRO:0001566"}
 synonym: "obligate acidophile" EXACT []
 synonym: "obligately acidophilic" EXACT []
-is_a: metpo:1003003 ! acidophilic
+is_a: METPO:1003003 ! acidophilic
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003007
+id: METPO:1003007
 name: facultatively acidophilic
 def: "A pH growth preference characterized by optimal growth in acidic environments (pH below 5.5) with the capacity to also grow at near-neutral pH values." [] {IAO:0000119="OMP:0007945", IAO:0000119="OMP:0007009", IAO:0000119="MICRO:0001557", IAO:0000119="OMP:0005009", IAO:0000119="OMP:0005010"}
 synonym: "facultative acidophile" EXACT []
 synonym: "facultatively acidophilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003008
+id: METPO:1003008
 name: acidotolerant
 def: "A pH growth preference characterized by the ability to tolerate acidic environments (typically pH below 5.5) while maintaining optimal growth near neutral pH." [] {IAO:0000119="MICRO:0001555"}
 synonym: "aciduric" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003009
+id: METPO:1003009
 name: alkalotolerant
 def: "A pH growth preference in which an organism can tolerate alkaline pH but grows optimally at neutral pH." [] {IAO:0000119="OMP:0005009", IAO:0000119="OMP:0007947", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771", IAO:0000119="OMP:0007011"}
 synonym: "alkalitolerant" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003021
+id: METPO:1003021
 name: pigmentation
 def: "A phenotype characterized by the color of pigments produced by a microorganism." [] {IAO:0000119="GO:0043473"}
 synonym: "cell color" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1003022
+id: METPO:1003022
 name: black pigmented
 synonym: "Pigment_black" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003023
+id: METPO:1003023
 name: brown pigmented
 synonym: "Pigment_brown" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003024
+id: METPO:1003024
 name: cream pigmented
 synonym: "Pigment_cream" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003025
+id: METPO:1003025
 name: green pigmented
 synonym: "Pigment_green" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003026
+id: METPO:1003026
 name: orange pigmented
 synonym: "Pigment_orange" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003027
+id: METPO:1003027
 name: pink pigmented
 synonym: "Pigment_pink" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003028
+id: METPO:1003028
 name: red pigmented
 synonym: "Pigment_red" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003029
+id: METPO:1003029
 name: white pigmented
 synonym: "Pigment_white" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003030
+id: METPO:1003030
 name: yellow pigmented
 synonym: "cell color: yellow pigment" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Pigment_yellow" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003031
+id: METPO:1003031
 name: carotenoid pigmentation
 synonym: "Pigment_carotenoid" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1004000
+id: METPO:1004000
 name: pathogenic to host
 def: "A phenotype where a microbe is a pathogen of of some host organism." [] {IAO:0000119="OMP:0000068", IAO:0000119="OMP:0007284"}
 synonym: "General.keywords" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "Safety information.risk assessment" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1004002
+id: METPO:1004002
 name: animal pathogen
 def: "A pathogen that infects organisms in the kingdom Metazoa." []
 synonym: "animal pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004003
+id: METPO:1004003
 name: plant pathogen
 def: "A pathogen that infects organisms in the kingdom Viridiplantae." []
 synonym: "plant pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004004
+id: METPO:1004004
 name: human pathogen
 def: "A pathogen that infects organisms of the species Homo sapiens." [] {IAO:0000119="IDO:0000639"}
 synonym: "human pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004005
+id: METPO:1004005
 name: growth medium
 def: "A material entity that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms." [] {IAO:0000119="OBI:0000079"}
 comment: This class is equivalent to OBI:0000079 'culture medium'. It is included in METPO to serve as the range for growth-related object properties.
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: skos:broadMatch https://biolink.github.io/biolink-model/ProcessedMaterial
 
 [Term]
-id: metpo:1005001
+id: METPO:1005001
 name: nitrification
 def: "A biological process in which ammonia is oxidized to nitrite (ammonia oxidation) and nitrite is oxidized to nitrate (nitrite oxidation), in two steps." [] {IAO:0000119="GO:0019332", IAO:0000119="GO:0019329"}
 comment: MetaTraits maps to OMIT:0027217 (wrong ontology). Correct GO terms are GO:0019329 (ammonia oxidation) and GO:0019332 (nitrite oxidation).
 synonym: "nitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005010
+id: METPO:1005010
 name: indole test
 def: "An assay that tests the ability of an organism to produce indole from tryptophan." [] {IAO:0000119="MICRO:0000430"}
 synonym: "indole test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005011
+id: METPO:1005011
 name: indole test positive
 def: "A phenotype in which an organism tests positive in the indole test, indicating it produces indole from tryptophan." []
 synonym: "indole test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005010 ! indole test
+is_a: METPO:1005010 ! indole test
 
 [Term]
-id: metpo:1005012
+id: METPO:1005012
 name: indole test negative
 def: "A phenotype in which an organism tests negative in the indole test, indicating it does not produce indole from tryptophan." []
-is_a: metpo:1005010 ! indole test
+is_a: METPO:1005010 ! indole test
 
 [Term]
-id: metpo:1005013
+id: METPO:1005013
 name: methyl red test
 def: "An assay that tests the ability of an organism to produce and maintain stable acid end products from glucose fermentation." [] {IAO:0000119="SNOMED:5894006"}
 synonym: "methyl red test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005014
+id: METPO:1005014
 name: methyl red test positive
 def: "A phenotype in which an organism tests positive in the methyl red test, indicating mixed acid fermentation." []
 synonym: "methyl red test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005013 ! methyl red test
+is_a: METPO:1005013 ! methyl red test
 
 [Term]
-id: metpo:1005015
+id: METPO:1005015
 name: methyl red test negative
 def: "A phenotype in which an organism tests negative in the methyl red test." []
-is_a: metpo:1005013 ! methyl red test
+is_a: METPO:1005013 ! methyl red test
 
 [Term]
-id: metpo:1005016
+id: METPO:1005016
 name: Voges-Proskauer test
 def: "An assay that tests the ability of an organism to produce acetoin from glucose via the butanediol fermentation pathway." [] {IAO:0000119="SNOMED:66592006"}
 synonym: "voges-proskauer test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005017
+id: METPO:1005017
 name: Voges-Proskauer test positive
 def: "A phenotype in which an organism tests positive in the Voges-Proskauer test, indicating acetoin production." []
 synonym: "voges-proskauer test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005016 ! Voges-Proskauer test
+is_a: METPO:1005016 ! Voges-Proskauer test
 
 [Term]
-id: metpo:1005018
+id: METPO:1005018
 name: Voges-Proskauer test negative
 def: "A phenotype in which an organism tests negative in the Voges-Proskauer test." []
-is_a: metpo:1005016 ! Voges-Proskauer test
+is_a: METPO:1005016 ! Voges-Proskauer test
 
 [Term]
-id: metpo:1005021
+id: METPO:1005021
 name: capnophilic
 def: "A phenotype describing an organism that requires elevated concentrations of carbon dioxide for growth." [] {IAO:0000119="SNOMED:413748004"}
 synonym: "capnophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1005025
+id: METPO:1005025
 name: hemolysis
 def: "A phenotype describing the ability of an organism to lyse red blood cells." [] {IAO:0000119="OMP:0005117"}
 synonym: "presence of hemolysis" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005026
+id: METPO:1005026
 name: hemolytic
 def: "A phenotype in which an organism is capable of lysing red blood cells." []
-is_a: metpo:1005025 ! hemolysis
+is_a: METPO:1005025 ! hemolysis
 
 [Term]
-id: metpo:1005027
+id: METPO:1005027
 name: non-hemolytic
 def: "A phenotype in which an organism does not lyse red blood cells." []
-is_a: metpo:1005025 ! hemolysis
+is_a: METPO:1005025 ! hemolysis
 
 [Term]
-id: metpo:1005031
+id: METPO:1005031
 name: peritrichous flagellation
 def: "A motility phenotype in which flagella are distributed over the entire cell surface." [] {IAO:0000119="OMP:0000078"}
 synonym: "flagellum arrangement" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005032
+id: METPO:1005032
 name: polar flagellation
 def: "A motility phenotype in which one or more flagella are located at one or both poles of the cell." []
 synonym: "flagellum arrangement" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005033
+id: METPO:1005033
 name: amphitrichous flagellation
 def: "A motility phenotype in which a single flagellum is present at each pole of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005034
+id: METPO:1005034
 name: lophotrichous flagellation
 def: "A motility phenotype in which a tuft of flagella is present at one or both poles of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005035
+id: METPO:1005035
 name: monotrichous flagellation
 def: "A motility phenotype in which a single flagellum is present at one pole of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005036
+id: METPO:1005036
 name: lateral flagellation
 def: "A motility phenotype in which flagella emerge from the lateral side of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005037
+id: METPO:1005037
 name: subpolar flagellation
 def: "A motility phenotype in which flagella are located near but not at the cell pole." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005038
+id: METPO:1005038
 name: denitrification
 def: "A biological process in which nitrate or nitrite is reduced to gaseous nitrogen compounds (NO, N2O, or N2) under anaerobic or microaerobic conditions." [] {IAO:0000119="GO:0019333"}
 synonym: "denitrification pathway" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005039
+id: METPO:1005039
 name: nitrogen fixation
 def: "A biological process in which atmospheric dinitrogen is reduced to ammonia, catalyzed by nitrogenase." [] {IAO:0000119="GO:0009399"}
 synonym: "nitrogen fixation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005040
+id: METPO:1005040
 name: generalist
 def: "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources." [] {IAO:0000119="inbio:000022"}
 synonym: "generalist" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1007005
+id: METPO:1007005
 name: flagellar arrangement
 def: "A phenotype characterized by the arrangement pattern of flagella on a bacterial or archaeal cell (e.g. peritrichous, polar, amphitrichous, lophotrichous, monotrichous, lateral, subpolar)." [] {IAO:0000119="OMP:0000078"}
 comment: subset=metpo_proposal_2026_04; priority=HIGH; xrefs=GO:0001539
 synonym: "flagellation pattern" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007006
+id: METPO:1007006
 name: polytrichous flagellation
 def: "A flagellar arrangement in which multiple flagella (typically a tuft) are present per cell, often combined with polar attachment." [] {IAO:0000119="MICRO:0000271"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; observations=4
 synonym: "polytrichous" EXACT []
-is_a: metpo:1007005 ! flagellar arrangement
+is_a: METPO:1007005 ! flagellar arrangement
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007062
+id: METPO:1007062
 name: colony morphology
 def: "A phenotype characterized by macroscopic colony characteristics such as shape, margin, elevation, surface, colour, and size." [] {IAO:0000119="OMP:0000100"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=PATO:0000052
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007063
+id: METPO:1007063
 name: colony shape
 def: "A colony morphology characterized by the overall macroscopic colony outline as observed on solid medium." [] {IAO:0000119="OMP:0000103"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=PATO:0000052
-is_a: metpo:1007062 ! colony morphology
+is_a: METPO:1007062 ! colony morphology
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007064
+id: METPO:1007064
 name: circular colony
 def: "A colony shape that has a regular round outline." [] {IAO:0000119="OMP:0000166"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=2649
 synonym: "round colony" EXACT []
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007065
+id: METPO:1007065
 name: irregular colony
 def: "A colony shape that has an irregular (non-round, non-rhizoid) outline." [] {IAO:0000119="OMP:0000167"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=148
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007066
+id: METPO:1007066
 name: filamentous colony
 def: "A colony shape that has a thread-like or filamentous outline." [] {IAO:0000119="OMP:0000088"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=16
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007067
+id: METPO:1007067
 name: punctiform colony
 def: "A colony shape that is very small (pinpoint), typically <1 mm in diameter." [] {IAO:0000119="OMP:0000240"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=11
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007068
+id: METPO:1007068
 name: rhizoid colony
 def: "A colony shape that has a branching, root-like outline." [] {IAO:0000119="OMP:0000168"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=8
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007069
+id: METPO:1007069
 name: fried-egg-shaped colony
 def: "A colony shape that has a raised opaque centre and a translucent peripheral zone, resembling a fried egg." [] {IAO:0000119="MICRO:0000349"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=6
 synonym: "fried-egg colony" EXACT []
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007070
+id: METPO:1007070
 name: pressure tolerance
 def: "A phenotype characterized by the ability to grow under elevated hydrostatic pressure." [] {IAO:0000119="OMP:0005012"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "barophile" EXACT []
 synonym: "piezophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007071
+id: METPO:1007071
 name: barophile phenotype
 def: "A pressure tolerance in which an organism requires or tolerates elevated hydrostatic pressure for growth." [] {IAO:0000119="MICRO:0001359"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
-is_a: metpo:1007070 ! pressure tolerance
+is_a: METPO:1007070 ! pressure tolerance
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007072
+id: METPO:1007072
 name: radiation tolerance
 def: "A phenotype characterized by the ability to withstand ionizing or UV radiation." [] {IAO:0000119="wikidata:Q2353022"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "radioresistant" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007073
+id: METPO:1007073
 name: osmotic tolerance
 def: "A phenotype characterized by the ability to grow under high osmotic pressure (non-NaCl)." [] {IAO:0000119="OMP:0005015"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "osmophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007074
+id: METPO:1007074
 name: metal tolerance
 def: "A phenotype characterized by the ability to grow in the presence of elevated metal concentrations." [] {IAO:0000119="OMP:0007890"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "metallophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007076
+id: METPO:1007076
 name: capsule presence
 def: "A phenotype characterized by the presence of an extracellular polysaccharide capsule." [] {IAO:0000119="OMP:0000203"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=GO:0042603
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007077
+id: METPO:1007077
 name: biofilm formation capability
 def: "A phenotype characterized by the ability to form surface-attached biofilms." [] {IAO:0000119="OMP:0000176"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0042710
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007080
+id: METPO:1007080
 name: catalase test
 def: "A biochemical test that detects catalase enzyme activity by exposing cells to hydrogen peroxide and observing for visible bubbling. The test outcome (positive or negative) is captured by its child classes; this class itself does not assert that the organism has catalase activity." [] {IAO:0000119="OMP:0000218"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "catalase activity test" EXACT []
 synonym: "catalase assay" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007081
+id: METPO:1007081
 name: oxidase test
 def: "A biochemical test that detects cytochrome c oxidase activity using a redox indicator. The test outcome (positive or negative) is captured by its child classes; this class itself does not assert oxidase activity." [] {IAO:0000119="OMP:0000220"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "cytochrome oxidase test" EXACT []
 synonym: "oxidase activity test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007082
+id: METPO:1007082
 name: urease test
 def: "A biochemical test that detects urease enzyme activity by observing urea hydrolysis (typically via a pH-indicator color change). The test outcome (positive or negative) is captured by its child classes; this class itself does not assert urease activity." [] {IAO:0000119="OMP:0000222"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "urea hydrolysis test" EXACT []
 synonym: "urease activity test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007083
+id: METPO:1007083
 name: catalase positive
 def: "Test-outcome phenotype where the catalase test yields a positive result (visible bubbling on H2O2). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0004096 'catalase activity'." [] {IAO:0000119="OMP:0000194"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0004096
 synonym: "catalase +" EXACT []
 synonym: "catalase test positive" EXACT []
-is_a: metpo:1007080 ! catalase test
+is_a: METPO:1007080 ! catalase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007084
+id: METPO:1007084
 name: catalase negative
 def: "Test-outcome phenotype where the catalase test yields a negative result (no bubbling on H2O2). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0004096 'catalase activity'." [] {IAO:0000119="OMP:0000198"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "catalase -" EXACT []
 synonym: "catalase test negative" EXACT []
-is_a: metpo:1007080 ! catalase test
+is_a: METPO:1007080 ! catalase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007085
+id: METPO:1007085
 name: oxidase positive
 def: "Test-outcome phenotype where the oxidase test yields a positive result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0004129 'cytochrome-c oxidase activity'." [] {IAO:0000119="OMP:0006085"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0004129
 synonym: "oxidase +" EXACT []
 synonym: "oxidase test positive" EXACT []
-is_a: metpo:1007081 ! oxidase test
+is_a: METPO:1007081 ! oxidase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007086
+id: METPO:1007086
 name: oxidase negative
 def: "Test-outcome phenotype where the oxidase test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0004129 'cytochrome-c oxidase activity'." [] {IAO:0000119="OMP:0006084"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "oxidase -" EXACT []
 synonym: "oxidase test negative" EXACT []
-is_a: metpo:1007081 ! oxidase test
+is_a: METPO:1007081 ! oxidase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007087
+id: METPO:1007087
 name: urease positive
 def: "Test-outcome phenotype where the urease test yields a positive result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0009039 'urease activity'." [] {IAO:0000119="OMP:0006089"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0009039
 synonym: "urease +" EXACT []
 synonym: "urease test positive" EXACT []
-is_a: metpo:1007082 ! urease test
+is_a: METPO:1007082 ! urease test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007088
+id: METPO:1007088
 name: urease negative
 def: "Test-outcome phenotype where the urease test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0009039 'urease activity'." [] {IAO:0000119="OMP:0006090"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "urease -" EXACT []
 synonym: "urease test negative" EXACT []
-is_a: metpo:1007082 ! urease test
+is_a: METPO:1007082 ! urease test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007089
+id: METPO:1007089
 name: coagulase activity
 def: "A phenotype characterized by coagulase enzyme activity (clotting of blood plasma); a diagnostic marker, e.g. for Staphylococcus aureus." [] {IAO:0000119="MICRO:0000991"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007090
+id: METPO:1007090
 name: coagulase positive
 def: "Test-outcome phenotype where the coagulase test yields a positive result (plasma clotting). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' <coagulase enzyme term> once a sufficiently specific enzyme term is selected (no GO/EC term currently exists at the bacteriological coagulase test granularity)." [] {IAO:0000119="wikidata:Q98095684"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase +" EXACT []
 synonym: "coagulase test positive" EXACT []
-is_a: metpo:1007089 ! coagulase activity
+is_a: METPO:1007089 ! coagulase activity
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007091
+id: METPO:1007091
 name: coagulase negative
 def: "Test-outcome phenotype where the coagulase test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' <coagulase enzyme term> once a sufficiently specific enzyme term is selected." [] {IAO:0000119="wikidata:Q98095684"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase -" EXACT []
 synonym: "coagulase test negative" EXACT []
-is_a: metpo:1007089 ! coagulase activity
+is_a: METPO:1007089 ! coagulase activity
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007092
+id: METPO:1007092
 name: xerophilic phenotype
 def: "A phenotype characterized by a microbe that thrives in low water-activity environments (typically aw < 0.85), where the limiting factor is water activity (aw) rather than solute concentration; distinct from halophily and osmotic tolerance." [] {IAO:0000119="wikidata:Q980491"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "xerophile" EXACT []
 synonym: "xerotolerant" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007093
+id: METPO:1007093
 name: epibiont phenotype
 def: "A phenotype characterized by a microbe that lives on the external surface of a host organism or substrate, as distinct from endosymbionts (which live inside the host); captures host-association mode, not specific host taxonomy." [] {IAO:0000119="wikidata:Q640114"}
 comment: subset=metpo_proposal_2026_04; priority=LOW
 synonym: "ectosymbiont" EXACT []
 synonym: "epibiont" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:9999999
+id: METPO:9999999
 name: obsolete obsolete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
@@ -10881,814 +10881,814 @@ id: oboInOwl:ObsoleteClass
 name: Obsolete Class
 
 [Typedef]
-id: metpo:2000000
+id: METPO:2000000
 name: obsolete has susceptibility profile
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000001
+id: METPO:2000001
 name: organism interacts with chemical
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000002
+id: METPO:2000002
 name: assimilates
 synonym: "assimilation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000003
+id: METPO:2000003
 name: builds acid from
 synonym: "builds acid from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000004
+id: METPO:2000004
 name: builds base from
 synonym: "builds base from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000005
+id: METPO:2000005
 name: builds gas from
 synonym: "builds gas from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000006
+id: METPO:2000006
 name: uses as carbon source
 synonym: "carbon source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000007
+id: METPO:2000007
 name: degrades
 synonym: "degradation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000008
+id: METPO:2000008
 name: uses as electron acceptor
 synonym: "electron acceptor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000009
+id: METPO:2000009
 name: uses as electron donor
 synonym: "electron donor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000010
+id: METPO:2000010
 name: uses as energy source
 synonym: "energy source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000011
+id: METPO:2000011
 name: ferments
 synonym: "fermentation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000012
+id: METPO:2000012
 name: uses for growth
 synonym: "growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000013
+id: METPO:2000013
 name: hydrolyzes
 synonym: "hydrolysis" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000014
+id: METPO:2000014
 name: uses as nitrogen source
 synonym: "nitrogen source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000015
+id: METPO:2000015
 name: uses in other way
 synonym: "other" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "utilizes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000016
+id: METPO:2000016
 name: oxidizes
 synonym: "oxidation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000017
+id: METPO:2000017
 name: reduces
 synonym: "reduction" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000018
+id: METPO:2000018
 name: requires for growth
 synonym: "required for growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000019
+id: METPO:2000019
 name: uses for respiration
 synonym: "respiration" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000020
+id: METPO:2000020
 name: uses as sulfur source
 synonym: "sulfur source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000021
+id: METPO:2000021
 name: does not use for aerobic catabolization
 synonym: "aerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000022
+id: METPO:2000022
 name: does not use for aerobic growth
 synonym: "aerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000023
+id: METPO:2000023
 name: does not use for anaerobic catabolization
 synonym: "anaerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000024
+id: METPO:2000024
 name: does not use for anaerobic growth
 synonym: "anaerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000025
+id: METPO:2000025
 name: does not use for anaerobic growth in the dark
 synonym: "anaerobic growth in the dark" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000026
+id: METPO:2000026
 name: does not use for anaerobic growth with light
 synonym: "anaerobic growth with light" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000027
+id: METPO:2000027
 name: does not assimilate
 synonym: "assimilation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000028
+id: METPO:2000028
 name: does not build acid from
 synonym: "builds acid from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000029
+id: METPO:2000029
 name: does not build base from
 synonym: "builds base from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000030
+id: METPO:2000030
 name: does not build gas from
 synonym: "builds gas from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000031
+id: METPO:2000031
 name: does not use as carbon source
 synonym: "carbon source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000032
+id: METPO:2000032
 name: uses for aerobic catabolization
 synonym: "aerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000033
+id: METPO:2000033
 name: does not degrade
 synonym: "degradation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000034
+id: METPO:2000034
 name: does not use as electron acceptor
 synonym: "electron acceptor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000035
+id: METPO:2000035
 name: does not use as electron donor
 synonym: "electron donor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000036
+id: METPO:2000036
 name: does not use as energy source
 synonym: "energy source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000037
+id: METPO:2000037
 name: does not ferment
 synonym: "fermentation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000038
+id: METPO:2000038
 name: does not use for growth
 synonym: "growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000039
+id: METPO:2000039
 name: does not hydrolyze
 synonym: "hydrolysis" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000040
+id: METPO:2000040
 name: does not use as nitrogen source
 synonym: "nitrogen source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000041
+id: METPO:2000041
 name: does not use in other way
 synonym: "other" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "utilizes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000042
+id: METPO:2000042
 name: does not oxidize
 synonym: "oxidation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000043
+id: METPO:2000043
 name: uses for aerobic growth
 synonym: "aerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000044
+id: METPO:2000044
 name: does not reduce
 synonym: "reduction" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000045
+id: METPO:2000045
 name: is not required for growth
 synonym: "required for growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000046
+id: METPO:2000046
 name: does not use for respiration
 synonym: "respiration" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000047
+id: METPO:2000047
 name: does not use as sulfur source
 synonym: "sulfur source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000048
+id: METPO:2000048
 name: uses for anaerobic catabolization
 synonym: "anaerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000049
+id: METPO:2000049
 name: uses for anaerobic growth
 synonym: "anaerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000050
+id: METPO:2000050
 name: uses for anaerobic growth in the dark
 synonym: "anaerobic growth in the dark" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000051
+id: METPO:2000051
 name: uses for anaerobic growth with light
 synonym: "anaerobic growth with light" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000052
+id: METPO:2000052
 name: obsolete has temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000053
+id: METPO:2000053
 name: obsolete has optimum temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000054
+id: METPO:2000054
 name: obsolete has growth temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000055
+id: METPO:2000055
 name: obsolete has range temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000056
+id: METPO:2000056
 name: obsolete has temperature delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000057
+id: METPO:2000057
 name: obsolete has culture temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000064
+id: METPO:2000064
 name: tolerates
 def: "A relation between a microbe and a chemical entity indicating that the microbe's growth is not inhibited by the chemical at the concentration tested. Positive form of the chemical-tolerance pair; the negative form is METPO:2000065 'does not tolerate'." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000065
+id: METPO:2000065
 name: does not tolerate
 def: "A relation between a microbe and a chemical entity indicating that the microbe's growth is inhibited by the chemical at the concentration tested. Negative form of the chemical-tolerance pair; positive form is METPO:2000064 'tolerates'. Equivalent in meaning to 'is susceptible to' and 'is sensitive to'; the canonical label uses the 'does not X' convention so the metatraits pairing logic auto-detects it as the negative member." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000067
+id: METPO:2000067
 name: isolated from host with quality
 def: "A relation between a microbe and a quality of the host from which the microbe was isolated. Examples: a microbe isolated from a juvenile host has the relation `<microbe> METPO:2000067 PATO:0001190 'juvenile'`; a microbe isolated from a female host has the relation `<microbe> METPO:2000067 PATO:0000383 'female'`. The relation is one-directional: it asserts that the host bore the named quality at isolation time, not that the microbe itself has the quality." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000068
+id: METPO:2000068
 name: isolated from environment with quality
 def: "A relation between a microbe and a quality of the environment from which the microbe was isolated. Examples: a microbe isolated from an acidic environment has the relation `<microbe> METPO:2000068 PATO:0001429 'acidic'`; a microbe isolated from an anaerobic environment has `<microbe> METPO:2000068 PATO:0001456 'anaerobic'`. The relation does not by itself entail that the microbe is acidophilic, anaerobic, etc. as a phenotype; it only records the environment's quality at the time of isolation. Microbe phenotype assertions belong on a separate edge (e.g. METPO:1000615 acidophilic via has_phenotype)." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000101
+id: METPO:2000101
 name: has quality
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000102
+id: METPO:2000102
 name: has phenotype
 property_value: skos:closeMatch has:phenotype
-domain: metpo:1000525 ! microbe
-range: metpo:1000059 ! phenotype
-is_a: metpo:2000101 ! has quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000059 ! phenotype
+is_a: METPO:2000101 ! has quality
 
 [Typedef]
-id: metpo:2000103
+id: METPO:2000103
 name: capable of
 property_value: skos:closeMatch capable:of
-domain: metpo:1000525 ! microbe
-range: metpo:1000630 ! biological process
+domain: METPO:1000525 ! microbe
+range: METPO:1000630 ! biological process
 
 [Typedef]
-id: metpo:2000200
+id: METPO:2000200
 name: disproportionates
 synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000201
+id: METPO:2000201
 name: obsolete lyses
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000202
+id: METPO:2000202
 name: produces
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000203
+id: METPO:2000203
 name: obsolete fixes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000204
+id: METPO:2000204
 name: obsolete catabolizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000205
+id: METPO:2000205
 name: obsolete mineralizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000206
+id: METPO:2000206
 name: obsolete conjugates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000207
+id: METPO:2000207
 name: transports
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000208
+id: METPO:2000208
 name: imports
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000207 ! transports
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000207 ! transports
 
 [Typedef]
-id: metpo:2000209
+id: METPO:2000209
 name: exports
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000207 ! transports
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000207 ! transports
 
 [Typedef]
-id: metpo:2000210
+id: METPO:2000210
 name: accumulates
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000211
+id: METPO:2000211
 name: sequesters
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000210 ! accumulates
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000210 ! accumulates
 
 [Typedef]
-id: metpo:2000212
+id: METPO:2000212
 name: compartmentalizes
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000210 ! accumulates
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000210 ! accumulates
 
 [Typedef]
-id: metpo:2000213
+id: METPO:2000213
 name: obsolete binds
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000214
+id: METPO:2000214
 name: obsolete chelates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000215
+id: METPO:2000215
 name: obsolete precipitates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000216
+id: METPO:2000216
 name: obsolete solubilizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000217
+id: METPO:2000217
 name: obsolete volatilizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000218
+id: METPO:2000218
 name: obsolete crystallizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000219
+id: METPO:2000219
 name: obsolete adsorbs
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000220
+id: METPO:2000220
 name: does not disproportionate
 synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000221
+id: METPO:2000221
 name: obsolete does not lyse
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000222
+id: METPO:2000222
 name: does not produce
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000223
+id: METPO:2000223
 name: obsolete does not fix
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000224
+id: METPO:2000224
 name: obsolete does not catabolize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000225
+id: METPO:2000225
 name: obsolete does not mineralize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000226
+id: METPO:2000226
 name: obsolete does not conjugate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000227
+id: METPO:2000227
 name: does not transport
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000228
+id: METPO:2000228
 name: does not import
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000227 ! does not transport
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000227 ! does not transport
 
 [Typedef]
-id: metpo:2000229
+id: METPO:2000229
 name: does not export
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000227 ! does not transport
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000227 ! does not transport
 
 [Typedef]
-id: metpo:2000230
+id: METPO:2000230
 name: does not accumulate
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000231
+id: METPO:2000231
 name: does not sequester
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000230 ! does not accumulate
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000230 ! does not accumulate
 
 [Typedef]
-id: metpo:2000232
+id: METPO:2000232
 name: does not compartmentalize
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000230 ! does not accumulate
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000230 ! does not accumulate
 
 [Typedef]
-id: metpo:2000233
+id: METPO:2000233
 name: obsolete does not bind
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000234
+id: METPO:2000234
 name: obsolete does not chelate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000235
+id: METPO:2000235
 name: obsolete does not precipitate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000236
+id: METPO:2000236
 name: obsolete does not solubilize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000237
+id: METPO:2000237
 name: obsolete does not volatilize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000238
+id: METPO:2000238
 name: obsolete does not crystallize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000239
+id: METPO:2000239
 name: obsolete has pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000301
+id: METPO:2000301
 name: enzyme activity analyzed
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
 
 [Typedef]
-id: metpo:2000302
+id: METPO:2000302
 name: shows activity of
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
-is_a: metpo:2000301 ! enzyme activity analyzed
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
+is_a: METPO:2000301 ! enzyme activity analyzed
 
 [Typedef]
-id: metpo:2000303
+id: METPO:2000303
 name: does not show activity of
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
-is_a: metpo:2000301 ! enzyme activity analyzed
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
+is_a: METPO:2000301 ! enzyme activity analyzed
 
 [Typedef]
-id: metpo:2000501
+id: METPO:2000501
 name: obsolete has optimum pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000502
+id: METPO:2000502
 name: obsolete has growth pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000503
+id: METPO:2000503
 name: obsolete has range pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000504
+id: METPO:2000504
 name: obsolete has pH delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000505
+id: METPO:2000505
 name: obsolete has culture pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000506
+id: METPO:2000506
 name: obsolete has NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000507
+id: METPO:2000507
 name: obsolete has optimum NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000508
+id: METPO:2000508
 name: obsolete has growth NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000509
+id: METPO:2000509
 name: obsolete has range NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000510
+id: METPO:2000510
 name: obsolete has NaCl delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000511
+id: METPO:2000511
 name: obsolete has observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000512
+id: METPO:2000512
 name: obsolete has oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000513
+id: METPO:2000513
 name: obsolete has optimum oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000514
+id: METPO:2000514
 name: obsolete has growth oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000515
+id: METPO:2000515
 name: obsolete has range oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000516
+id: METPO:2000516
 name: obsolete has oxygen delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000517
+id: METPO:2000517
 name: grows in
 def: "A relation between a microbe and a growth medium indicating that the microbe has been demonstrated to grow in that medium under some set of conditions. This relation represents a generalization from experimental observations reported in the literature or databases; it does not imply that the microbe will grow in the medium under all conditions." []
-domain: metpo:1000525 ! microbe
-range: metpo:1004005 ! growth medium
+domain: METPO:1000525 ! microbe
+range: METPO:1004005 ! growth medium
 
 [Typedef]
-id: metpo:2000518
+id: METPO:2000518
 name: does not grow in
 def: "A relation between a microbe and a growth medium indicating that the microbe has been demonstrated to fail to grow in that medium under some set of conditions. This relation represents a generalization from experimental observations reported in the literature or databases; it does not imply that the microbe cannot grow in the medium under any conditions." []
-domain: metpo:1000525 ! microbe
-range: metpo:1004005 ! growth medium
+domain: METPO:1000525 ! microbe
+range: METPO:1004005 ! growth medium
 
 [Typedef]
-id: metpo:2000601
+id: METPO:2000601
 name: denitrifies
 synonym: "denitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000602
+id: METPO:2000602
 name: does not denitrify
 synonym: "denitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000603
+id: METPO:2000603
 name: ammonifies
 synonym: "ammonification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000604
+id: METPO:2000604
 name: does not ammonify
 synonym: "ammonification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000605
+id: METPO:2000605
 name: oxidizes in darkness
 synonym: "oxidation in darkness" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000606
+id: METPO:2000606
 name: does not oxidize in darkness
 synonym: "oxidation in darkness" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 

--- a/metpo-full.owl
+++ b/metpo-full.owl
@@ -10,7 +10,7 @@
      xmlns:qudt="http://qudt.org/schema/qudt/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-     xmlns:metpo="https://w3id.org/metpo/"
+     xmlns:METPO="https://w3id.org/metpo/"
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="https://w3id.org/metpo/metpo-full.owl">
@@ -13876,7 +13876,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_&lt;=42.65</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC low</rdfs:label>
-        <metpo:range_max>42.65</metpo:range_max>
+        <METPO:range_max>42.65</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000429"/>
@@ -13916,8 +13916,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_42.65_57.0</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC mid1</rdfs:label>
-        <metpo:range_max>57</metpo:range_max>
-        <metpo:range_min>42.65</metpo:range_min>
+        <METPO:range_max>57</METPO:range_max>
+        <METPO:range_min>42.65</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000430"/>
@@ -13957,8 +13957,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_57.0_66.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC mid2</rdfs:label>
-        <metpo:range_max>66.3</metpo:range_max>
-        <metpo:range_min>57</metpo:range_min>
+        <METPO:range_max>66.3</METPO:range_max>
+        <METPO:range_min>57</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000431"/>
@@ -13995,7 +13995,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_&gt;66.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC high</rdfs:label>
-        <metpo:range_min>66.3</metpo:range_min>
+        <METPO:range_min>66.3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000432"/>
@@ -14130,7 +14130,7 @@
         <oboInOwl:hasExactSynonym>Psychrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_&lt;=10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum very low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
+        <METPO:range_max>10</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000441"/>
@@ -14173,8 +14173,8 @@
         <oboInOwl:hasExactSynonym>Psychrotolerant</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_10_to_22</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum low</rdfs:label>
-        <metpo:range_max>22</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>22</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000442"/>
@@ -14216,8 +14216,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid1</rdfs:label>
-        <metpo:range_max>27</metpo:range_max>
-        <metpo:range_min>22</metpo:range_min>
+        <METPO:range_max>27</METPO:range_max>
+        <METPO:range_min>22</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000443"/>
@@ -14259,8 +14259,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>27</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>27</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000444"/>
@@ -14302,8 +14302,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid3</rdfs:label>
-        <metpo:range_max>34</metpo:range_max>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_max>34</METPO:range_max>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000445"/>
@@ -14345,8 +14345,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid4</rdfs:label>
-        <metpo:range_max>40</metpo:range_max>
-        <metpo:range_min>34</metpo:range_min>
+        <METPO:range_max>40</METPO:range_max>
+        <METPO:range_min>34</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000446"/>
@@ -14385,7 +14385,7 @@
         <oboInOwl:hasExactSynonym>Thermophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_&gt;40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum high</rdfs:label>
-        <metpo:range_min>40</metpo:range_min>
+        <METPO:range_min>40</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000447"/>
@@ -14424,7 +14424,7 @@
         <oboInOwl:hasExactSynonym>Psychrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_&lt;=10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range very low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
+        <METPO:range_max>10</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000448"/>
@@ -14467,8 +14467,8 @@
         <oboInOwl:hasExactSynonym>Psychrotolerant</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_10_to_22</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range low</rdfs:label>
-        <metpo:range_max>22</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>22</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000449"/>
@@ -14510,8 +14510,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid1</rdfs:label>
-        <metpo:range_max>27</metpo:range_max>
-        <metpo:range_min>22</metpo:range_min>
+        <METPO:range_max>27</METPO:range_max>
+        <METPO:range_min>22</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000450"/>
@@ -14553,8 +14553,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>27</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>27</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000451"/>
@@ -14596,8 +14596,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid3</rdfs:label>
-        <metpo:range_max>34</metpo:range_max>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_max>34</METPO:range_max>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000452"/>
@@ -14639,8 +14639,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid4</rdfs:label>
-        <metpo:range_max>40</metpo:range_max>
-        <metpo:range_min>34</metpo:range_min>
+        <METPO:range_max>40</METPO:range_max>
+        <METPO:range_min>34</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000453"/>
@@ -14679,7 +14679,7 @@
         <oboInOwl:hasExactSynonym>Thermophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_&gt;40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range high</rdfs:label>
-        <metpo:range_min>40</metpo:range_min>
+        <METPO:range_min>40</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000454"/>
@@ -14724,8 +14724,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_0_to_6</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum low</rdfs:label>
-        <metpo:range_max>6</metpo:range_max>
-        <metpo:range_min>0</metpo:range_min>
+        <METPO:range_max>6</METPO:range_max>
+        <METPO:range_min>0</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000455"/>
@@ -14767,8 +14767,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_6_to_7</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum mid1</rdfs:label>
-        <metpo:range_max>7</metpo:range_max>
-        <metpo:range_min>6</metpo:range_min>
+        <METPO:range_max>7</METPO:range_max>
+        <METPO:range_min>6</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000456"/>
@@ -14811,8 +14811,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_7_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>7</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>7</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000457"/>
@@ -14855,8 +14855,8 @@
         <oboInOwl:hasExactSynonym>Extreme Alkaliphile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_8_to_14</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum high</rdfs:label>
-        <metpo:range_max>14</metpo:range_max>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_max>14</METPO:range_max>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000458"/>
@@ -14901,8 +14901,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_0_to_4</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range very low</rdfs:label>
-        <metpo:range_max>4</metpo:range_max>
-        <metpo:range_min>0</metpo:range_min>
+        <METPO:range_max>4</METPO:range_max>
+        <METPO:range_min>0</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000459"/>
@@ -14946,8 +14946,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_4_to_6</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range low</rdfs:label>
-        <metpo:range_max>6</metpo:range_max>
-        <metpo:range_min>4</metpo:range_min>
+        <METPO:range_max>6</METPO:range_max>
+        <METPO:range_min>4</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000460"/>
@@ -14990,8 +14990,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_6_to_7</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid1</rdfs:label>
-        <metpo:range_max>7</metpo:range_max>
-        <metpo:range_min>6</metpo:range_min>
+        <METPO:range_max>7</METPO:range_max>
+        <METPO:range_min>6</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000461"/>
@@ -15035,8 +15035,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_7_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>7</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>7</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000462"/>
@@ -15080,8 +15080,8 @@
         <oboInOwl:hasExactSynonym>Facultative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_8_to_10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid3</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_max>10</METPO:range_max>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000463"/>
@@ -15124,8 +15124,8 @@
         <oboInOwl:hasExactSynonym>Extreme Alkaliphile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>10_to_14</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range high</rdfs:label>
-        <metpo:range_max>14</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>14</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000464"/>
@@ -15165,7 +15165,7 @@
         <oboInOwl:hasExactSynonym>Non-halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000465"/>
@@ -15208,8 +15208,8 @@
         <oboInOwl:hasExactSynonym>Slight halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_1_to_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000466"/>
@@ -15252,8 +15252,8 @@
         <oboInOwl:hasExactSynonym>Moderate halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_3_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000467"/>
@@ -15292,7 +15292,7 @@
         <oboInOwl:hasExactSynonym>Extreme halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000468"/>
@@ -15332,7 +15332,7 @@
         <oboInOwl:hasExactSynonym>Non-halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000469"/>
@@ -15375,8 +15375,8 @@
         <oboInOwl:hasExactSynonym>Slight halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_1_to_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000470"/>
@@ -15419,8 +15419,8 @@
         <oboInOwl:hasExactSynonym>Moderate halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_3_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000471"/>
@@ -15459,7 +15459,7 @@
         <oboInOwl:hasExactSynonym>Extreme halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000472"/>
@@ -15496,7 +15496,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta very low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000473"/>
@@ -15536,8 +15536,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_1_2</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta low</rdfs:label>
-        <metpo:range_max>2</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>2</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000474"/>
@@ -15577,8 +15577,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_2_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>2</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>2</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000475"/>
@@ -15618,8 +15618,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_3_4</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid2</rdfs:label>
-        <metpo:range_max>4</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>4</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000476"/>
@@ -15659,8 +15659,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_4_5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid3</rdfs:label>
-        <metpo:range_max>5</metpo:range_max>
-        <metpo:range_min>4</metpo:range_min>
+        <METPO:range_max>5</METPO:range_max>
+        <METPO:range_min>4</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000477"/>
@@ -15700,8 +15700,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_5_9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta high</rdfs:label>
-        <metpo:range_max>9</metpo:range_max>
-        <metpo:range_min>5</metpo:range_min>
+        <METPO:range_max>9</METPO:range_max>
+        <METPO:range_min>5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000478"/>
@@ -15739,7 +15739,7 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000479"/>
@@ -15780,8 +15780,8 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_1_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000480"/>
@@ -15822,8 +15822,8 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_3_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000481"/>
@@ -15861,7 +15861,7 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000482"/>
@@ -15902,8 +15902,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_1_5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta very low</rdfs:label>
-        <metpo:range_max>5</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>5</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000483"/>
@@ -15944,8 +15944,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_5_10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
-        <metpo:range_min>5</metpo:range_min>
+        <METPO:range_max>10</METPO:range_max>
+        <METPO:range_min>5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000484"/>
@@ -15986,8 +15986,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_10_20</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta mid1</rdfs:label>
-        <metpo:range_max>20</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>20</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000485"/>
@@ -16028,8 +16028,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_20_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>20</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>20</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000486"/>
@@ -16067,7 +16067,7 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_&gt;30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta high</rdfs:label>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000487"/>
@@ -20603,7 +20603,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_&lt;=1.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length very small</rdfs:label>
-        <metpo:range_max>1.3</metpo:range_max>
+        <METPO:range_max>1.3</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000883"/>
@@ -20644,8 +20644,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_1.3_2</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length small</rdfs:label>
-        <metpo:range_max>2</metpo:range_max>
-        <metpo:range_min>1.3</metpo:range_min>
+        <METPO:range_max>2</METPO:range_max>
+        <METPO:range_min>1.3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000884"/>
@@ -20686,8 +20686,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_2_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length medium</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>2</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>2</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000885"/>
@@ -20725,7 +20725,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_&gt;3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length large</rdfs:label>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000886"/>
@@ -20763,7 +20763,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_&lt;=0.5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width very small</rdfs:label>
-        <metpo:range_max>0.5</metpo:range_max>
+        <METPO:range_max>0.5</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000887"/>
@@ -20804,8 +20804,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_0.5_0.65</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width small</rdfs:label>
-        <metpo:range_max>0.65</metpo:range_max>
-        <metpo:range_min>0.5</metpo:range_min>
+        <METPO:range_max>0.65</METPO:range_max>
+        <METPO:range_min>0.5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000888"/>
@@ -20846,8 +20846,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_0.65_0.9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width medium</rdfs:label>
-        <metpo:range_max>0.9</metpo:range_max>
-        <metpo:range_min>0.65</metpo:range_min>
+        <METPO:range_max>0.9</METPO:range_max>
+        <METPO:range_min>0.65</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000889"/>
@@ -20885,7 +20885,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_&gt;0.9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width large</rdfs:label>
-        <metpo:range_min>0.9</metpo:range_min>
+        <METPO:range_min>0.9</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000890"/>

--- a/metpo.obo
+++ b/metpo.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
 data-version: https://w3id.org/metpo/releases/2026-06-12/metpo.owl
 idspace: dcterms http://purl.org/dc/terms/ 
-idspace: metpo https://w3id.org/metpo/ 
+idspace: METPO https://w3id.org/metpo/ 
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
 idspace: qudt http://qudt.org/schema/qudt/ 
 idspace: skos http://www.w3.org/2004/02/skos/core# 
@@ -18,7566 +18,7566 @@ property_value: seeAlso https://bioregistry.io/registry/metpo
 property_value: seeAlso https://github.com/berkeleybop/metpo
 
 [Term]
-id: metpo:0000001
+id: METPO:0000001
 name: obsolete Temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000002
+id: METPO:0000002
 name: obsolete Salinity
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000003
+id: METPO:0000003
 name: obsolete pH
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000004
+id: METPO:0000004
 name: obsolete Oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000005
+id: METPO:0000005
 name: obsolete Trophic type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000631
+replaced_by: METPO:1000631
 
 [Term]
-id: metpo:0000006
+id: METPO:0000006
 name: obsolete Motility
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000701
+replaced_by: METPO:1000701
 
 [Term]
-id: metpo:0000007
+id: METPO:0000007
 name: obsolete Sporulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:0000008
+id: METPO:0000008
 name: obsolete Pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000009
+id: METPO:0000009
 name: obsolete GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:000001
+id: METPO:000001
 name: obsolete Temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000010
+id: METPO:0000010
 name: obsolete Cell Width
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000011
+id: METPO:0000011
 name: obsolete Cell Length
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000012
+id: METPO:0000012
 name: obsolete Temperature Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000304
+replaced_by: METPO:1000304
 
 [Term]
-id: metpo:0000013
+id: METPO:0000013
 name: obsolete Temperature Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000306
+replaced_by: METPO:1000306
 
 [Term]
-id: metpo:0000014
+id: METPO:0000014
 name: obsolete pH Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000331
+replaced_by: METPO:1000331
 
 [Term]
-id: metpo:0000015
+id: METPO:0000015
 name: obsolete pH Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000332
+replaced_by: METPO:1000332
 
 [Term]
-id: metpo:0000016
+id: METPO:0000016
 name: obsolete NaCl Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000333
+replaced_by: METPO:1000333
 
 [Term]
-id: metpo:0000017
+id: METPO:0000017
 name: obsolete NaCl Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000334
+replaced_by: METPO:1000334
 
 [Term]
-id: metpo:0000018
+id: METPO:0000018
 name: obsolete pH delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000232
+replaced_by: METPO:1000232
 
 [Term]
-id: metpo:0000019
+id: METPO:0000019
 name: obsolete NaCl delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000335
+replaced_by: METPO:1000335
 
 [Term]
-id: metpo:000002
+id: METPO:000002
 name: obsolete Salinity
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000020
+id: METPO:0000020
 name: obsolete Temperature Delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000303
+replaced_by: METPO:1000303
 
 [Term]
-id: metpo:0000021
+id: METPO:0000021
 name: obsolete METPO Morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000022
+id: METPO:0000022
 name: obsolete Psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:0000023
+id: METPO:0000023
 name: obsolete Psychrotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:0000024
+id: METPO:0000024
 name: obsolete Mesophilie
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000025
+id: METPO:0000025
 name: obsolete Thermotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:0000026
+id: METPO:0000026
 name: obsolete Thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:0000027
+id: METPO:0000027
 name: obsolete Extreme thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:0000028
+id: METPO:0000028
 name: obsolete Hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:0000029
+id: METPO:0000029
 name: obsolete Extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:000003
+id: METPO:000003
 name: obsolete pH
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000030
+id: METPO:0000030
 name: obsolete Halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:0000031
+id: METPO:0000031
 name: obsolete Non-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:0000032
+id: METPO:0000032
 name: obsolete Slight halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:0000033
+id: METPO:0000033
 name: obsolete Moderate halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:0000034
+id: METPO:0000034
 name: obsolete Extreme halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:0000035
+id: METPO:0000035
 name: obsolete Halotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:0000036
+id: METPO:0000036
 name: obsolete Haloalkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:0000037
+id: METPO:0000037
 name: obsolete Extreme Acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000038
+id: METPO:0000038
 name: obsolete Acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:0000039
+id: METPO:0000039
 name: obsolete Neutrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:000004
+id: METPO:000004
 name: obsolete Oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000040
+id: METPO:0000040
 name: obsolete Alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:0000041
+id: METPO:0000041
 name: obsolete Acid Tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000042
+id: METPO:0000042
 name: obsolete Alkali Tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000043
+id: METPO:0000043
 name: obsolete Extreme Alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000044
+id: METPO:0000044
 name: obsolete Facultative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:0000045
+id: METPO:0000045
 name: obsolete Obligative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:0000046
+id: METPO:0000046
 name: obsolete Aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000047
+id: METPO:0000047
 name: obsolete Anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:0000048
+id: METPO:0000048
 name: obsolete Facultative anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:0000049
+id: METPO:0000049
 name: obsolete Facultative aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:000005
+id: METPO:000005
 name: obsolete Trophic type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000631
+replaced_by: METPO:1000631
 
 [Term]
-id: metpo:0000050
+id: METPO:0000050
 name: obsolete Microaerophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:0000051
+id: METPO:0000051
 name: obsolete Aerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:0000052
+id: METPO:0000052
 name: obsolete Microaerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:0000053
+id: METPO:0000053
 name: obsolete Aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000054
+id: METPO:0000054
 name: obsolete Obligate aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:0000055
+id: METPO:0000055
 name: obsolete Obligate anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:0000056
+id: METPO:0000056
 name: obsolete Oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000057
+id: METPO:0000057
 name: obsolete Anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000058
+id: METPO:0000058
 name: obsolete Autotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:0000059
+id: METPO:0000059
 name: obsolete Photoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:000006
+id: METPO:000006
 name: obsolete Motility
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000701
+replaced_by: METPO:1000701
 
 [Term]
-id: metpo:0000060
+id: METPO:0000060
 name: obsolete Chemoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:0000061
+id: METPO:0000061
 name: obsolete Heterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:0000062
+id: METPO:0000062
 name: obsolete Photoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:0000063
+id: METPO:0000063
 name: obsolete Chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:0000064
+id: METPO:0000064
 name: obsolete Lithotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:0000065
+id: METPO:0000065
 name: obsolete Organotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:0000066
+id: METPO:0000066
 name: obsolete Phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:0000067
+id: METPO:0000067
 name: obsolete Chemotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:0000068
+id: METPO:0000068
 name: obsolete Oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:0000069
+id: METPO:0000069
 name: obsolete Copiotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:000007
+id: METPO:000007
 name: obsolete Sporulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:0000070
+id: METPO:0000070
 name: obsolete Lithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:0000071
+id: METPO:0000071
 name: obsolete Mixotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:0000072
+id: METPO:0000072
 name: obsolete Lithoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:0000073
+id: METPO:0000073
 name: obsolete Chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:0000074
+id: METPO:0000074
 name: obsolete Chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:0000075
+id: METPO:0000075
 name: obsolete Methylotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:0000076
+id: METPO:0000076
 name: obsolete Methanotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:0000077
+id: METPO:0000077
 name: obsolete Carboxydotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:0000078
+id: METPO:0000078
 name: obsolete Hydrogenotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:0000079
+id: METPO:0000079
 name: obsolete Hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000008
+id: METPO:000008
 name: obsolete Pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000080
+id: METPO:0000080
 name: obsolete Hydrogen producer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000081
+id: METPO:0000081
 name: obsolete Nitrogen fixer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000082
+id: METPO:0000082
 name: obsolete Methanogen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000083
+id: METPO:0000083
 name: obsolete Sulfate reducer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000084
+id: METPO:0000084
 name: obsolete Sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000085
+id: METPO:0000085
 name: obsolete Denitrifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000086
+id: METPO:0000086
 name: obsolete Capnophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:0000087
+id: METPO:0000087
 name: obsolete Motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:0000088
+id: METPO:0000088
 name: obsolete Non-motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:0000089
+id: METPO:0000089
 name: obsolete Flagellated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:000009
+id: METPO:000009
 name: obsolete GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:0000090
+id: METPO:0000090
 name: obsolete Peritrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000091
+id: METPO:0000091
 name: obsolete Lophotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000092
+id: METPO:0000092
 name: obsolete Monotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000093
+id: METPO:0000093
 name: obsolete Ciliated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000094
+id: METPO:0000094
 name: obsolete Gliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:0000095
+id: METPO:0000095
 name: obsolete Twitching
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000096
+id: METPO:0000096
 name: obsolete Sliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000097
+id: METPO:0000097
 name: obsolete Swarming
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000098
+id: METPO:0000098
 name: obsolete Endospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000099
+id: METPO:0000099
 name: obsolete Exospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000010
+id: METPO:000010
 name: obsolete Cell Width
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000100
+id: METPO:0000100
 name: obsolete Myxospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000101
+id: METPO:0000101
 name: obsolete Arthrospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000102
+id: METPO:0000102
 name: obsolete Conidia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000103
+id: METPO:0000103
 name: obsolete Sporangiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000104
+id: METPO:0000104
 name: obsolete Zygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000105
+id: METPO:0000105
 name: obsolete Akinetes
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000106
+id: METPO:0000106
 name: obsolete Chlamydospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000107
+id: METPO:0000107
 name: obsolete Sporocysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000108
+id: METPO:0000108
 name: obsolete Hypnospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000109
+id: METPO:0000109
 name: obsolete Gemmae
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000011
+id: METPO:000011
 name: obsolete Cell Length
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000110
+id: METPO:0000110
 name: obsolete Oospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000111
+id: METPO:0000111
 name: obsolete Azygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000112
+id: METPO:0000112
 name: obsolete Cysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000113
+id: METPO:0000113
 name: obsolete Ascospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000114
+id: METPO:0000114
 name: obsolete Basidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000115
+id: METPO:0000115
 name: obsolete Aleuriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000116
+id: METPO:0000116
 name: obsolete Stylospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000117
+id: METPO:0000117
 name: obsolete Sclerotia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000118
+id: METPO:0000118
 name: obsolete Zoospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000119
+id: METPO:0000119
 name: obsolete Teliospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000012
+id: METPO:000012
 name: obsolete Temperature Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000304
+replaced_by: METPO:1000304
 
 [Term]
-id: metpo:0000120
+id: METPO:0000120
 name: obsolete Urediniospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000121
+id: METPO:0000121
 name: obsolete Pycnidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000122
+id: METPO:0000122
 name: obsolete Acriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000123
+id: METPO:0000123
 name: obsolete Aplanospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000124
+id: METPO:0000124
 name: obsolete Statismospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000125
+id: METPO:0000125
 name: obsolete Barotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000126
+id: METPO:0000126
 name: obsolete Piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000127
+id: METPO:0000127
 name: obsolete Piezotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000128
+id: METPO:0000128
 name: obsolete Piezosensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000129
+id: METPO:0000129
 name: obsolete Obligate barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000013
+id: METPO:000013
 name: obsolete Temperature Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000306
+replaced_by: METPO:1000306
 
 [Term]
-id: metpo:0000130
+id: METPO:0000130
 name: obsolete Facultative barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000131
+id: METPO:0000131
 name: obsolete Hyperbarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000132
+id: METPO:0000132
 name: obsolete Hypobarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000133
+id: METPO:0000133
 name: obsolete Atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000134
+id: METPO:0000134
 name: obsolete Moderate piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000135
+id: METPO:0000135
 name: obsolete Extreme piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000136
+id: METPO:0000136
 name: obsolete Stenopiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000137
+id: METPO:0000137
 name: obsolete Eurypiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000138
+id: METPO:0000138
 name: obsolete Pressure-sensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000139
+id: METPO:0000139
 name: obsolete Pressure-resistant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000014
+id: METPO:000014
 name: obsolete pH Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000331
+replaced_by: METPO:1000331
 
 [Term]
-id: metpo:0000140
+id: METPO:0000140
 name: obsolete Pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000141
+id: METPO:0000141
 name: obsolete Piezo-acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000142
+id: METPO:0000142
 name: obsolete Piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000143
+id: METPO:0000143
 name: obsolete Piezo-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000144
+id: METPO:0000144
 name: obsolete Piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000145
+id: METPO:0000145
 name: obsolete Piezo-thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000146
+id: METPO:0000146
 name: obsolete Piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000147
+id: METPO:0000147
 name: obsolete Piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:0000148
+id: METPO:0000148
 name: obsolete Piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000149
+id: METPO:0000149
 name: obsolete Piezo-endolithic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000015
+id: METPO:000015
 name: obsolete pH Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000332
+replaced_by: METPO:1000332
 
 [Term]
-id: metpo:0000150
+id: METPO:0000150
 name: obsolete Piezo-tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000151
+id: METPO:0000151
 name: obsolete GC low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000429
+replaced_by: METPO:1000429
 
 [Term]
-id: metpo:0000152
+id: METPO:0000152
 name: obsolete GC mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000430
+replaced_by: METPO:1000430
 
 [Term]
-id: metpo:0000153
+id: METPO:0000153
 name: obsolete GC mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000431
+replaced_by: METPO:1000431
 
 [Term]
-id: metpo:0000154
+id: METPO:0000154
 name: obsolete GC high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000432
+replaced_by: METPO:1000432
 
 [Term]
-id: metpo:0000155
+id: METPO:0000155
 name: obsolete Cell width very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000887
+replaced_by: METPO:1000887
 
 [Term]
-id: metpo:0000156
+id: METPO:0000156
 name: obsolete Cell width low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000157
+id: METPO:0000157
 name: obsolete Cell width mid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000889
+replaced_by: METPO:1000889
 
 [Term]
-id: metpo:0000158
+id: METPO:0000158
 name: obsolete Cell width high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:0000159
+id: METPO:0000159
 name: obsolete Cell length very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000883
+replaced_by: METPO:1000883
 
 [Term]
-id: metpo:000016
+id: METPO:000016
 name: obsolete NaCl Optimum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000333
+replaced_by: METPO:1000333
 
 [Term]
-id: metpo:0000160
+id: METPO:0000160
 name: obsolete Cell length low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000161
+id: METPO:0000161
 name: obsolete Cell length mid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000885
+replaced_by: METPO:1000885
 
 [Term]
-id: metpo:0000162
+id: METPO:0000162
 name: obsolete Cell length high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:0000163
+id: METPO:0000163
 name: obsolete Temperature Optimum very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000441
+replaced_by: METPO:1000441
 
 [Term]
-id: metpo:0000164
+id: METPO:0000164
 name: obsolete Temperature Optimum low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000442
+replaced_by: METPO:1000442
 
 [Term]
-id: metpo:0000165
+id: METPO:0000165
 name: obsolete Temperature Optimum mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000443
+replaced_by: METPO:1000443
 
 [Term]
-id: metpo:0000166
+id: METPO:0000166
 name: obsolete Temperature Optimum mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000444
+replaced_by: METPO:1000444
 
 [Term]
-id: metpo:0000167
+id: METPO:0000167
 name: obsolete Temperature Optimum mid3
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:0000168
+id: METPO:0000168
 name: obsolete Temperature Optimum mid4
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000446
+replaced_by: METPO:1000446
 
 [Term]
-id: metpo:0000169
+id: METPO:0000169
 name: obsolete Temperature Optimum high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000447
+replaced_by: METPO:1000447
 
 [Term]
-id: metpo:000017
+id: METPO:000017
 name: obsolete NaCl Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000334
+replaced_by: METPO:1000334
 
 [Term]
-id: metpo:0000170
+id: METPO:0000170
 name: obsolete Temperature Range very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000448
+replaced_by: METPO:1000448
 
 [Term]
-id: metpo:0000171
+id: METPO:0000171
 name: obsolete Temperature Range low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000449
+replaced_by: METPO:1000449
 
 [Term]
-id: metpo:0000172
+id: METPO:0000172
 name: obsolete Temperature Range mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000450
+replaced_by: METPO:1000450
 
 [Term]
-id: metpo:0000173
+id: METPO:0000173
 name: obsolete Temperature Range mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000451
+replaced_by: METPO:1000451
 
 [Term]
-id: metpo:0000174
+id: METPO:0000174
 name: obsolete Temperature Range mid3
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000452
+replaced_by: METPO:1000452
 
 [Term]
-id: metpo:0000175
+id: METPO:0000175
 name: obsolete Temperature Range mid4
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000453
+replaced_by: METPO:1000453
 
 [Term]
-id: metpo:0000176
+id: METPO:0000176
 name: obsolete Temperature Range high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000454
+replaced_by: METPO:1000454
 
 [Term]
-id: metpo:0000177
+id: METPO:0000177
 name: obsolete pH Optimum low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000455
+replaced_by: METPO:1000455
 
 [Term]
-id: metpo:0000178
+id: METPO:0000178
 name: obsolete pH Optimum mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000456
+replaced_by: METPO:1000456
 
 [Term]
-id: metpo:0000179
+id: METPO:0000179
 name: obsolete pH Optimum mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000457
+replaced_by: METPO:1000457
 
 [Term]
-id: metpo:000018
+id: METPO:000018
 name: obsolete pH delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000232
+replaced_by: METPO:1000232
 
 [Term]
-id: metpo:0000180
+id: METPO:0000180
 name: obsolete pH Optimum high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000458
+replaced_by: METPO:1000458
 
 [Term]
-id: metpo:0000181
+id: METPO:0000181
 name: obsolete pH Range very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000459
+replaced_by: METPO:1000459
 
 [Term]
-id: metpo:0000182
+id: METPO:0000182
 name: obsolete pH Range low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000460
+replaced_by: METPO:1000460
 
 [Term]
-id: metpo:0000183
+id: METPO:0000183
 name: obsolete pH Range mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000461
+replaced_by: METPO:1000461
 
 [Term]
-id: metpo:0000184
+id: METPO:0000184
 name: obsolete pH Range mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000462
+replaced_by: METPO:1000462
 
 [Term]
-id: metpo:0000185
+id: METPO:0000185
 name: obsolete pH Range mid3
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000463
+replaced_by: METPO:1000463
 
 [Term]
-id: metpo:0000186
+id: METPO:0000186
 name: obsolete pH Range high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000464
+replaced_by: METPO:1000464
 
 [Term]
-id: metpo:0000187
+id: METPO:0000187
 name: obsolete NaCl Optimum low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000465
+replaced_by: METPO:1000465
 
 [Term]
-id: metpo:0000188
+id: METPO:0000188
 name: obsolete NaCl Optimum mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000466
+replaced_by: METPO:1000466
 
 [Term]
-id: metpo:0000189
+id: METPO:0000189
 name: obsolete NaCl Optimum mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000467
+replaced_by: METPO:1000467
 
 [Term]
-id: metpo:000019
+id: METPO:000019
 name: obsolete NaCl delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000335
+replaced_by: METPO:1000335
 
 [Term]
-id: metpo:0000190
+id: METPO:0000190
 name: obsolete NaCl Optimum high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000468
+replaced_by: METPO:1000468
 
 [Term]
-id: metpo:0000191
+id: METPO:0000191
 name: obsolete NaCl Range low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000469
+replaced_by: METPO:1000469
 
 [Term]
-id: metpo:0000192
+id: METPO:0000192
 name: obsolete NaCl Range mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000470
+replaced_by: METPO:1000470
 
 [Term]
-id: metpo:0000193
+id: METPO:0000193
 name: obsolete NaCl Range mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000471
+replaced_by: METPO:1000471
 
 [Term]
-id: metpo:0000194
+id: METPO:0000194
 name: obsolete NaCl Range high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000472
+replaced_by: METPO:1000472
 
 [Term]
-id: metpo:0000195
+id: METPO:0000195
 name: obsolete pH Delta very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000473
+replaced_by: METPO:1000473
 
 [Term]
-id: metpo:0000196
+id: METPO:0000196
 name: obsolete pH Delta low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000474
+replaced_by: METPO:1000474
 
 [Term]
-id: metpo:0000197
+id: METPO:0000197
 name: obsolete pH Delta mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000475
+replaced_by: METPO:1000475
 
 [Term]
-id: metpo:0000198
+id: METPO:0000198
 name: obsolete pH Delta mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000476
+replaced_by: METPO:1000476
 
 [Term]
-id: metpo:0000199
+id: METPO:0000199
 name: obsolete pH Delta mid3
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000477
+replaced_by: METPO:1000477
 
 [Term]
-id: metpo:000020
+id: METPO:000020
 name: obsolete Temperature Delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000303
+replaced_by: METPO:1000303
 
 [Term]
-id: metpo:0000200
+id: METPO:0000200
 name: obsolete pH Delta high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000478
+replaced_by: METPO:1000478
 
 [Term]
-id: metpo:0000201
+id: METPO:0000201
 name: obsolete NaCl Delta low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000479
+replaced_by: METPO:1000479
 
 [Term]
-id: metpo:0000202
+id: METPO:0000202
 name: obsolete NaCl Delta mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000481
+replaced_by: METPO:1000481
 
 [Term]
-id: metpo:0000203
+id: METPO:0000203
 name: obsolete NaCl Delta mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000481
+replaced_by: METPO:1000481
 
 [Term]
-id: metpo:0000204
+id: METPO:0000204
 name: obsolete NaCl Delta high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000482
+replaced_by: METPO:1000482
 
 [Term]
-id: metpo:0000205
+id: METPO:0000205
 name: obsolete Temperature Delta very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000483
+replaced_by: METPO:1000483
 
 [Term]
-id: metpo:0000206
+id: METPO:0000206
 name: obsolete Temperature Delta low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000484
+replaced_by: METPO:1000484
 
 [Term]
-id: metpo:0000207
+id: METPO:0000207
 name: obsolete Temperature Delta mid1
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000485
+replaced_by: METPO:1000485
 
 [Term]
-id: metpo:0000208
+id: METPO:0000208
 name: obsolete Temperature Delta mid2
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000486
+replaced_by: METPO:1000486
 
 [Term]
-id: metpo:0000209
+id: METPO:0000209
 name: obsolete Temperature Delta high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000487
+replaced_by: METPO:1000487
 
 [Term]
-id: metpo:000021
+id: METPO:000021
 name: obsolete Morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000210
+id: METPO:0000210
 name: obsolete Bacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000211
+id: METPO:0000211
 name: obsolete Branced
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000212
+id: METPO:0000212
 name: obsolete Coccobacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000213
+id: METPO:0000213
 name: obsolete Coccus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000214
+id: METPO:0000214
 name: obsolete Crescent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000215
+id: METPO:0000215
 name: obsolete Curved
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000216
+id: METPO:0000216
 name: obsolete Curved Spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000217
+id: METPO:0000217
 name: obsolete Diplococcus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000218
+id: METPO:0000218
 name: obsolete Disc
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000219
+id: METPO:0000219
 name: obsolete Dumbbell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000022
+id: METPO:000022
 name: obsolete Other
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000220
+id: METPO:0000220
 name: obsolete Ellipsoidal
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:0000221
+id: METPO:0000221
 name: obsolete Filament
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000222
+id: METPO:0000222
 name: obsolete Flask
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000223
+id: METPO:0000223
 name: obsolete Fusiform
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000224
+id: METPO:0000224
 name: obsolete Helical
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000225
+id: METPO:0000225
 name: obsolete Irregular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000226
+id: METPO:0000226
 name: obsolete Oval
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000227
+id: METPO:0000227
 name: obsolete Ovoid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000228
+id: METPO:0000228
 name: obsolete Pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000229
+id: METPO:0000229
 name: obsolete Ring
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000023
+id: METPO:000023
 name: obsolete Psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:0000230
+id: METPO:0000230
 name: obsolete Rod
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000231
+id: METPO:0000231
 name: obsolete Sphere
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000232
+id: METPO:0000232
 name: obsolete Spindle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000233
+id: METPO:0000233
 name: obsolete Spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000234
+id: METPO:0000234
 name: obsolete Spirochete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000235
+id: METPO:0000235
 name: obsolete Spore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000236
+id: METPO:0000236
 name: obsolete Square
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000237
+id: METPO:0000237
 name: obsolete Star
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000238
+id: METPO:0000238
 name: obsolete Star - Dumbbell - Pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000239
+id: METPO:0000239
 name: obsolete Tailed
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000024
+id: METPO:000024
 name: obsolete Psychrotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:0000240
+id: METPO:0000240
 name: obsolete Triangular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000241
+id: METPO:0000241
 name: obsolete Vibrio
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000242
+id: METPO:0000242
 name: obsolete Environmental Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000243
+id: METPO:0000243
 name: obsolete Growth Condition
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000244
+id: METPO:0000244
 name: obsolete Physiological Trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000245
+id: METPO:0000245
 name: obsolete Metabolic Classification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000246
+id: METPO:0000246
 name: obsolete Cellular Characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000247
+id: METPO:0000247
 name: obsolete Taxonomic Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000248
+id: METPO:0000248
 name: obsolete Microbial Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000249
+id: METPO:0000249
 name: obsolete Growth Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000025
+id: METPO:000025
 name: obsolete Mesophilie
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000250
+id: METPO:0000250
 name: obsolete Structural Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000251
+id: METPO:0000251
 name: obsolete Temperature Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000252
+id: METPO:0000252
 name: obsolete Salinity Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000253
+id: METPO:0000253
 name: obsolete pH Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000254
+id: METPO:0000254
 name: obsolete Oxygen Requirement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000255
+id: METPO:0000255
 name: obsolete Carbon Source Utilization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000256
+id: METPO:0000256
 name: obsolete Energy Acquisition Mode
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000257
+id: METPO:0000257
 name: obsolete Electron Donor Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000258
+id: METPO:0000258
 name: obsolete Motility Mechanism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000259
+id: METPO:0000259
 name: obsolete Motility Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000026
+id: METPO:000026
 name: obsolete Thermotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:0000260
+id: METPO:0000260
 name: obsolete Bacterial Spore Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000261
+id: METPO:0000261
 name: obsolete Fungal Spore Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000262
+id: METPO:0000262
 name: obsolete Reproductive Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000263
+id: METPO:0000263
 name: obsolete Dormancy Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000264
+id: METPO:0000264
 name: obsolete Pressure Adaptation Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000265
+id: METPO:0000265
 name: obsolete Pressure Tolerance Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:0000266
+id: METPO:0000266
 name: obsolete Genomic Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000267
+id: METPO:0000267
 name: obsolete Cell Dimension
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000268
+id: METPO:0000268
 name: obsolete Optimal Growth Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000269
+id: METPO:0000269
 name: obsolete Growth Range Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000027
+id: METPO:000027
 name: obsolete Thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:0000270
+id: METPO:0000270
 name: obsolete Growth Tolerance Metric
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000271
+id: METPO:0000271
 name: obsolete Cell Shape
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:0000272
+id: METPO:0000272
 name: obsolete Cell Arrangement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:0000273
+id: METPO:0000273
 name: obsolete Colony Morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:0000274
+id: METPO:0000274
 name: obsolete Physical Property
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000275
+id: METPO:0000275
 name: obsolete Environmental Context
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000276
+id: METPO:0000276
 name: obsolete Biological Property
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:0000277
+id: METPO:0000277
 name: obsolete Functional Classification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000278
+id: METPO:0000278
 name: obsolete Classification Property
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000279
+id: METPO:0000279
 name: obsolete METPO Biological Process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:000028
+id: METPO:000028
 name: obsolete Extreme thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:0000280
+id: METPO:0000280
 name: obsolete Measurable Property
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0000281
+id: METPO:0000281
 name: obsolete Gram-stain negative
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000699
+replaced_by: METPO:1000699
 
 [Term]
-id: metpo:0000282
+id: METPO:0000282
 name: obsolete Gram-stain positive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000698
+replaced_by: METPO:1000698
 
 [Term]
-id: metpo:000029
+id: METPO:000029
 name: obsolete Hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:000030
+id: METPO:000030
 name: obsolete Extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:000031
+id: METPO:000031
 name: obsolete Halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:000032
+id: METPO:000032
 name: obsolete Non-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:000033
+id: METPO:000033
 name: obsolete Slight halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:000034
+id: METPO:000034
 name: obsolete Moderate halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:000035
+id: METPO:000035
 name: obsolete Extreme halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:000036
+id: METPO:000036
 name: obsolete Halotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:000037
+id: METPO:000037
 name: obsolete Haloalkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:000038
+id: METPO:000038
 name: obsolete Extreme Acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000039
+id: METPO:000039
 name: obsolete Acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:000040
+id: METPO:000040
 name: obsolete Neutrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:000041
+id: METPO:000041
 name: obsolete Alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:000042
+id: METPO:000042
 name: obsolete Acid Tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000043
+id: METPO:000043
 name: obsolete Alkali Tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000044
+id: METPO:000044
 name: obsolete Extreme Alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000045
+id: METPO:000045
 name: obsolete Facultative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:000046
+id: METPO:000046
 name: obsolete Obligative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:000047
+id: METPO:000047
 name: obsolete Aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000048
+id: METPO:000048
 name: obsolete Anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:000049
+id: METPO:000049
 name: obsolete Facultative anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:000050
+id: METPO:000050
 name: obsolete Facultative aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:000051
+id: METPO:000051
 name: obsolete Microaerophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:000052
+id: METPO:000052
 name: obsolete Aerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:000053
+id: METPO:000053
 name: obsolete Microaerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:000054
+id: METPO:000054
 name: obsolete Aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000055
+id: METPO:000055
 name: obsolete Obligate aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:000056
+id: METPO:000056
 name: obsolete Obligate anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:000057
+id: METPO:000057
 name: obsolete Oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000058
+id: METPO:000058
 name: obsolete Anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000059
+id: METPO:000059
 name: obsolete Autotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:000060
+id: METPO:000060
 name: obsolete Photoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:000061
+id: METPO:000061
 name: obsolete Chemoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:000062
+id: METPO:000062
 name: obsolete Heterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:000063
+id: METPO:000063
 name: obsolete Photoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:000064
+id: METPO:000064
 name: obsolete Chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:000065
+id: METPO:000065
 name: obsolete Lithotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:000066
+id: METPO:000066
 name: obsolete Organotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:000067
+id: METPO:000067
 name: obsolete Phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:000068
+id: METPO:000068
 name: obsolete Chemotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:000069
+id: METPO:000069
 name: obsolete Oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:000070
+id: METPO:000070
 name: obsolete Copiotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:000071
+id: METPO:000071
 name: obsolete Lithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:000072
+id: METPO:000072
 name: obsolete Mixotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:000073
+id: METPO:000073
 name: obsolete Lithoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:000074
+id: METPO:000074
 name: obsolete Chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:000075
+id: METPO:000075
 name: obsolete Chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:000076
+id: METPO:000076
 name: obsolete Methylotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:000077
+id: METPO:000077
 name: obsolete Methanotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:000078
+id: METPO:000078
 name: obsolete Carboxydotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:000079
+id: METPO:000079
 name: obsolete Hydrogenotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:000080
+id: METPO:000080
 name: obsolete Hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000081
+id: METPO:000081
 name: obsolete Hydrogen producer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000082
+id: METPO:000082
 name: obsolete Nitrogen fixer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000083
+id: METPO:000083
 name: obsolete Methanogen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000084
+id: METPO:000084
 name: obsolete Sulfate reducer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000085
+id: METPO:000085
 name: obsolete Sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000086
+id: METPO:000086
 name: obsolete Denitrifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000087
+id: METPO:000087
 name: obsolete Capnophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:000088
+id: METPO:000088
 name: obsolete Motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:000089
+id: METPO:000089
 name: obsolete Non-motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:000090
+id: METPO:000090
 name: obsolete Flagellated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:000091
+id: METPO:000091
 name: obsolete Peritrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000092
+id: METPO:000092
 name: obsolete Lophotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000093
+id: METPO:000093
 name: obsolete Monotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000094
+id: METPO:000094
 name: obsolete Ciliated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000095
+id: METPO:000095
 name: obsolete Gliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:000096
+id: METPO:000096
 name: obsolete Twitching
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000097
+id: METPO:000097
 name: obsolete Sliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000098
+id: METPO:000098
 name: obsolete Swarming
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000099
+id: METPO:000099
 name: obsolete Endospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000100
+id: METPO:000100
 name: obsolete Exospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001000
+id: METPO:0001000
 name: obsolete sensitivity to oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001001
+id: METPO:0001001
 name: obsolete sensitivity toward
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001002
+id: METPO:0001002
 name: obsolete 'organismal quality'
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001003
+id: METPO:0001003
 name: obsolete 'physicial object quality'
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001004
+id: METPO:0001004
 name: obsolete 'quality'
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000188
+replaced_by: METPO:1000188
 
 [Term]
-id: metpo:0001006
+id: METPO:0001006
 name: obsolete size
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001007
+id: METPO:0001007
 name: obsolete 1-D extent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001008
+id: METPO:0001008
 name: obsolete width
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001009
+id: METPO:0001009
 name: obsolete length
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000101
+id: METPO:000101
 name: obsolete Myxospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001010
+id: METPO:0001010
 name: obsolete 'prokaryotic metabolically differentiated cell'
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001012
+id: METPO:0001012
 name: obsolete heterotrophy
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001013
+id: METPO:0001013
 name: obsolete structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001014
+id: METPO:0001014
 name: obsolete spore type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001016
+id: METPO:0001016
 name: obsolete sensitivity toward pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001017
+id: METPO:0001017
 name: obsolete sensitivity toward NaCl
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001018
+id: METPO:0001018
 name: obsolete sensitivity toward pH
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001019
+id: METPO:0001019
 name: obsolete sensitivity toward temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000102
+id: METPO:000102
 name: obsolete Arthrospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001020
+id: METPO:0001020
 name: obsolete metabolic constraints
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:0001021
+id: METPO:0001021
 name: obsolete cell by chemical produced
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000103
+id: METPO:000103
 name: obsolete Conidia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000104
+id: METPO:000104
 name: obsolete Sporangiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000105
+id: METPO:000105
 name: obsolete Zygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000106
+id: METPO:000106
 name: obsolete Akinetes
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000107
+id: METPO:000107
 name: obsolete Chlamydospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000108
+id: METPO:000108
 name: obsolete Sporocysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000109
+id: METPO:000109
 name: obsolete Hypnospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000110
+id: METPO:000110
 name: obsolete Gemmae
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000111
+id: METPO:000111
 name: obsolete Oospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000112
+id: METPO:000112
 name: obsolete Azygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000113
+id: METPO:000113
 name: obsolete Cysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000114
+id: METPO:000114
 name: obsolete Ascospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000115
+id: METPO:000115
 name: obsolete Basidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000116
+id: METPO:000116
 name: obsolete Aleuriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000117
+id: METPO:000117
 name: obsolete Stylospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000118
+id: METPO:000118
 name: obsolete Sclerotia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000119
+id: METPO:000119
 name: obsolete Zoospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000120
+id: METPO:000120
 name: obsolete Teliospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000121
+id: METPO:000121
 name: obsolete Urediniospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000122
+id: METPO:000122
 name: obsolete Pycnidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000123
+id: METPO:000123
 name: obsolete Acriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000124
+id: METPO:000124
 name: obsolete Aplanospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000125
+id: METPO:000125
 name: obsolete Statismospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000126
+id: METPO:000126
 name: obsolete Barotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000127
+id: METPO:000127
 name: obsolete Piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000128
+id: METPO:000128
 name: obsolete Piezotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000129
+id: METPO:000129
 name: obsolete Piezosensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000130
+id: METPO:000130
 name: obsolete Obligate barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000131
+id: METPO:000131
 name: obsolete Facultative barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000132
+id: METPO:000132
 name: obsolete Hyperbarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000133
+id: METPO:000133
 name: obsolete Hypobarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000134
+id: METPO:000134
 name: obsolete Atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000135
+id: METPO:000135
 name: obsolete Moderate piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000136
+id: METPO:000136
 name: obsolete Extreme piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000137
+id: METPO:000137
 name: obsolete Stenopiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000138
+id: METPO:000138
 name: obsolete Eurypiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000139
+id: METPO:000139
 name: obsolete Pressure-sensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000140
+id: METPO:000140
 name: obsolete Pressure-resistant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000141
+id: METPO:000141
 name: obsolete Pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000142
+id: METPO:000142
 name: obsolete Piezo-acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000143
+id: METPO:000143
 name: obsolete Piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000144
+id: METPO:000144
 name: obsolete Piezo-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000145
+id: METPO:000145
 name: obsolete Piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000146
+id: METPO:000146
 name: obsolete Piezo-thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000147
+id: METPO:000147
 name: obsolete Piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000148
+id: METPO:000148
 name: obsolete Piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:000149
+id: METPO:000149
 name: obsolete Piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000150
+id: METPO:000150
 name: obsolete Piezo-endolithic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000151
+id: METPO:000151
 name: obsolete Piezo-tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000152
+id: METPO:000152
 name: obsolete GC% low ( < 42.65)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000153
+id: METPO:000153
 name: obsolete GC% mid1 (42.65 - 57)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000154
+id: METPO:000154
 name: obsolete GC% mid2 (57 - 66.3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000155
+id: METPO:000155
 name: obsolete GC% high ( > 66.3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000156
+id: METPO:000156
 name: obsolete Cell width uM very low (< 0.5)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000157
+id: METPO:000157
 name: obsolete Cell width uM low (0.5 - 0.65)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000158
+id: METPO:000158
 name: obsolete Cell width uM mid (0.65 - 0.9)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000159
+id: METPO:000159
 name: obsolete Cell width uM high (> 0.9)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000160
+id: METPO:000160
 name: obsolete Cell length uM very low (<= 1.3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000161
+id: METPO:000161
 name: obsolete Cell length uM low (1.3 - 2)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000162
+id: METPO:000162
 name: obsolete Cell length uM mid (2 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000163
+id: METPO:000163
 name: obsolete Cell length uM high (> 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000164
+id: METPO:000164
 name: obsolete Temperature Optimum C very low (<= 10)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000441
+replaced_by: METPO:1000441
 
 [Term]
-id: metpo:000165
+id: METPO:000165
 name: obsolete Temperature Optimum C low (10 - 22)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000166
+id: METPO:000166
 name: obsolete Temperature Optimum C mid1 (22 - 27)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000443
+replaced_by: METPO:1000443
 
 [Term]
-id: metpo:000167
+id: METPO:000167
 name: obsolete Temperature Optimum C mid2 (27 - 30)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000444
+replaced_by: METPO:1000444
 
 [Term]
-id: metpo:000168
+id: METPO:000168
 name: obsolete Temperature Optimum C mid3 (30 - 34)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:000169
+id: METPO:000169
 name: obsolete Temperature Optimum C mid4 (34 - 40)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000445
+replaced_by: METPO:1000445
 
 [Term]
-id: metpo:000170
+id: METPO:000170
 name: obsolete Temperature Optimum C high (> 40)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000447
+replaced_by: METPO:1000447
 
 [Term]
-id: metpo:000171
+id: METPO:000171
 name: obsolete Temperature Range C very low (<= 10)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000448
+replaced_by: METPO:1000448
 
 [Term]
-id: metpo:000172
+id: METPO:000172
 name: obsolete Temperature Range C low (10 - 22)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000173
+id: METPO:000173
 name: obsolete Temperature Range C mid1 (22 - 27)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000174
+id: METPO:000174
 name: obsolete Temperature Range C mid2 (27 - 30)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000175
+id: METPO:000175
 name: obsolete Temperature Range C mid3 (30 - 34)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000176
+id: METPO:000176
 name: obsolete Temperature Range C mid4 (34 - 40)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000177
+id: METPO:000177
 name: obsolete Temperature Range C high (> 40)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000454
+replaced_by: METPO:1000454
 
 [Term]
-id: metpo:000178
+id: METPO:000178
 name: obsolete pH Optimum low (0 - 6)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000179
+id: METPO:000179
 name: obsolete pH Optimum mid1 (6 - 7)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000180
+id: METPO:000180
 name: obsolete pH Optimum mid2 (7 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000181
+id: METPO:000181
 name: obsolete pH Optimum high (8 - 14)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000182
+id: METPO:000182
 name: obsolete pH Range very low (0 - 4)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000459
+replaced_by: METPO:1000459
 
 [Term]
-id: metpo:000183
+id: METPO:000183
 name: obsolete pH Range low (4 - 6)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000184
+id: METPO:000184
 name: obsolete pH Range mid1 (6 - 7)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000185
+id: METPO:000185
 name: obsolete pH Range mid2 (7 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000186
+id: METPO:000186
 name: obsolete pH Range mid3 (8 - 10)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000187
+id: METPO:000187
 name: obsolete pH Range high (10 - 14)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000188
+id: METPO:000188
 name: obsolete % NaCl Optimum low (<= 1)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000189
+id: METPO:000189
 name: obsolete % NaCl Optimum mid1 (1 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000190
+id: METPO:000190
 name: obsolete % NaCl Optimum mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000191
+id: METPO:000191
 name: obsolete % NaCl Optimum high (> 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000468
+replaced_by: METPO:1000468
 
 [Term]
-id: metpo:000192
+id: METPO:000192
 name: obsolete % NaCl Range low (<= 1)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000193
+id: METPO:000193
 name: obsolete % NaCl Range mid1 (1 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000194
+id: METPO:000194
 name: obsolete % NaCl Range mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000195
+id: METPO:000195
 name: obsolete % NaCl Range high (> 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000196
+id: METPO:000196
 name: obsolete pH delta very low (<= 1)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000473
+replaced_by: METPO:1000473
 
 [Term]
-id: metpo:000197
+id: METPO:000197
 name: obsolete pH delta low (1 - 2)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000198
+id: METPO:000198
 name: obsolete pH delta mid1 (2 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000199
+id: METPO:000199
 name: obsolete pH delta mid2 (3 - 4)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000200
+id: METPO:000200
 name: obsolete pH delta mid3 (4 - 5)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000201
+id: METPO:000201
 name: obsolete pH delta high (5 - 9)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000202
+id: METPO:000202
 name: obsolete % NaCl delta low (<= 1)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000203
+id: METPO:000203
 name: obsolete % NaCl delta mid2 (1 - 3)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000204
+id: METPO:000204
 name: obsolete % NaCl delta mid2 (3 - 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000205
+id: METPO:000205
 name: obsolete % NaCl delta high (>= 8)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000206
+id: METPO:000206
 name: obsolete Temperature C delta very low (1 - 5)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000483
+replaced_by: METPO:1000483
 
 [Term]
-id: metpo:000207
+id: METPO:000207
 name: obsolete Temperature C delta low (5 - 10)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000208
+id: METPO:000208
 name: obsolete Temperature C delta mid1 (10 - 20)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000209
+id: METPO:000209
 name: obsolete Temperature C delta mid2 (20 - 30)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000210
+id: METPO:000210
 name: obsolete Temperature C delta high (>= 30)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000487
+replaced_by: METPO:1000487
 
 [Term]
-id: metpo:000211
+id: METPO:000211
 name: obsolete bacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000212
+id: METPO:000212
 name: obsolete branced
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000213
+id: METPO:000213
 name: obsolete coccobacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000214
+id: METPO:000214
 name: obsolete coccus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000215
+id: METPO:000215
 name: obsolete crescent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000216
+id: METPO:000216
 name: obsolete curved
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000217
+id: METPO:000217
 name: obsolete curved spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000218
+id: METPO:000218
 name: obsolete diplococcus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000219
+id: METPO:000219
 name: obsolete disc
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000220
+id: METPO:000220
 name: obsolete dumbbell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000221
+id: METPO:000221
 name: obsolete ellipsoidal
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:000222
+id: METPO:000222
 name: obsolete filament
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000223
+id: METPO:000223
 name: obsolete flask
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000224
+id: METPO:000224
 name: obsolete fusiform
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000225
+id: METPO:000225
 name: obsolete helical
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000226
+id: METPO:000226
 name: obsolete irregular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000227
+id: METPO:000227
 name: obsolete oval
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000228
+id: METPO:000228
 name: obsolete ovoid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000229
+id: METPO:000229
 name: obsolete pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000230
+id: METPO:000230
 name: obsolete ring
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000231
+id: METPO:000231
 name: obsolete rod
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000232
+id: METPO:000232
 name: obsolete sphere
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000233
+id: METPO:000233
 name: obsolete spindle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000234
+id: METPO:000234
 name: obsolete spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000235
+id: METPO:000235
 name: obsolete spirochete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000236
+id: METPO:000236
 name: obsolete spore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000237
+id: METPO:000237
 name: obsolete square
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000238
+id: METPO:000238
 name: obsolete star
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000239
+id: METPO:000239
 name: obsolete star - dumbbell - pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000240
+id: METPO:000240
 name: obsolete tailed
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000241
+id: METPO:000241
 name: obsolete triangular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000242
+id: METPO:000242
 name: obsolete vibrio
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000243
+id: METPO:000243
 name: obsolete Environmental Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000244
+id: METPO:000244
 name: obsolete Growth Condition
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000245
+id: METPO:000245
 name: obsolete Physiological Trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000246
+id: METPO:000246
 name: obsolete Metabolic Classification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000247
+id: METPO:000247
 name: obsolete Cellular Characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000248
+id: METPO:000248
 name: obsolete Taxonomic Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000249
+id: METPO:000249
 name: obsolete Microbial Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000250
+id: METPO:000250
 name: obsolete Growth Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000251
+id: METPO:000251
 name: obsolete Structural Feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000252
+id: METPO:000252
 name: obsolete Temperature Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000253
+id: METPO:000253
 name: obsolete Salinity Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000254
+id: METPO:000254
 name: obsolete pH Adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000255
+id: METPO:000255
 name: obsolete Oxygen Requirement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000256
+id: METPO:000256
 name: obsolete Carbon Source Utilization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000257
+id: METPO:000257
 name: obsolete Energy Acquisition Mode
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000258
+id: METPO:000258
 name: obsolete Electron Donor Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000259
+id: METPO:000259
 name: obsolete Motility Mechanism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000260
+id: METPO:000260
 name: obsolete Motility Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000261
+id: METPO:000261
 name: obsolete Bacterial Spore Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000262
+id: METPO:000262
 name: obsolete Fungal Spore Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000263
+id: METPO:000263
 name: obsolete Reproductive Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000264
+id: METPO:000264
 name: obsolete Dormancy Structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000265
+id: METPO:000265
 name: obsolete Pressure Adaptation Type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000266
+id: METPO:000266
 name: obsolete Pressure Tolerance Range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:000267
+id: METPO:000267
 name: obsolete GenomicFeature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000268
+id: METPO:000268
 name: obsolete Cell Dimension
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000269
+id: METPO:000269
 name: obsolete Optimal Growth Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000270
+id: METPO:000270
 name: obsolete Growth Range Parameter
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000271
+id: METPO:000271
 name: obsolete Growth Tolerance Metric
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:000272
+id: METPO:000272
 name: obsolete Cell Shape
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:000273
+id: METPO:000273
 name: obsolete Cell Arrangement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:000274
+id: METPO:000274
 name: obsolete Colony Morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:1000001
+id: METPO:1000001
 name: obsolete acid-fast
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000002
+id: METPO:1000002
 name: obsolete acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003003
+replaced_by: METPO:1003003
 
 [Term]
-id: metpo:1000003
+id: METPO:1000003
 name: obsolete active transport
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000004
+id: METPO:1000004
 name: obsolete adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000005
+id: METPO:1000005
 name: obsolete adaptive trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000006
+id: METPO:1000006
 name: obsolete adhesin
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000007
+id: METPO:1000007
 name: obsolete adhesion structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000008
+id: METPO:1000008
 name: obsolete aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000009
+id: METPO:1000009
 name: obsolete aerobic respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000801
+replaced_by: METPO:1000801
 
 [Term]
-id: metpo:1000010
+id: METPO:1000010
 name: obsolete aerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000609
+replaced_by: METPO:1000609
 
 [Term]
-id: metpo:1000011
+id: METPO:1000011
 name: obsolete aggregate
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000012
+id: METPO:1000012
 name: obsolete akinete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000013
+id: METPO:1000013
 name: obsolete alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003002
+replaced_by: METPO:1003002
 
 [Term]
-id: metpo:1000014
+id: METPO:1000014
 name: obsolete ammonification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000015
+id: METPO:1000015
 name: obsolete amylolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000016
+id: METPO:1000016
 name: obsolete anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000603
+replaced_by: METPO:1000603
 
 [Term]
-id: metpo:1000017
+id: METPO:1000017
 name: obsolete anaerobic respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000802
+replaced_by: METPO:1000802
 
 [Term]
-id: metpo:1000018
+id: METPO:1000018
 name: obsolete anoxygenic photosynthesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000019
+id: METPO:1000019
 name: obsolete antibiotic production
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000020
+id: METPO:1000020
 name: obsolete antibiotic resistance
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000021
+id: METPO:1000021
 name: obsolete antimicrobial resistance
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000022
+id: METPO:1000022
 name: obsolete appendage
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000023
+id: METPO:1000023
 name: obsolete arthrospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000024
+id: METPO:1000024
 name: obsolete ascospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000025
+id: METPO:1000025
 name: obsolete autotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000632
+replaced_by: METPO:1000632
 
 [Term]
-id: metpo:1000026
+id: METPO:1000026
 name: obsolete autotrophic process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000027
+id: METPO:1000027
 name: obsolete auxotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000028
+id: METPO:1000028
 name: obsolete axial filament
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000029
+id: METPO:1000029
 name: obsolete bacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000030
+id: METPO:1000030
 name: obsolete barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000031
+id: METPO:1000031
 name: obsolete barotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000032
+id: METPO:1000032
 name: obsolete basidiospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000033
+id: METPO:1000033
 name: obsolete binary fission
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000034
+id: METPO:1000034
 name: obsolete biofilm
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000035
+id: METPO:1000035
 name: obsolete biofilm component
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000036
+id: METPO:1000036
 name: obsolete biofilm formation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000037
+id: METPO:1000037
 name: obsolete biogeochemical cycling
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000038
+id: METPO:1000038
 name: obsolete bioluminescence
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000039
+id: METPO:1000039
 name: obsolete budding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000040
+id: METPO:1000040
 name: obsolete buoyancy structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000041
+id: METPO:1000041
 name: obsolete capnophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005021
+replaced_by: METPO:1005021
 
 [Term]
-id: metpo:1000042
+id: METPO:1000042
 name: obsolete capsule
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000043
+id: METPO:1000043
 name: obsolete carbon fixation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000044
+id: METPO:1000044
 name: obsolete carbon source
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000045
+id: METPO:1000045
 name: obsolete carboxydotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000633
+replaced_by: METPO:1000633
 
 [Term]
-id: metpo:1000046
+id: METPO:1000046
 name: obsolete cell arrangement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007005
+replaced_by: METPO:1007005
 
 [Term]
-id: metpo:1000047
+id: METPO:1000047
 name: obsolete cell envelope
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000048
+id: METPO:1000048
 name: obsolete cell length category
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000049
+id: METPO:1000049
 name: obsolete cell shape
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000666
+replaced_by: METPO:1000666
 
 [Term]
-id: metpo:1000050
+id: METPO:1000050
 name: obsolete cell size
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000051
+id: METPO:1000051
 name: obsolete cell wall characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000052
+id: METPO:1000052
 name: obsolete cell wall component
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000053
+id: METPO:1000053
 name: obsolete cell width category
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000054
+id: METPO:1000054
 name: obsolete cellular characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000055
+id: METPO:1000055
 name: obsolete cellular component
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000056
+id: METPO:1000056
 name: obsolete cellular process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000057
+id: METPO:1000057
 name: obsolete cellular product
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000058
+id: METPO:1000058
 name: obsolete cellulolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000059
+id: METPO:1000059
 name: phenotype
 def: "A quality that differentiates specific instances of a species from other instances of the same species." [] {IAO:0000119="PHIPO:0000505"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/PhenotypicQuality
 
 [Term]
-id: metpo:1000060
+id: METPO:1000060
 name: metabolism
 def: "A biological process that maintain life in an organism." [] {IAO:0000119="https://purl.dsmz.de/schema/MetabolicProcess", IAO:0000119="GO:0008152"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000061
+id: METPO:1000061
 name: obsolete chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000062
+id: METPO:1000062
 name: obsolete chemotaxis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000063
+id: METPO:1000063
 name: obsolete chlamydospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000064
+id: METPO:1000064
 name: obsolete class
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000065
+id: METPO:1000065
 name: obsolete clinically relevant feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000066
+id: METPO:1000066
 name: obsolete coccus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000067
+id: METPO:1000067
 name: obsolete cold shock protein
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000068
+id: METPO:1000068
 name: obsolete cold shock response
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000069
+id: METPO:1000069
 name: obsolete colonization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000070
+id: METPO:1000070
 name: obsolete colony elevation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000071
+id: METPO:1000071
 name: obsolete colony margin
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000072
+id: METPO:1000072
 name: obsolete colony morphology
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1007062
+replaced_by: METPO:1007062
 
 [Term]
-id: metpo:1000073
+id: METPO:1000073
 name: obsolete colony texture
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000074
+id: METPO:1000074
 name: obsolete commensalism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000075
+id: METPO:1000075
 name: obsolete community behavior
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000076
+id: METPO:1000076
 name: obsolete community structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000077
+id: METPO:1000077
 name: obsolete compatible solute
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000078
+id: METPO:1000078
 name: obsolete competence
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000079
+id: METPO:1000079
 name: obsolete component
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000080
+id: METPO:1000080
 name: obsolete conidium
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000081
+id: METPO:1000081
 name: obsolete conjugation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000082
+id: METPO:1000082
 name: obsolete CRISPR
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000083
+id: METPO:1000083
 name: obsolete culturability
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000084
+id: METPO:1000084
 name: obsolete cyst
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000085
+id: METPO:1000085
 name: obsolete death phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000086
+id: METPO:1000086
 name: obsolete denitrification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005038
+replaced_by: METPO:1005038
 
 [Term]
-id: metpo:1000087
+id: METPO:1000087
 name: obsolete developmental process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000088
+id: METPO:1000088
 name: obsolete diagnostic enzyme
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000089
+id: METPO:1000089
 name: obsolete diagnostic feature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000090
+id: METPO:1000090
 name: obsolete diazotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000091
+id: METPO:1000091
 name: obsolete differentiation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000092
+id: METPO:1000092
 name: obsolete dimorphism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000093
+id: METPO:1000093
 name: obsolete disc-shaped cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000094
+id: METPO:1000094
 name: obsolete domain
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000095
+id: METPO:1000095
 name: obsolete dormancy
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000096
+id: METPO:1000096
 name: obsolete dormancy structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000097
+id: METPO:1000097
 name: obsolete dumbbell-shaped cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000672
+replaced_by: METPO:1000672
 
 [Term]
-id: metpo:1000098
+id: METPO:1000098
 name: obsolete ecological niche
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000099
+id: METPO:1000099
 name: obsolete ecological process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:1000100
+id: METPO:1000100
 name: obsolete ecological trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000101
+id: METPO:1000101
 name: obsolete ectosymbiosis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000102
+id: METPO:1000102
 name: obsolete electron acceptor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000103
+id: METPO:1000103
 name: obsolete electron donor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000104
+id: METPO:1000104
 name: obsolete endospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000105
+id: METPO:1000105
 name: obsolete endosymbiosis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000106
+id: METPO:1000106
 name: obsolete energy metabolism process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000107
+id: METPO:1000107
 name: obsolete enzyme activity
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000108
+id: METPO:1000108
 name: obsolete epigenetic modification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000109
+id: METPO:1000109
 name: obsolete evolutionary process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000110
+id: METPO:1000110
 name: obsolete exospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000111
+id: METPO:1000111
 name: obsolete exponential phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000112
+id: METPO:1000112
 name: obsolete extracellular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000113
+id: METPO:1000113
 name: obsolete extracellular polysaccharide
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000114
+id: METPO:1000114
 name: obsolete extreme halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000628
+replaced_by: METPO:1000628
 
 [Term]
-id: metpo:1000115
+id: METPO:1000115
 name: obsolete extremophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000116
+id: METPO:1000116
 name: obsolete facultative
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000117
+id: METPO:1000117
 name: obsolete facultative anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000605
+replaced_by: METPO:1000605
 
 [Term]
-id: metpo:1000118
+id: METPO:1000118
 name: obsolete family
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000119
+id: METPO:1000119
 name: obsolete fastidious
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000120
+id: METPO:1000120
 name: obsolete fermentation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1002005
+replaced_by: METPO:1002005
 
 [Term]
-id: metpo:1000121
+id: METPO:1000121
 name: obsolete filamentous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000122
+id: METPO:1000122
 name: obsolete fimbriae
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000123
+id: METPO:1000123
 name: obsolete flagellum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000124
+id: METPO:1000124
 name: obsolete flask-shaped cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000125
+id: METPO:1000125
 name: obsolete fungal spore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000126
+id: METPO:1000126
 name: obsolete gas vesicle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000127
+id: METPO:1000127
 name: GC content
 def: "A quality that is describing the percentage of guanine and cytosine nucleotides in genomic DNA, calculated as the ratio of GC base pairs to total base pairs." [] {IAO:0000119="https://purl.dsmz.de/schema/GCContent"}
 synonym: "GC percentage" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000128
+id: METPO:1000128
 name: obsolete high GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:1000129
+id: METPO:1000129
 name: obsolete low GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000127
+replaced_by: METPO:1000127
 
 [Term]
-id: metpo:1000130
+id: METPO:1000130
 name: obsolete lower-mid GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000131
+id: METPO:1000131
 name: obsolete upper-mid GC content
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000132
+id: METPO:1000132
 name: obsolete generation time
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000133
+id: METPO:1000133
 name: obsolete genetic element
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000134
+id: METPO:1000134
 name: obsolete genetic exchange
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000135
+id: METPO:1000135
 name: obsolete genetic process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000136
+id: METPO:1000136
 name: obsolete genome size
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000137
+id: METPO:1000137
 name: obsolete genomic element
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000138
+id: METPO:1000138
 name: obsolete genomic island
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000139
+id: METPO:1000139
 name: obsolete genomic trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000140
+id: METPO:1000140
 name: obsolete genus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000141
+id: METPO:1000141
 name: obsolete gliding motility
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000142
+id: METPO:1000142
 name: obsolete global regulator
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000143
+id: METPO:1000143
 name: obsolete Gram-negative
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000699
+replaced_by: METPO:1000699
 
 [Term]
-id: metpo:1000144
+id: METPO:1000144
 name: obsolete Gram-positive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000698
+replaced_by: METPO:1000698
 
 [Term]
-id: metpo:1000145
+id: METPO:1000145
 name: obsolete Gram stain
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000697
+replaced_by: METPO:1000697
 
 [Term]
-id: metpo:1000146
+id: METPO:1000146
 name: obsolete growth characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000147
+id: METPO:1000147
 name: obsolete growth conditions constraints
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000148
+id: METPO:1000148
 name: obsolete growth pattern
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000149
+id: METPO:1000149
 name: obsolete growth rate
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000150
+id: METPO:1000150
 name: obsolete habitat
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000151
+id: METPO:1000151
 name: obsolete halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000620
+replaced_by: METPO:1000620
 
 [Term]
-id: metpo:1000152
+id: METPO:1000152
 name: obsolete halotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000622
+replaced_by: METPO:1000622
 
 [Term]
-id: metpo:1000153
+id: METPO:1000153
 name: obsolete heat shock protein
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000154
+id: METPO:1000154
 name: obsolete heat shock response
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000155
+id: METPO:1000155
 name: obsolete hemolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005025
+replaced_by: METPO:1005025
 
 [Term]
-id: metpo:1000156
+id: METPO:1000156
 name: obsolete heterocyst
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000157
+id: METPO:1000157
 name: obsolete heterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000644
+replaced_by: METPO:1000644
 
 [Term]
-id: metpo:1000158
+id: METPO:1000158
 name: obsolete holdfast
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000159
+id: METPO:1000159
 name: obsolete horizontal gene transfer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000160
+id: METPO:1000160
 name: obsolete hydrolase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000161
+id: METPO:1000161
 name: obsolete hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000617
+replaced_by: METPO:1000617
 
 [Term]
-id: metpo:1000162
+id: METPO:1000162
 name: obsolete inclusion body
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000163
+id: METPO:1000163
 name: obsolete infection
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000164
+id: METPO:1000164
 name: obsolete interaction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000165
+id: METPO:1000165
 name: obsolete interaction with a phage
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000166
+id: METPO:1000166
 name: obsolete interaction with an environment
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000167
+id: METPO:1000167
 name: obsolete interaction with host
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000168
+id: METPO:1000168
 name: obsolete interaction within a community
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000169
+id: METPO:1000169
 name: obsolete intracellular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000170
+id: METPO:1000170
 name: obsolete invasion
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000171
+id: METPO:1000171
 name: obsolete laboratory characteristic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000172
+id: METPO:1000172
 name: obsolete lag phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000173
+id: METPO:1000173
 name: obsolete life cycle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000174
+id: METPO:1000174
 name: obsolete life cycle phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000175
+id: METPO:1000175
 name: obsolete lipolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000176
+id: METPO:1000176
 name: obsolete lipopolysaccharide
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000177
+id: METPO:1000177
 name: obsolete localization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000178
+id: METPO:1000178
 name: obsolete lysogeny
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000179
+id: METPO:1000179
 name: obsolete macroscopic trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000180
+id: METPO:1000180
 name: obsolete magnetotaxis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000181
+id: METPO:1000181
 name: obsolete mesophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000615
+replaced_by: METPO:1000615
 
 [Term]
-id: metpo:1000182
+id: METPO:1000182
 name: obsolete metabolic partner
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000183
+id: METPO:1000183
 name: obsolete metabolic trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000184
+id: METPO:1000184
 name: obsolete methanogenesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000844
+replaced_by: METPO:1000844
 
 [Term]
-id: metpo:1000185
+id: METPO:1000185
 name: obsolete methylation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000186
+id: METPO:1000186
 name: material entity
 def: "An object or portion of a substance or mixture of substances that consists of matter" [] {IAO:0000119="BFO:0000040"}
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000187
+id: METPO:1000187
 name: obsolete process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000188
+id: METPO:1000188
 name: quality
 def: "A characteristic of an entity that depends on the entity's existence, size, color, and physiological traits." []
 
 [Term]
-id: metpo:1000189
+id: METPO:1000189
 name: obsolete system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000190
+id: METPO:1000190
 name: obsolete microaerophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:1000191
+id: METPO:1000191
 name: obsolete mobile genetic element
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000192
+id: METPO:1000192
 name: obsolete moderate halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000623
+replaced_by: METPO:1000623
 
 [Term]
-id: metpo:1000193
+id: METPO:1000193
 name: obsolete morphological trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000194
+id: METPO:1000194
 name: obsolete motility process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000195
+id: METPO:1000195
 name: obsolete motility structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000196
+id: METPO:1000196
 name: obsolete mutualism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000197
+id: METPO:1000197
 name: obsolete mycolic acid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000198
+id: METPO:1000198
 name: obsolete mycorrhization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000199
+id: METPO:1000199
 name: obsolete neutrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003001
+replaced_by: METPO:1003001
 
 [Term]
-id: metpo:1000200
+id: METPO:1000200
 name: obsolete nitrification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005001
+replaced_by: METPO:1005001
 
 [Term]
-id: metpo:1000201
+id: METPO:1000201
 name: obsolete nitrogen fixation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1000202
+id: METPO:1000202
 name: obsolete nodulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000203
+id: METPO:1000203
 name: obsolete nucleoid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000204
+id: METPO:1000204
 name: obsolete nutrient utilization
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000205
+id: METPO:1000205
 name: obsolete obligate
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000206
+id: METPO:1000206
 name: obsolete obligate aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:1000207
+id: METPO:1000207
 name: obsolete obligate anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:1000208
+id: METPO:1000208
 name: obsolete oospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000209
+id: METPO:1000209
 name: obsolete order
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000210
+id: METPO:1000210
 name: obsolete microbe characterized by growth conditions
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000211
+id: METPO:1000211
 name: obsolete microbe characterized by nutritional requirement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000212
+id: METPO:1000212
 name: obsolete microbe characterized by product produced
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000213
+id: METPO:1000213
 name: obsolete microbe characterized by relation to oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000214
+id: METPO:1000214
 name: obsolete microbe characterized by relation to ph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000215
+id: METPO:1000215
 name: obsolete microbe characterized by relation to pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000216
+id: METPO:1000216
 name: obsolete microbe characterized by relation to salt concentration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000217
+id: METPO:1000217
 name: obsolete microbe characterized by relation to temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000218
+id: METPO:1000218
 name: obsolete microbe characterized by shape
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000219
+id: METPO:1000219
 name: obsolete microbe characterized by trophic type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000220
+id: METPO:1000220
 name: obsolete osmophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000221
+id: METPO:1000221
 name: obsolete osmoregulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000222
+id: METPO:1000222
 name: obsolete oxidative stress response
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000223
+id: METPO:1000223
 name: obsolete oxidoreductase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000224
+id: METPO:1000224
 name: obsolete oxygen requirement
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000225
+id: METPO:1000225
 name: obsolete oxygenic photosynthesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000226
+id: METPO:1000226
 name: obsolete pan-genome
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000227
+id: METPO:1000227
 name: obsolete parasitism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000228
+id: METPO:1000228
 name: obsolete passive transport
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000229
+id: METPO:1000229
 name: obsolete pathogenicity
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000230
+id: METPO:1000230
 name: obsolete pathogenicity island
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000231
+id: METPO:1000231
 name: obsolete peptidoglycan
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000232
+id: METPO:1000232
 name: pH delta
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000233
+id: METPO:1000233
 name: obsolete pH optimum (growth range)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000234
+id: METPO:1000234
 name: obsolete pH preference
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000235
+id: METPO:1000235
 name: obsolete pH range (growth tolerance)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000236
+id: METPO:1000236
 name: obsolete pH tolerance
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000237
+id: METPO:1000237
 name: obsolete phage defense
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000238
+id: METPO:1000238
 name: obsolete photoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000656
+replaced_by: METPO:1000656
 
 [Term]
-id: metpo:1000239
+id: METPO:1000239
 name: obsolete photoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000657
+replaced_by: METPO:1000657
 
 [Term]
-id: metpo:1000240
+id: METPO:1000240
 name: obsolete photosynthesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000241
+id: METPO:1000241
 name: obsolete phototaxis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000242
+id: METPO:1000242
 name: obsolete phylum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000243
+id: METPO:1000243
 name: obsolete physiological process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000630
+replaced_by: METPO:1000630
 
 [Term]
-id: metpo:1000244
+id: METPO:1000244
 name: obsolete physiological state
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000245
+id: METPO:1000245
 name: obsolete physiological trait
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000246
+id: METPO:1000246
 name: obsolete piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000247
+id: METPO:1000247
 name: obsolete pigment
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000248
+id: METPO:1000248
 name: obsolete pigmentation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1003021
+replaced_by: METPO:1003021
 
 [Term]
-id: metpo:1000249
+id: METPO:1000249
 name: obsolete pilus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000250
+id: METPO:1000250
 name: obsolete plant growth promotion
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000251
+id: METPO:1000251
 name: obsolete plasmid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000252
+id: METPO:1000252
 name: obsolete pleomorphism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000253
+id: METPO:1000253
 name: obsolete process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000254
+id: METPO:1000254
 name: obsolete prophage
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000255
+id: METPO:1000255
 name: obsolete prostheca
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000256
+id: METPO:1000256
 name: obsolete protein synthesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000257
+id: METPO:1000257
 name: obsolete proteolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000258
+id: METPO:1000258
 name: obsolete prototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000259
+id: METPO:1000259
 name: obsolete psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000614
+replaced_by: METPO:1000614
 
 [Term]
-id: metpo:1000260
+id: METPO:1000260
 name: obsolete qualifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000261
+id: METPO:1000261
 name: obsolete quorum sensing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000262
+id: METPO:1000262
 name: obsolete regulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000263
+id: METPO:1000263
 name: obsolete regulatory mechanism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000264
+id: METPO:1000264
 name: obsolete reproductive process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000265
+id: METPO:1000265
 name: obsolete reproductive structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000266
+id: METPO:1000266
 name: obsolete resistance mechanism
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000267
+id: METPO:1000267
 name: obsolete respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000800
+replaced_by: METPO:1000800
 
 [Term]
-id: metpo:1000268
+id: METPO:1000268
 name: obsolete restriction-modification system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000269
+id: METPO:1000269
 name: obsolete ribosome
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000270
+id: METPO:1000270
 name: obsolete S-layer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000271
+id: METPO:1000271
 name: obsolete salinity delta
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000272
+id: METPO:1000272
 name: obsolete salinity preference
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000273
+id: METPO:1000273
 name: obsolete secondary metabolite
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000274
+id: METPO:1000274
 name: obsolete secretion
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000275
+id: METPO:1000275
 name: obsolete secretion system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000276
+id: METPO:1000276
 name: obsolete sheathed
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000277
+id: METPO:1000277
 name: obsolete siderophore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000278
+id: METPO:1000278
 name: obsolete sigma factor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000279
+id: METPO:1000279
 name: obsolete signaling
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000280
+id: METPO:1000280
 name: obsolete slime layer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000281
+id: METPO:1000281
 name: obsolete specialized cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000282
+id: METPO:1000282
 name: obsolete species
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000283
+id: METPO:1000283
 name: obsolete spirillum
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000284
+id: METPO:1000284
 name: obsolete spirochete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000285
+id: METPO:1000285
 name: obsolete sporangiospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000286
+id: METPO:1000286
 name: obsolete sporulation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000870
+replaced_by: METPO:1000870
 
 [Term]
-id: metpo:1000287
+id: METPO:1000287
 name: obsolete square cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000288
+id: METPO:1000288
 name: obsolete stalk
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000289
+id: METPO:1000289
 name: obsolete star-shaped cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000290
+id: METPO:1000290
 name: obsolete stationary phase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000291
+id: METPO:1000291
 name: obsolete storage structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000292
+id: METPO:1000292
 name: obsolete strain
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000293
+id: METPO:1000293
 name: obsolete stress response
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000294
+id: METPO:1000294
 name: obsolete structure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000295
+id: METPO:1000295
 name: obsolete sulfate reducer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000296
+id: METPO:1000296
 name: obsolete swarming
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000297
+id: METPO:1000297
 name: obsolete symbiosis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000298
+id: METPO:1000298
 name: obsolete symbiotic process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000299
+id: METPO:1000299
 name: obsolete syntrophy
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1002006
+replaced_by: METPO:1002006
 
 [Term]
-id: metpo:1000300
+id: METPO:1000300
 name: obsolete taxonomic identifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000301
+id: METPO:1000301
 name: obsolete taxonomic rank
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000302
+id: METPO:1000302
 name: obsolete teichoic acid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000303
+id: METPO:1000303
 name: temperature delta
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000304
+id: METPO:1000304
 name: temperature optimum
 def: "A temperature phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction." [] {IAO:0000119="https://purl.dsmz.de/schema/OptimumTemperature"}
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000305
+id: METPO:1000305
 name: obsolete temperature preference
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000613
+replaced_by: METPO:1000613
 
 [Term]
-id: metpo:1000306
+id: METPO:1000306
 name: temperature range
-is_a: metpo:1000533 ! temperature phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000533 ! temperature phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 
 [Term]
-id: metpo:1000307
+id: METPO:1000307
 name: obsolete thermal tolerance
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000308
+id: METPO:1000308
 name: obsolete thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
-replaced_by: metpo:1000616
+replaced_by: METPO:1000616
 
 [Term]
-id: metpo:1000309
+id: METPO:1000309
 name: obsolete toxin
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000310
+id: METPO:1000310
 name: obsolete transcription factor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000311
+id: METPO:1000311
 name: obsolete transduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000312
+id: METPO:1000312
 name: obsolete transferase
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000313
+id: METPO:1000313
 name: obsolete transformation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000314
+id: METPO:1000314
 name: obsolete transport system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000315
+id: METPO:1000315
 name: obsolete transposon
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000316
+id: METPO:1000316
 name: obsolete triangular cell
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000317
+id: METPO:1000317
 name: obsolete trichome
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000318
+id: METPO:1000318
 name: obsolete twitching motility
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000319
+id: METPO:1000319
 name: obsolete two-component system
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000320
+id: METPO:1000320
 name: obsolete viable but non-culturable
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000321
+id: METPO:1000321
 name: obsolete vibrio
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000322
+id: METPO:1000322
 name: obsolete virulence
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000323
+id: METPO:1000323
 name: obsolete virulence factor
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000324
+id: METPO:1000324
 name: obsolete virulence process
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000325
+id: METPO:1000325
 name: obsolete xylanolysis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000326
+id: METPO:1000326
 name: obsolete zoospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000327
+id: METPO:1000327
 name: obsolete zygospore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 OMO:0001000
 is_obsolete: true
 
 [Term]
-id: metpo:1000328
+id: METPO:1000328
 name: obsolete pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000329
+id: METPO:1000329
 name: obsolete temperature optimum (metabolic activity)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000330
+id: METPO:1000330
 name: obsolete temperature range (metabolic viability)
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000331
+id: METPO:1000331
 name: pH optimum
 def: "A pH phenotype with numerical limits that represents the conditions at which an organism exhibits the most efficient growth and reproduction." []
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 
 [Term]
-id: metpo:1000332
+id: METPO:1000332
 name: pH range
-is_a: metpo:1000531 ! pH phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000531 ! pH phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000333
+id: METPO:1000333
 name: NaCl optimum
 def: "A salinity phenotype with numerical limits that supports the most efficient growth and reproduction of an organism." [] {IAO:0000119="https://purl.dsmz.de/schema/OptimumSalinity"}
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000536 ! optimum phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000536 ! optimum phenotype with numerical limits
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000334
+id: METPO:1000334
 name: NaCl range
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000535 ! growth range phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000535 ! growth range phenotype with numerical limits
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000335
+id: METPO:1000335
 name: NaCl delta
-is_a: metpo:1000532 ! salinity phenotype with numerical limits
-is_a: metpo:1000534 ! delta phenotype with numerical limits
+is_a: METPO:1000532 ! salinity phenotype with numerical limits
+is_a: METPO:1000534 ! delta phenotype with numerical limits
 
 [Term]
-id: metpo:1000336
+id: METPO:1000336
 name: obsolete psychrotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000618
+replaced_by: METPO:1000618
 
 [Term]
-id: metpo:1000337
+id: METPO:1000337
 name: obsolete thermotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000619
+replaced_by: METPO:1000619
 
 [Term]
-id: metpo:1000338
+id: METPO:1000338
 name: obsolete extreme thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:1000339
+id: METPO:1000339
 name: obsolete extreme hyperthermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000721
+replaced_by: METPO:1000721
 
 [Term]
-id: metpo:1000340
+id: METPO:1000340
 name: obsolete non-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000624
+replaced_by: METPO:1000624
 
 [Term]
-id: metpo:1000341
+id: METPO:1000341
 name: obsolete slight halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000625
+replaced_by: METPO:1000625
 
 [Term]
-id: metpo:1000342
+id: METPO:1000342
 name: obsolete haloalkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000621
+replaced_by: METPO:1000621
 
 [Term]
-id: metpo:1000343
+id: METPO:1000343
 name: obsolete extreme acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000344
+id: METPO:1000344
 name: obsolete acid tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000345
+id: METPO:1000345
 name: obsolete alkali tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000346
+id: METPO:1000346
 name: obsolete extreme alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000347
+id: METPO:1000347
 name: obsolete facultative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1003007
+replaced_by: METPO:1003007
 
 [Term]
-id: metpo:1000348
+id: METPO:1000348
 name: obsolete obligative acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1003006
+replaced_by: METPO:1003006
 
 [Term]
-id: metpo:1000349
+id: METPO:1000349
 name: obsolete facultative aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000608
+replaced_by: METPO:1000608
 
 [Term]
-id: metpo:1000350
+id: METPO:1000350
 name: obsolete microaerophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000604
+replaced_by: METPO:1000604
 
 [Term]
-id: metpo:1000351
+id: METPO:1000351
 name: obsolete microaerotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000610
+replaced_by: METPO:1000610
 
 [Term]
-id: metpo:1000352
+id: METPO:1000352
 name: obsolete aerotolerant anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000353
+id: METPO:1000353
 name: obsolete obligate aerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000606
+replaced_by: METPO:1000606
 
 [Term]
-id: metpo:1000354
+id: METPO:1000354
 name: obsolete obligate anaerobe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000607
+replaced_by: METPO:1000607
 
 [Term]
-id: metpo:1000355
+id: METPO:1000355
 name: obsolete oxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000356
+id: METPO:1000356
 name: obsolete anoxygenic phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000357
+id: METPO:1000357
 name: obsolete chemoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000635
+replaced_by: METPO:1000635
 
 [Term]
-id: metpo:1000358
+id: METPO:1000358
 name: obsolete chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000359
+id: METPO:1000359
 name: obsolete lithotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000649
+replaced_by: METPO:1000649
 
 [Term]
-id: metpo:1000360
+id: METPO:1000360
 name: obsolete organotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000655
+replaced_by: METPO:1000655
 
 [Term]
-id: metpo:1000361
+id: METPO:1000361
 name: obsolete phototroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000660
+replaced_by: METPO:1000660
 
 [Term]
-id: metpo:1000362
+id: METPO:1000362
 name: obsolete chemotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000641
+replaced_by: METPO:1000641
 
 [Term]
-id: metpo:1000363
+id: METPO:1000363
 name: obsolete oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000654
+replaced_by: METPO:1000654
 
 [Term]
-id: metpo:1000364
+id: METPO:1000364
 name: obsolete copiotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000642
+replaced_by: METPO:1000642
 
 [Term]
-id: metpo:1000365
+id: METPO:1000365
 name: obsolete lithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000647
+replaced_by: METPO:1000647
 
 [Term]
-id: metpo:1000366
+id: METPO:1000366
 name: obsolete mixotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000652
+replaced_by: METPO:1000652
 
 [Term]
-id: metpo:1000367
+id: METPO:1000367
 name: obsolete lithoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000648
+replaced_by: METPO:1000648
 
 [Term]
-id: metpo:1000368
+id: METPO:1000368
 name: obsolete chemoorganoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000640
+replaced_by: METPO:1000640
 
 [Term]
-id: metpo:1000369
+id: METPO:1000369
 name: obsolete chemolithoautotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000637
+replaced_by: METPO:1000637
 
 [Term]
-id: metpo:1000370
+id: METPO:1000370
 name: obsolete methylotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000651
+replaced_by: METPO:1000651
 
 [Term]
-id: metpo:1000371
+id: METPO:1000371
 name: obsolete methanotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000650
+replaced_by: METPO:1000650
 
 [Term]
-id: metpo:1000372
+id: METPO:1000372
 name: obsolete hydrogenotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000646
+replaced_by: METPO:1000646
 
 [Term]
-id: metpo:1000373
+id: METPO:1000373
 name: obsolete hydrogen oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000374
+id: METPO:1000374
 name: obsolete hydrogen producer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000375
+id: METPO:1000375
 name: obsolete nitrogen fixer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000376
+id: METPO:1000376
 name: obsolete methanogen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000377
+id: METPO:1000377
 name: obsolete sulfur oxidizer
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000378
+id: METPO:1000378
 name: obsolete denitrifier
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000379
+id: METPO:1000379
 name: obsolete motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000702
+replaced_by: METPO:1000702
 
 [Term]
-id: metpo:1000380
+id: METPO:1000380
 name: obsolete non-motile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000703
+replaced_by: METPO:1000703
 
 [Term]
-id: metpo:1000381
+id: METPO:1000381
 name: obsolete flagellated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000704
+replaced_by: METPO:1000704
 
 [Term]
-id: metpo:1000382
+id: METPO:1000382
 name: obsolete peritrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000383
+id: METPO:1000383
 name: obsolete lophotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000384
+id: METPO:1000384
 name: obsolete monotrichous
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000385
+id: METPO:1000385
 name: obsolete ciliated
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000386
+id: METPO:1000386
 name: obsolete gliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000706
+replaced_by: METPO:1000706
 
 [Term]
-id: metpo:1000387
+id: METPO:1000387
 name: obsolete twitching
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000388
+id: METPO:1000388
 name: obsolete sliding
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000389
+id: METPO:1000389
 name: obsolete myxospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000390
+id: METPO:1000390
 name: obsolete conidia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000391
+id: METPO:1000391
 name: obsolete chlamydospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000392
+id: METPO:1000392
 name: obsolete sporocysts
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000393
+id: METPO:1000393
 name: obsolete hypnospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000394
+id: METPO:1000394
 name: obsolete gemmae
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000395
+id: METPO:1000395
 name: obsolete azygospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000396
+id: METPO:1000396
 name: obsolete aleuriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000397
+id: METPO:1000397
 name: obsolete stylospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000398
+id: METPO:1000398
 name: obsolete sclerotia
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000399
+id: METPO:1000399
 name: obsolete teliospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000400
+id: METPO:1000400
 name: obsolete urediniospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000401
+id: METPO:1000401
 name: obsolete pycnidiospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000402
+id: METPO:1000402
 name: obsolete acriospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000403
+id: METPO:1000403
 name: obsolete aplanospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000404
+id: METPO:1000404
 name: obsolete statismospores
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000405
+id: METPO:1000405
 name: obsolete piezotolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000406
+id: METPO:1000406
 name: obsolete piezosensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000407
+id: METPO:1000407
 name: obsolete obligate barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000408
+id: METPO:1000408
 name: obsolete facultative barophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000409
+id: METPO:1000409
 name: obsolete hyperbarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000410
+id: METPO:1000410
 name: obsolete hypobarophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000411
+id: METPO:1000411
 name: obsolete atmospheric pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000412
+id: METPO:1000412
 name: obsolete moderate piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000413
+id: METPO:1000413
 name: obsolete extreme piezophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000414
+id: METPO:1000414
 name: obsolete stenopiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000415
+id: METPO:1000415
 name: obsolete eurypiezic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000416
+id: METPO:1000416
 name: obsolete pressure-sensitive
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000417
+id: METPO:1000417
 name: obsolete pressure-resistant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000418
+id: METPO:1000418
 name: obsolete pressure-adapted
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000419
+id: METPO:1000419
 name: obsolete piezo-acidophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000420
+id: METPO:1000420
 name: obsolete piezo-alkaliphile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000421
+id: METPO:1000421
 name: obsolete piezo-halophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000422
+id: METPO:1000422
 name: obsolete piezo-psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000423
+id: METPO:1000423
 name: obsolete piezo-thermophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000424
+id: METPO:1000424
 name: obsolete piezo-lithoautotrophe
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000425
+id: METPO:1000425
 name: obsolete piezo-chemoheterotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000636
+replaced_by: METPO:1000636
 
 [Term]
-id: metpo:1000426
+id: METPO:1000426
 name: obsolete piezo-oligotroph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000427
+id: METPO:1000427
 name: obsolete piezo-endolithic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000428
+id: METPO:1000428
 name: obsolete piezo-tolerant
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000429
+id: METPO:1000429
 name: GC low
 synonym: "GC_<=42.65" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "42.65" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "42.65" xsd:string
 
 [Term]
-id: metpo:1000430
+id: METPO:1000430
 name: GC mid1
 synonym: "GC_42.65_57.0" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "57" xsd:string
-property_value: metpo:range_min "42.65" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "57" xsd:string
+property_value: METPO:range_min "42.65" xsd:string
 
 [Term]
-id: metpo:1000431
+id: METPO:1000431
 name: GC mid2
 synonym: "GC_57.0_66.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_max "66.3" xsd:string
-property_value: metpo:range_min "57" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_max "66.3" xsd:string
+property_value: METPO:range_min "57" xsd:string
 
 [Term]
-id: metpo:1000432
+id: METPO:1000432
 name: GC high
 synonym: "GC_>66.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000127 ! GC content
-property_value: metpo:range_min "66.3" xsd:string
+is_a: METPO:1000127 ! GC content
+property_value: METPO:range_min "66.3" xsd:string
 
 [Term]
-id: metpo:1000433
+id: METPO:1000433
 name: obsolete cell width very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000887
+replaced_by: METPO:1000887
 
 [Term]
-id: metpo:1000434
+id: METPO:1000434
 name: obsolete cell width low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:1000435
+id: METPO:1000435
 name: obsolete cell width mid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000889
+replaced_by: METPO:1000889
 
 [Term]
-id: metpo:1000436
+id: METPO:1000436
 name: obsolete cell width high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000882
+replaced_by: METPO:1000882
 
 [Term]
-id: metpo:1000437
+id: METPO:1000437
 name: obsolete cell length very low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000883
+replaced_by: METPO:1000883
 
 [Term]
-id: metpo:1000438
+id: METPO:1000438
 name: obsolete cell length low
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:1000439
+id: METPO:1000439
 name: obsolete cell length mid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000885
+replaced_by: METPO:1000885
 
 [Term]
-id: metpo:1000440
+id: METPO:1000440
 name: obsolete cell length high
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000881
+replaced_by: METPO:1000881
 
 [Term]
-id: metpo:1000441
+id: METPO:1000441
 name: temperature optimum very low
 synonym: "Psychrophile" EXACT []
 synonym: "TO_<=10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "10" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000442
+id: METPO:1000442
 name: temperature optimum low
 synonym: "Psychrophile" EXACT []
 synonym: "Psychrotolerant" EXACT []
 synonym: "TO_10_to_22" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "22" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "22" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000443
+id: METPO:1000443
 name: temperature optimum mid1
 synonym: "mesophilic" EXACT []
 synonym: "TO_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "27" xsd:string
-property_value: metpo:range_min "22" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "27" xsd:string
+property_value: METPO:range_min "22" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000444
+id: METPO:1000444
 name: temperature optimum mid2
 synonym: "mesophilic" EXACT []
 synonym: "TO_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "27" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "27" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000445
+id: METPO:1000445
 name: temperature optimum mid3
 synonym: "mesophilic" EXACT []
 synonym: "TO_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "34" xsd:string
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "34" xsd:string
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000446
+id: METPO:1000446
 name: temperature optimum mid4
 synonym: "mesophilic" EXACT []
 synonym: "TO_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_max "40" xsd:string
-property_value: metpo:range_min "34" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_max "40" xsd:string
+property_value: METPO:range_min "34" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000447
+id: METPO:1000447
 name: temperature optimum high
 synonym: "Thermophile" EXACT []
 synonym: "TO_>40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000304 ! temperature optimum
-property_value: metpo:range_min "40" xsd:string
+is_a: METPO:1000304 ! temperature optimum
+property_value: METPO:range_min "40" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000448
+id: METPO:1000448
 name: temperature range very low
 synonym: "Psychrophile" EXACT []
 synonym: "TR_<=10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "10" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000449
+id: METPO:1000449
 name: temperature range low
 synonym: "Psychrophile" EXACT []
 synonym: "Psychrotolerant" EXACT []
 synonym: "TR_10_to_22" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "22" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "22" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000450
+id: METPO:1000450
 name: temperature range mid1
 synonym: "mesophilic" EXACT []
 synonym: "TR_22_to_27" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "27" xsd:string
-property_value: metpo:range_min "22" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "27" xsd:string
+property_value: METPO:range_min "22" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000451
+id: METPO:1000451
 name: temperature range mid2
 synonym: "mesophilic" EXACT []
 synonym: "TR_27_to_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "27" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "27" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000452
+id: METPO:1000452
 name: temperature range mid3
 synonym: "mesophilic" EXACT []
 synonym: "TR_30_to_34" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "34" xsd:string
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "34" xsd:string
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000453
+id: METPO:1000453
 name: temperature range mid4
 synonym: "mesophilic" EXACT []
 synonym: "TR_34_to_40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_max "40" xsd:string
-property_value: metpo:range_min "34" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_max "40" xsd:string
+property_value: METPO:range_min "34" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000454
+id: METPO:1000454
 name: temperature range high
 synonym: "Thermophile" EXACT []
 synonym: "TR_>40" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000306 ! temperature range
-property_value: metpo:range_min "40" xsd:string
+is_a: METPO:1000306 ! temperature range
+property_value: METPO:range_min "40" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000455
+id: METPO:1000455
 name: pH optimum low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
@@ -7585,44 +7585,44 @@ synonym: "Extreme Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHO_0_to_6" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "6" xsd:string
-property_value: metpo:range_min "0" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "6" xsd:string
+property_value: METPO:range_min "0" xsd:string
 
 [Term]
-id: metpo:1000456
+id: METPO:1000456
 name: pH optimum mid1
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHO_6_to_7" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "7" xsd:string
-property_value: metpo:range_min "6" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "7" xsd:string
+property_value: METPO:range_min "6" xsd:string
 
 [Term]
-id: metpo:1000457
+id: METPO:1000457
 name: pH optimum mid2
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHO_7_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "7" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "7" xsd:string
 
 [Term]
-id: metpo:1000458
+id: METPO:1000458
 name: pH optimum high
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
 synonym: "pHO_8_to_14" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000331 ! pH optimum
-property_value: metpo:range_max "14" xsd:string
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000331 ! pH optimum
+property_value: METPO:range_max "14" xsd:string
+property_value: METPO:range_min "8" xsd:string
 
 [Term]
-id: metpo:1000459
+id: METPO:1000459
 name: pH range very low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
@@ -7630,1054 +7630,1054 @@ synonym: "Extreme Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHR_0_to_4" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "4" xsd:string
-property_value: metpo:range_min "0" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "4" xsd:string
+property_value: METPO:range_min "0" xsd:string
 
 [Term]
-id: metpo:1000460
+id: METPO:1000460
 name: pH range low
 synonym: "Acid Tolerant" EXACT []
 synonym: "Acidophile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Obligative acidophile" EXACT []
 synonym: "pHR_4_to_6" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "6" xsd:string
-property_value: metpo:range_min "4" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "6" xsd:string
+property_value: METPO:range_min "4" xsd:string
 
 [Term]
-id: metpo:1000461
+id: METPO:1000461
 name: pH range mid1
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHR_6_to_7" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "7" xsd:string
-property_value: metpo:range_min "6" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "7" xsd:string
+property_value: METPO:range_min "6" xsd:string
 
 [Term]
-id: metpo:1000462
+id: METPO:1000462
 name: pH range mid2
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "Neutrophile" EXACT []
 synonym: "pHR_7_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "7" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "7" xsd:string
 
 [Term]
-id: metpo:1000463
+id: METPO:1000463
 name: pH range mid3
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
 synonym: "Facultative acidophile" EXACT []
 synonym: "pHR_8_to_10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "10" xsd:string
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "10" xsd:string
+property_value: METPO:range_min "8" xsd:string
 
 [Term]
-id: metpo:1000464
+id: METPO:1000464
 name: pH range high
 synonym: "10_to_14" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Alkali Tolerant" EXACT []
 synonym: "Alkaliphile" EXACT []
 synonym: "Extreme Alkaliphile" EXACT []
-is_a: metpo:1000332 ! pH range
-property_value: metpo:range_max "14" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000332 ! pH range
+property_value: METPO:range_max "14" xsd:string
+property_value: METPO:range_min "10" xsd:string
 
 [Term]
-id: metpo:1000465
+id: METPO:1000465
 name: NaCl optimum low
 synonym: "Halotolerant" EXACT []
 synonym: "NaO_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Non-halophile" EXACT []
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000466
+id: METPO:1000466
 name: NaCl optimum mid1
 synonym: "Halotolerant" EXACT []
 synonym: "NaO_1_to_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Slight halophile" EXACT []
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000467
+id: METPO:1000467
 name: NaCl optimum mid2
 synonym: "Halotolerant" EXACT []
 synonym: "Moderate halophile" EXACT []
 synonym: "NaO_3_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000468
+id: METPO:1000468
 name: NaCl optimum high
 synonym: "Extreme halophile" EXACT []
 synonym: "NaO_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000333 ! NaCl optimum
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000333 ! NaCl optimum
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000469
+id: METPO:1000469
 name: NaCl range low
 synonym: "Halotolerant" EXACT []
 synonym: "NaR_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Non-halophile" EXACT []
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000470
+id: METPO:1000470
 name: NaCl range mid1
 synonym: "Halotolerant" EXACT []
 synonym: "NaR_1_to_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "Slight halophile" EXACT []
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000471
+id: METPO:1000471
 name: NaCl range mid2
 synonym: "Halotolerant" EXACT []
 synonym: "Moderate halophile" EXACT []
 synonym: "NaR_3_to_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000472
+id: METPO:1000472
 name: NaCl range high
 synonym: "Extreme halophile" EXACT []
 synonym: "NaR_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000334 ! NaCl range
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000334 ! NaCl range
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000473
+id: METPO:1000473
 name: pH delta very low
 synonym: "pHd_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "1" xsd:string
 
 [Term]
-id: metpo:1000474
+id: METPO:1000474
 name: pH delta low
 synonym: "pHd_1_2" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "2" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "2" xsd:string
+property_value: METPO:range_min "1" xsd:string
 
 [Term]
-id: metpo:1000475
+id: METPO:1000475
 name: pH delta mid1
 synonym: "pHd_2_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "2" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "2" xsd:string
 
 [Term]
-id: metpo:1000476
+id: METPO:1000476
 name: pH delta mid2
 synonym: "pHd_3_4" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "4" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "4" xsd:string
+property_value: METPO:range_min "3" xsd:string
 
 [Term]
-id: metpo:1000477
+id: METPO:1000477
 name: pH delta mid3
 synonym: "pHd_4_5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "5" xsd:string
-property_value: metpo:range_min "4" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "5" xsd:string
+property_value: METPO:range_min "4" xsd:string
 
 [Term]
-id: metpo:1000478
+id: METPO:1000478
 name: pH delta high
 synonym: "pHd_5_9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000232 ! pH delta
-property_value: metpo:range_max "9" xsd:string
-property_value: metpo:range_min "5" xsd:string
+is_a: METPO:1000232 ! pH delta
+property_value: METPO:range_max "9" xsd:string
+property_value: METPO:range_min "5" xsd:string
 
 [Term]
-id: metpo:1000479
+id: METPO:1000479
 name: NaCl delta low
 synonym: "Nad_<=1" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "1" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000480
+id: METPO:1000480
 name: NaCl delta mid1
 synonym: "Nad_1_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000481
+id: METPO:1000481
 name: NaCl delta mid2
 synonym: "Nad_3_8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_max "8" xsd:string
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_max "8" xsd:string
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000482
+id: METPO:1000482
 name: NaCl delta high
 synonym: "Nad_>8" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000335 ! NaCl delta
-property_value: metpo:range_min "8" xsd:string
+is_a: METPO:1000335 ! NaCl delta
+property_value: METPO:range_min "8" xsd:string
 property_value: qudt:ucumCode "%" xsd:string
 
 [Term]
-id: metpo:1000483
+id: METPO:1000483
 name: temperature delta very low
 synonym: "Td_1_5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "5" xsd:string
-property_value: metpo:range_min "1" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "5" xsd:string
+property_value: METPO:range_min "1" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000484
+id: METPO:1000484
 name: temperature delta low
 synonym: "Td_5_10" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "10" xsd:string
-property_value: metpo:range_min "5" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "10" xsd:string
+property_value: METPO:range_min "5" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000485
+id: METPO:1000485
 name: temperature delta mid1
 synonym: "Td_10_20" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "20" xsd:string
-property_value: metpo:range_min "10" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "20" xsd:string
+property_value: METPO:range_min "10" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000486
+id: METPO:1000486
 name: temperature delta mid2
 synonym: "Td_20_30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_max "30" xsd:string
-property_value: metpo:range_min "20" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_max "30" xsd:string
+property_value: METPO:range_min "20" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000487
+id: METPO:1000487
 name: temperature delta high
 synonym: "Td_>30" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000303 ! temperature delta
-property_value: metpo:range_min "30" xsd:string
+is_a: METPO:1000303 ! temperature delta
+property_value: METPO:range_min "30" xsd:string
 property_value: qudt:ucumCode "Cel" xsd:string
 
 [Term]
-id: metpo:1000488
+id: METPO:1000488
 name: obsolete branched
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000489
+id: METPO:1000489
 name: obsolete coccobacillus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000490
+id: METPO:1000490
 name: obsolete crescent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000491
+id: METPO:1000491
 name: obsolete curved
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000492
+id: METPO:1000492
 name: obsolete curved spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000493
+id: METPO:1000493
 name: obsolete diplococcus
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000494
+id: METPO:1000494
 name: obsolete ellipsoidal
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000673
+replaced_by: METPO:1000673
 
 [Term]
-id: metpo:1000495
+id: METPO:1000495
 name: obsolete filament
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000496
+id: METPO:1000496
 name: obsolete fusiform
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000497
+id: METPO:1000497
 name: obsolete helical
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000498
+id: METPO:1000498
 name: obsolete irregular
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000499
+id: METPO:1000499
 name: obsolete oval
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000500
+id: METPO:1000500
 name: obsolete ovoid
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000501
+id: METPO:1000501
 name: obsolete pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000502
+id: METPO:1000502
 name: obsolete ring
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000503
+id: METPO:1000503
 name: obsolete rod
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000504
+id: METPO:1000504
 name: obsolete sphere
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000505
+id: METPO:1000505
 name: obsolete spindle
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000506
+id: METPO:1000506
 name: obsolete spiral
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000507
+id: METPO:1000507
 name: obsolete star - dumbbell - pleomorphic
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000508
+id: METPO:1000508
 name: obsolete tailed
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000509
+id: METPO:1000509
 name: obsolete temperature adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000510
+id: METPO:1000510
 name: obsolete salinity adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000511
+id: METPO:1000511
 name: obsolete pH adaptation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000512
+id: METPO:1000512
 name: obsolete bacterial spore
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000513
+id: METPO:1000513
 name: obsolete pressure adaptation type
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000514
+id: METPO:1000514
 name: obsolete pressure tolerance range
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1007070
+replaced_by: METPO:1007070
 
 [Term]
-id: metpo:1000515
+id: METPO:1000515
 name: obsolete sensitivity to oxygen
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000516
+id: METPO:1000516
 name: obsolete sensitivity toward
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000517
+id: METPO:1000517
 name: obsolete size
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000518
+id: METPO:1000518
 name: obsolete 1-D extent
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000519
+id: METPO:1000519
 name: obsolete width
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000520
+id: METPO:1000520
 name: obsolete length
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000521
+id: METPO:1000521
 name: obsolete sensitivity toward pressure
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000522
+id: METPO:1000522
 name: obsolete sensitivity toward nacl
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000523
+id: METPO:1000523
 name: obsolete sensitivity toward ph
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000524
+id: METPO:1000524
 name: obsolete sensitivity toward temperature
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000525
+id: METPO:1000525
 name: microbe
 def: "A material entity that is too small to be viewed by the unaided eye, typically requiring microscopy for observation." [] {IAO:0000119="OHMI:0000460"}
 comment: METPO is primarily concerned with unicellular, prokaryotic life forms, i.e. bacteria and archaea, including the cases of giant bacteria like Thiomargarita
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: IAO:0000117 "Luke Wang" xsd:string
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/OrganismTaxon
 
 [Term]
-id: metpo:1000526
+id: METPO:1000526
 name: chemical entity
 def: "A material entity that is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances." [] {IAO:0000119="CHEBI:24431"}
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: skos:closeMatch https://biolink.github.io/biolink-model/ChemicalEntity
 
 [Term]
-id: metpo:1000527
+id: METPO:1000527
 name: enzyme
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 
 [Term]
-id: metpo:1000528
+id: METPO:1000528
 name: obsolete structured susceptibility detail
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000529
+id: METPO:1000529
 name: obsolete facultative psychrophile
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000720
+replaced_by: METPO:1000720
 
 [Term]
-id: metpo:1000531
+id: METPO:1000531
 name: pH phenotype with numerical limits
 def: "A phenotype characterized by specific pH values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000532
+id: METPO:1000532
 name: salinity phenotype with numerical limits
 def: "A phenotype characterized by specific salt concentration values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000533
+id: METPO:1000533
 name: temperature phenotype with numerical limits
 def: "A phenotype characterized by specific temperature values or ranges that define growth or activity limits." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000534
+id: METPO:1000534
 name: delta phenotype with numerical limits
 def: "A phenotype characterized by the difference between maximum and minimum values of a growth parameter." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000535
+id: METPO:1000535
 name: growth range phenotype with numerical limits
 def: "A phenotype characterized by the span of values within which an organism can maintain growth." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000536
+id: METPO:1000536
 name: optimum phenotype with numerical limits
 def: "A phenotype characterized by the value at which an organism exhibits maximum growth rate or activity." []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000601
+id: METPO:1000601
 name: oxygen preference
 def: "A phenotype that is relating to an organism's oxygen requirements or tolerance for growth." [] {IAO:0000119="UPHENO:0049673", IAO:0000119="https://purl.dsmz.de/schema/OxygenTolerance"}
 synonym: "metabolism" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "oxygen preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Physiology and metabolism.oxygen tolerance.oxygen tolerance" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000602
+id: METPO:1000602
 name: aerobic
 def: "An oxygen preference in which growth occurs in the presence of molecular oxygen (O2), typically using O2 as the terminal electron acceptor." [] {IAO:0000119="ECOCORE:00000173", IAO:0000119="OMP:0005253"}
 synonym: "aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "aerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_aerobic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000603
+id: METPO:1000603
 name: anaerobic
 def: "An oxygen preference in which growth occurs in the absence of molecular oxygen (O2)." [] {IAO:0000119="MICRO:0000495"}
 synonym: "anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_anaerobic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000604
+id: METPO:1000604
 name: microaerophilic
 def: "An oxygen preference that requires molecular oxygen (O2) at concentrations lower than atmospheric." [] {IAO:0000119="ECOCORE:00000180", IAO:0000119="OMP:0005254", IAO:0000119="MICRO:0000515"}
 synonym: "microaerophile" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "microaerophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Ox_microerophile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000605
+id: METPO:1000605
 name: facultatively anaerobic
 def: "An oxygen preference in which growth can occur with or without molecular oxygen (O2)." [] {IAO:0000119="OMP:0000087", IAO:0000119="MICRO:0001520"}
 synonym: "facultative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "facultative anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "facultative anaerobe" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000606
+id: METPO:1000606
 name: obligately aerobic
 def: "An aerobic phenotype that requires molecular oxygen (O2) for growth." [] {IAO:0000119="MICRO:0000516"}
 synonym: "obligate aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "obligate aerobic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "obligate aerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000602 ! aerobic
+is_a: METPO:1000602 ! aerobic
 
 [Term]
-id: metpo:1000607
+id: METPO:1000607
 name: obligately anaerobic
 def: "An anaerobic phenotype in which molecular oxygen (O2) inhibits or prevents growth." [] {IAO:0000119="MICRO:0000504"}
 synonym: "obligate anaerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "obligate anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000603 ! anaerobic
+is_a: METPO:1000603 ! anaerobic
 
 [Term]
-id: metpo:1000608
+id: METPO:1000608
 name: facultatively aerobic
 def: "An oxygen preference in which growth can occur without oxygen but is capable of aerobic growth." [] {IAO:0000119="OMP:0000087", IAO:0000119="ECOCORE:00000177"}
 synonym: "facultative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "facultative aerobe" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000609
+id: METPO:1000609
 name: aerotolerant
 def: "An oxygen preference that does not use O2 for growth but tolerates its presence." [] {IAO:0000119="MICRO:0000502"}
 synonym: "aerotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "aerotolerant" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000610
+id: METPO:1000610
 name: microaerotolerant
 def: "An oxygen preference that tolerates low levels of molecular oxygen (O2) without requiring it." [] {IAO:0000119="ECOCORE:00000180", IAO:0000119="ECOCORE:00000181", IAO:0000119="OMP:0000087", IAO:0000119="OMP:0000105"}
 synonym: "microaerotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000611
+id: METPO:1000611
 name: strictly anaerobic
 def: "An obligately anaerobic where a microorganism does not grow in the presence of oxygen gas (O2)." [] {IAO:0000119="OMP:0000184"}
 synonym: "obligate anaerobic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "strictly anaerobic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000607 ! obligately anaerobic
+is_a: METPO:1000607 ! obligately anaerobic
 
 [Term]
-id: metpo:1000612
+id: METPO:1000612
 name: facultative oxygen preference
 def: "An oxygen preference that describes a microorganism that can grow with or without molecular oxygen." [] {IAO:0000119="OMP:0000087"}
 synonym: "Ox_facultative_aerobe_anaerobe" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1000613
+id: METPO:1000613
 name: temperature preference
 def: "A phenotype that describes characteristic growth with respect to environmental temperature." [] {IAO:0000119="OMP:0005002"}
 synonym: "Physiology and metabolism.culture temp.temperature" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "range_tmp" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "temperature preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000614
+id: METPO:1000614
 name: psychrophilic
 def: "A temperature preference in which growth is favored at low temperatures, typically near or below ~15 C." [] {IAO:0000119="MICRO:0001306"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "psychrophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000615
+id: METPO:1000615
 name: mesophilic
 def: "A temperature preference in which growth is favored at intermediate temperatures, typically ~20-45 C." [] {IAO:0000119="MICRO:0000111"}
 synonym: "mesophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "mesophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000616
+id: METPO:1000616
 name: thermophilic
 def: "A temperature preference in which growth is favored at elevated temperatures, typically >=45 C." [] {IAO:0000119="OMP:0005003", IAO:0000119="OMP:0005004", IAO:0000119="MICRO:0000118"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "thermophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000617
+id: METPO:1000617
 name: hyperthermophilic
 def: "A temperature preference in which growth is favored at very high temperatures, typically >=80 C." [] {IAO:0000119="MICRO:0001538"}
 synonym: "extreme thermophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "hyperthermophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000618
+id: METPO:1000618
 name: psychrotolerant
 def: "A temperature preference in which growth can occur at low temperatures without an obligate low-temperature preference." [] {IAO:0000119="MICRO:0001310", IAO:0000119="OMP:0005007", IAO:0000119="OMP:0005006"}
 synonym: "psychrotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000619
+id: METPO:1000619
 name: thermotolerant
 def: "A temperature preference in which growth can occur at elevated temperatures without an obligate high-temperature preference." [] {IAO:0000119="MICRO:0001286"}
 synonym: "thermotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 
 [Term]
-id: metpo:1000620
+id: METPO:1000620
 name: halophilic
 def: "A halophily preference in which an organism requires high concentrations of salt for growth and survival." [] {IAO:0000119="GO:0170002", IAO:0000119="OMP:0005016", IAO:0000119="MICRO:0001315", IAO:0000119="MICRO:0001314"}
 synonym: "halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000621
+id: METPO:1000621
 name: haloalkaliphilic
 def: "A halophily preference in which an organism requires both high salt concentrations and alkaline pH for optimal growth." [] {IAO:0000119="MICRO:0001392", IAO:0000119="MICRO:0001554", IAO:0000119="OMP:0005011", IAO:0000119="MICRO:0001314"}
 synonym: "haloalkaliphilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000622
+id: METPO:1000622
 name: halotolerant
 def: "A halophily preference in which an organism can tolerate high salt concentrations but does not require them for growth." [] {IAO:0000119="MICRO:0001316"}
 synonym: "halotolerant" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "halotolerant" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000623
+id: METPO:1000623
 name: moderately halophilic
 def: "A halophilic phenotype in which an organism requires high levels of sodium chloride, usually above or about 0.2 M." [] {IAO:0000119="OMP:0005016"}
 synonym: "moderate-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "moderately halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000624
+id: METPO:1000624
 name: non halophilic
 def: "A halophily preference in which an organism does not require or prefer elevated salt concentrations for growth." []
 synonym: "non-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "non-halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000625
+id: METPO:1000625
 name: slightly halophilic
 def: "A halophilic phenotype in which an organism requires low to moderate salt concentrations (0.3 to 0.8 M NaCl) for optimal growth." [] {IAO:0000119="OMP:0005016"}
 synonym: "slightly halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 
 [Term]
-id: metpo:1000626
+id: METPO:1000626
 name: stenohaline
 def: "A halophily preference in which an organism can only tolerate a narrow range of salinity concentrations and cannot survive significant changes in environmental salt levels." [] {IAO:0000119="https://purl.dsmz.de/schema/SaltTolerance"}
 synonym: "stenohaline" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000627
+id: METPO:1000627
 name: euryhaline
 def: "A halophily preference in which an organism can tolerate a wide range of salinity conditions." []
 synonym: "euryhaline" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000629 ! halophily preference
+is_a: METPO:1000629 ! halophily preference
 
 [Term]
-id: metpo:1000628
+id: METPO:1000628
 name: extremely halophilic
 def: "A halophilic phenotype in which an organism requires very high salt concentrations (typically 15-30% NaCl or higher) for optimal growth and cannot grow at salt concentrations below approximately 12%." [] {IAO:0000119="OMP:0005016", IAO:0000119="MICRO:0001314"}
 synonym: "extreme-halophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "extremely halophilic" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000620 ! halophilic
+is_a: METPO:1000620 ! halophilic
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000629
+id: METPO:1000629
 name: halophily preference
 def: "A phenotype that is relating to an organism's salt concentration requirements or tolerance for growth." [] {IAO:0000119="https://purl.dsmz.de/schema/SaltTolerance", IAO:0000119="OMP:0005016"}
 synonym: "Physiology and metabolism.halophily.halophily level" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "range_salinity" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "salinity preference" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000630
+id: METPO:1000630
 name: biological process
 def: "A execution of a genetically-encoded biological module or program. It consists of all the steps required to achieve the specific biological objective of the module. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence." []
 
 [Term]
-id: metpo:1000631
+id: METPO:1000631
 name: trophic type
 def: "A phenotype that is describing how an organism obtains carbon and energy for growth and metabolism." []
 synonym: "nutritional type" RELATED []
 synonym: "pathways" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Physiology and metabolism.nutrition type.type" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000632
+id: METPO:1000632
 name: autotrophic
 def: "A trophic type in which an organism produces organic compounds from inorganic carbon sources (primarily carbon dioxide or bicarbonate) using energy from light (photoautotrophy) or from the oxidation of inorganic compounds (chemoautotrophy)." [] {IAO:0000119="ECOCORE:00000009", IAO:0000119="MICRO:0001456"}
 synonym: "autotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "autotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_autotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000633
+id: METPO:1000633
 name: carboxydotrophic
 def: "A trophic type in which an organism derives energy from the oxidation of carbon monoxide." []
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000634
+id: METPO:1000634
 name: chemoautolithotrophic
 def: "A trophic type in which an organism uses chemical oxidation of inorganic compounds as the energy source and carbon dioxide as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000129", IAO:0000119="ECOCORE:00000124", IAO:0000119="ECOCORE:00000123", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110"}
 synonym: "chemoautolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000635
+id: METPO:1000635
 name: chemoautotrophic
 def: "A trophic type in which an organism obtains energy from oxidation of inorganic compounds and carbon from carbon dioxide." [] {IAO:0000119="ECOCORE:00000129", IAO:0000119="MICRO:0001480", IAO:0000119="ECOCORE:00000123", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110"}
 synonym: "chemoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000636
+id: METPO:1000636
 name: chemoheterotrophic
 def: "A trophic type in which an organism obtains both energy and carbon from organic compounds." [] {IAO:0000119="ECOCORE:00000012", IAO:0000119="ECOCORE:00000132", IAO:0000119="OMP:0007111", IAO:0000119="OMP:0007110", IAO:0000119="ECOCORE:00000127"}
 synonym: "aerobic_chemo_heterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "chemoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000637
+id: METPO:1000637
 name: chemolithoautotrophic
 def: "A trophic type in which an organism obtains energy from oxidation of inorganic compounds (lithotrophy) and carbon from carbon dioxide." [] {IAO:0000119="MICRO:0000511"}
 synonym: "chemolithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000638
+id: METPO:1000638
 name: chemolithoheterotrophic
 def: "A trophic type characterized by the use of inorganic chemical compounds as electron donors for energy generation while utilizing organic compounds as the primary carbon source." [] {IAO:0000119="MICRO:0001478", IAO:0000119="MICRO:0000512"}
 synonym: "chemolithoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000639
+id: METPO:1000639
 name: chemolithotrophic
 def: "A trophic type characterized by the use of inorganic chemical compounds as electron donors and carbon dioxide as the primary carbon source for energy generation and biosynthesis." [] {IAO:0000119="MICRO:0001499", IAO:0000119="OMP:0007110"}
 synonym: "chemolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000640
+id: METPO:1000640
 name: chemoorganoheterotrophic
 def: "A trophic type in which an organism obtains both energy and carbon from organic compounds through oxidation." [] {IAO:0000119="MICRO:0001481", IAO:0000119="MICRO:0000514", IAO:0000119="OMP:0007111", IAO:0000119="ECOCORE:00000127", IAO:0000119="MICRO:0001479"}
 synonym: "chemoorganoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000641
+id: METPO:1000641
 name: chemotrophic
 def: "A trophic type in which an organism obtains energy from chemical oxidation of either inorganic or organic compounds." [] {IAO:0000119="MICRO:0001458"}
 synonym: "chemotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_chemotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000642
+id: METPO:1000642
 name: copiotrophic
 def: "A nutrient adaptation in which an organism thrives in environments with high nutrient concentrations, typically exhibiting rapid growth rates and utilizing diverse carbon sources." []
 synonym: "copiotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000731 ! nutrient adaptation
+is_a: METPO:1000731 ! nutrient adaptation
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000643
+id: METPO:1000643
 name: obsolete denitrifying
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000644
+id: METPO:1000644
 name: heterotrophic
 def: "A trophic type in which an organism obtains carbon from organic compounds rather than from carbon dioxide." [] {IAO:0000119="MICRO:0001474"}
 synonym: "aerobic_heterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "heterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "heterotrophic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_heterotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000645
+id: METPO:1000645
 name: obsolete hydrogen-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000646
+id: METPO:1000646
 name: hydrogenotrophic
 def: "A trophic type in which an organism uses molecular hydrogen as an electron donor for energy generation and carbon dioxide as the primary carbon source." []
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000647
+id: METPO:1000647
 name: lithoautotrophic
 def: "A trophic type in which an organism obtains energy from inorganic electron donors and carbon from carbon dioxide." [] {IAO:0000119="ECOCORE:00000009", IAO:0000119="MICRO:0001483", IAO:0000119="ECOCORE:00000122", IAO:0000119="ECOCORE:00000014", IAO:0000119="MICRO:0001477"}
 synonym: "lithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000648
+id: METPO:1000648
 name: lithoheterotrophic
 def: "A trophic type in which an organism obtains energy from the oxidation of inorganic compounds while using organic compounds as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="MICRO:0001459", IAO:0000119="ECOCORE:00000014", IAO:0000119="MICRO:0001478", IAO:0000119="OMP:0007110"}
 synonym: "lithoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000649
+id: METPO:1000649
 name: lithotrophic
 def: "A trophic type in which an organism uses inorganic compounds as electron donors for energy generation." [] {IAO:0000119="MICRO:0001459"}
 synonym: "lithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_lithotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000650
+id: METPO:1000650
 name: methanotrophic
 def: "A trophic type in which an organism uses methane as the primary carbon and energy source through oxidation of methane to carbon dioxide." []
 synonym: "methanotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000651
+id: METPO:1000651
 name: methylotrophic
 def: "A trophic type in which an organism obtains energy and carbon from reduced one-carbon compounds." []
 synonym: "methylotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "methylotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "TT_methylotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000652
+id: METPO:1000652
 name: mixotrophic
 def: "A trophic type in which an organism can use both organic and inorganic carbon sources for growth." [] {IAO:0000119="MICRO:0001475"}
 synonym: "mixotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000653
+id: METPO:1000653
 name: obsolete nitrogen-fixing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1000654
+id: METPO:1000654
 name: oligotrophic
 def: "A nutrient adaptation characterized by the ability to thrive in environments with very low nutrient concentrations, typically possessing efficient nutrient uptake and utilization systems." [] {IAO:0000119="ENVO:01000774", IAO:0000119="ENVO:00002223"}
 synonym: "oligotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_oligotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000731 ! nutrient adaptation
+is_a: METPO:1000731 ! nutrient adaptation
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000655
+id: METPO:1000655
 name: organotrophic
 def: "A trophic type in which an organism obtains energy from the oxidation of organic compounds." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="OMP:0007111"}
 synonym: "organotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_organotroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000656
+id: METPO:1000656
 name: photoautotrophic
 def: "A trophic type characterized by the use of light as the energy source and carbon dioxide as the primary carbon source for biosynthesis." [] {IAO:0000119="MICRO:0001483", IAO:0000119="OMP:0006008", IAO:0000119="ECOCORE:00000121", IAO:0000119="ECOCORE:00000017", IAO:0000119="MICRO:0001457"}
 synonym: "anoxygenic_photoautotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
@@ -8686,2191 +8686,2191 @@ synonym: "anoxygenic_photoautotrophy_iron_oxidation" RELATED [] {IAO:0000119="ht
 synonym: "anoxygenic_photoautotrophy_sulfur_oxidation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "photoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "photoautotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000657
+id: METPO:1000657
 name: photoheterotrophic
 def: "A trophic type in which an organism uses light as the energy source and organic compounds as the primary carbon source for biosynthesis." [] {IAO:0000119="ECOCORE:00000131"}
 synonym: "photoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "photoheterotrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000658
+id: METPO:1000658
 name: photolithotrophic
 def: "A trophic type in which an organism uses light as the energy source and inorganic compounds as electron donors, typically with carbon dioxide as the primary carbon source." [] {IAO:0000119="MICRO:0001482"}
 synonym: "photolithotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000659
+id: METPO:1000659
 name: photoorganoheterotrophic
 def: "A trophic type in which an organism obtains energy from light and carbon from organic compounds." [] {IAO:0000119="MICRO:0000510"}
 synonym: "photoorganoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000660
+id: METPO:1000660
 name: phototrophic
 def: "A trophic type characterized by the use of light as the primary energy source for metabolic processes, regardless of carbon source." [] {IAO:0000119="OMP:0007064", IAO:0000119="MICRO:0001457"}
 synonym: "aerobic_anoxygenic_phototrophy" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "phototroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "TT_phototroph" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000661
+id: METPO:1000661
 name: obsolete sulfate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000662
+id: METPO:1000662
 name: obsolete sulfur-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000663
+id: METPO:1000663
 name: chemoorganotrophic
 def: "A trophic type in which an organism obtains energy through chemical oxidation of organic compounds that also serve as the carbon source for biosynthesis." [] {IAO:0000119="OMP:0007111"}
 synonym: "chemoorganotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000664
+id: METPO:1000664
 name: organoheterotrophic
 def: "A trophic type characterized by the use of organic compounds as both electron donors and primary carbon sources for energy generation and biosynthesis." [] {IAO:0000119="ECOCORE:00000162", IAO:0000119="ECOCORE:00000121", IAO:0000119="ECOCORE:00000126", IAO:0000119="ECOCORE:00000125", IAO:0000119="ECOCORE:00000127"}
 synonym: "organoheterotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000665
+id: METPO:1000665
 name: photolithoautotrophic
 def: "A trophic type in which an organism obtains energy from light and carbon from carbon dioxide using inorganic electron donors." [] {IAO:0000119="MICRO:0000500"}
 synonym: "photolithoautotroph" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 
 [Term]
-id: metpo:1000666
+id: METPO:1000666
 name: cell shape
 def: "A phenotype that describes the characteristic three-dimensional morphological form of a microbial cell, determined by cell wall structure, cytoskeletal elements, and environmental factors." [] {IAO:0000119="OMP:0000073"}
 synonym: "cell shape" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "cell_shape" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Morphology.cell morphology.cell shape" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000667
+id: METPO:1000667
 name: bacillus shaped
 def: "A cell shape characterized by an elongated, rod cylindrical morphology with relatively parallel sides and rounded ends." [] {IAO:0000119="OMP:0000076"}
 synonym: "bacillus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000668
+id: METPO:1000668
 name: coccus shaped
 def: "A cell shape in which an organism has a spherical or nearly spherical morphology, with roughly equal dimensions in all directions." [] {IAO:0000119="OMP:0000075", IAO:0000119="OMP:0000123", IAO:0000119="MICRO:0000402"}
 synonym: "coccus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "coccus-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000669
+id: METPO:1000669
 name: crescent shaped
 synonym: "crescent-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000670
+id: METPO:1000670
 name: curved shaped
 synonym: "curved-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_curved_spiral" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000671
+id: METPO:1000671
 name: diplococcus shaped
 def: "A cell shape in which spherical cells remain attached in pairs following cell division, forming characteristic doublets." [] {IAO:0000119="OMP:0000117"}
 synonym: "diplococcus-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000672
+id: METPO:1000672
 name: dumbbell shaped
 synonym: "dumbbell-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000673
+id: METPO:1000673
 name: ellipsoidal
 def: "A cell shape in which an organism has an oval or ellipse morphology, elongated along one axis with rounded ends, intermediate between spherical and rod-shaped." [] {IAO:0000119="PATO:0000947"}
 synonym: "ellipsoidal" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000674
+id: METPO:1000674
 name: filament shaped
 synonym: "filament" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "filament-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_filament" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000675
+id: METPO:1000675
 name: flask shaped
 synonym: "flask" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "flask-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000676
+id: METPO:1000676
 name: helical shaped
 synonym: "helical-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000677
+id: METPO:1000677
 name: ovoid shaped
 def: "A cell shape in which an organism has an oval morphology, rounded at both ends with one end often slightly broader than the other." [] {IAO:0000119="PATO:0001891"}
 synonym: "ovoid-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_ovoid" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000678
+id: METPO:1000678
 name: oval shaped
 def: "A cell shape characterized by an ellipsoidal morphology with rounded ends, resembling an elongated sphere." [] {IAO:0000119="OMP:0007100"}
 synonym: "oval-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000679
+id: METPO:1000679
 name: pleomorphic shaped
 def: "A cell shape characterized by variable and irregular morphology, where individual cells within a population exhibit multiple distinct shapes." [] {IAO:0000119="OMP:0000132"}
 synonym: "pleomorphic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "pleomorphic-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000680
+id: METPO:1000680
 name: ring shaped
 def: "A cell shape in which an organism forms circular or toroidal structures." [] {IAO:0000119="PATO:0002539"}
 synonym: "ring" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "ring-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000681
+id: METPO:1000681
 name: rod shaped
 def: "A cell shape in which an organism has an elongated, cylindrical morphology with relatively straight sides and rounded or flat ends." [] {IAO:0000119="OMP:0000076"}
 synonym: "rod-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "S_rod" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000682
+id: METPO:1000682
 name: spore shaped
 synonym: "spore-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000683
+id: METPO:1000683
 name: sphere shaped
 synonym: "S_sphere" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "sphere-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000684
+id: METPO:1000684
 name: spiral shaped
 synonym: "S_curved_spiral" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "spiral" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "spiral-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000685
+id: METPO:1000685
 name: star shaped
 def: "A cell shape in which an organism has multiple radiating projections from a central body." [] {IAO:0000119="OMP:0000130", IAO:0000119="PATO:0002065"}
 synonym: "S_star_dumbbell_pleomorphic" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "star" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "star-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000686
+id: METPO:1000686
 name: vibrio shaped
 def: "A cell shape in which an organism has a curved rod or comma morphology, characterized by a short curved cylindrical form with a single arc." [] {IAO:0000119="OMP:0000086", IAO:0000119="OMP:0000077"}
 synonym: "vibrio" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "vibrio-shaped" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000687
+id: METPO:1000687
 name: branched shaped
 synonym: "branced" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000688
+id: METPO:1000688
 name: coccobacillus shaped
 synonym: "coccobacillus" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000689
+id: METPO:1000689
 name: disc shaped
 def: "A cell shape in which an organism is flat and circular." []
 synonym: "disc" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000690
+id: METPO:1000690
 name: fusiform shaped
 def: "A cell shape that is wide in the middle and tapers at both ends." [] {IAO:0000119="PATO:0002400"}
 synonym: "fusiform" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000691
+id: METPO:1000691
 name: irregular shaped
 synonym: "irregular" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000692
+id: METPO:1000692
 name: spindle shaped
 synonym: "spindle" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000693
+id: METPO:1000693
 name: spirochete shaped
 def: "A cell shape in which an organism has an elongated, tightly coiled helical morphology with periplasmic flagella (endoflagella) located between the cell wall and outer membrane." [] {IAO:0000119="OMP:0000086", IAO:0000119="OMP:0000124", IAO:0000119="OMP:0000125"}
 synonym: "spirochete" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000694
+id: METPO:1000694
 name: square shaped
 synonym: "square" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000695
+id: METPO:1000695
 name: tailed shaped
 synonym: "tailed" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000696
+id: METPO:1000696
 name: triangular shaped
 synonym: "triangular" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000666 ! cell shape
+is_a: METPO:1000666 ! cell shape
 
 [Term]
-id: metpo:1000697
+id: METPO:1000697
 name: gram stain
 def: "A phenotype where microorganisms are grouped based on their ability to retain crystal violet dye in the Gram staining procedure." [] {IAO:0000119="OMP:0000191"}
 synonym: "gram_stain" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "Morphology.cell morphology.gram stain" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000698
+id: METPO:1000698
 name: gram positive
 def: "A gram stain in which an organism retains crystal violet dye and appears purple under microscopy due to a thick peptidoglycan cell wall." [] {IAO:0000119="OMP:0000188", IAO:0000119="https://purl.dsmz.de/schema/GramPositiveBacteria"}
 synonym: "G_positive" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "gram positive" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "positive" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "positive" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 
 [Term]
-id: metpo:1000699
+id: METPO:1000699
 name: gram negative
 def: "A gram stain in which bacteria do not retain crystal violet dye and appear pink or red after staining, indicating a thin peptidoglycan layer and presence of an outer membrane." []
 synonym: "G_negative" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "gram negative" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "negative" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "negative" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000700
+id: METPO:1000700
 name: gram variable
 def: "A gram stain in which bacteria from the same culture show both gram-positive and gram-negative staining characteristics, often due to age of culture or cell wall degradation." [] {IAO:0000119="OMP:0000190"}
 synonym: "variable" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000697 ! gram stain
+is_a: METPO:1000697 ! gram stain
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000701
+id: METPO:1000701
 name: motility
 def: "A phenotype in which an organism has the capability to move independently through its environment, typically by means of flagella, pili, gliding mechanisms, or other locomotory structures." [] {IAO:0000119="OMP:0000001"}
 synonym: "Morphology.cell morphology.motility" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "motility" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "presence of motility" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000702
+id: METPO:1000702
 name: motile
 def: "A motility in which an organism has the ability to move independently using metabolic energy." [] {IAO:0000119="CL:0000219", IAO:0000119="OMP:0000005"}
 synonym: "motile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "yes" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "yes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000701 ! motility
+is_a: METPO:1000701 ! motility
 
 [Term]
-id: metpo:1000703
+id: METPO:1000703
 name: non motile
 def: "A motility in which an organism lacks the ability to move independently under its own power." [] {IAO:0000119="OMP:0007489", IAO:0000119="OMP:0007488", IAO:0000119="OMP:0000133", IAO:0000119="UPHENO:0034076", IAO:0000119="OMP:0007490"}
 synonym: "no" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "no" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "non-motile" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000701 ! motility
+is_a: METPO:1000701 ! motility
 
 [Term]
-id: metpo:1000704
+id: METPO:1000704
 name: flagellated
 def: "A motile in which an organism possesses flagella for locomotion." [] {IAO:0000119="MICRO:0000272", IAO:0000119="CL:0011016", IAO:0000119="OMP:0000029", IAO:0000119="GO:0030317"}
 synonym: "flagella" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 
 [Term]
-id: metpo:1000705
+id: METPO:1000705
 name: axially filamented
 def: "A motile in which the flagellum filament of an organism is located in the periplasm and does not extend past the cell envelope." [] {IAO:0000119="OMP:0000023", IAO:0000119="GO:0055040"}
 synonym: "axial filament" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000706
+id: METPO:1000706
 name: gliding
 def: "A motile in which an organism moves smoothly along solid surfaces without flagella or pili." [] {IAO:0000119="OMP:0000112", IAO:0000119="GO:0071976", IAO:0000119="MICRO:0000437"}
 synonym: "gliding" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000702 ! motile
+is_a: METPO:1000702 ! motile
 
 [Term]
-id: metpo:1000720
+id: METPO:1000720
 name: facultative psychrophilic
 def: "A temperature preference characterized by the ability to grow at low temperatures (typically below 20C) while maintaining optimal growth at moderate temperatures." [] {IAO:0000119="OMP:0005007", IAO:0000119="MICRO:0001306", IAO:0000119="MICRO:0001417"}
 synonym: "facultative psychrophile" RELATED []
 synonym: "facultative psychrophilic" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000613 ! temperature preference
+is_a: METPO:1000613 ! temperature preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000721
+id: METPO:1000721
 name: extreme hyperthermophilic
 def: "A hyperthermophilic phenotype in which an organism grows optimally at temperatures above 90 C." [] {IAO:0000119="ENVO:00002027", IAO:0000119="OMP:0005003", IAO:0000119="MICRO:0001294", IAO:0000119="MICRO:0001538"}
 synonym: "extreme hyperthermophile" RELATED []
 synonym: "extremely hyperthermophilic" RELATED []
-is_a: metpo:1000617 ! hyperthermophilic
+is_a: METPO:1000617 ! hyperthermophilic
 
 [Term]
-id: metpo:1000731
+id: METPO:1000731
 name: nutrient adaptation
 def: "A trophic type that involves an organism's physiological and metabolic adaptations to specific nutrient availability." [] {IAO:0000119="PHIPO:0001216"}
-is_a: metpo:1000631 ! trophic type
+is_a: METPO:1000631 ! trophic type
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000800
+id: METPO:1000800
 name: respiration
 def: "A metabolism that is characterized by the method of performing cellular respiration, distinguished primarily by the specific terminal electron acceptor utilized for producing cellular energy." [] {IAO:0000119="GO:0045333", IAO:0000119="GO:0009060"}
 synonym: "pathways" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "respiration" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000801
+id: METPO:1000801
 name: Aerobic respiration
 def: "A respiration in which molecular oxygen serves as the terminal electron acceptor in the electron transport chain, generating ATP through oxidative phosphorylation with water as the final product." [] {IAO:0000119="GO:0009060"}
 synonym: "Oxic respiration" RELATED []
 synonym: "Oxygen respiration" RELATED []
-is_a: metpo:1000800 ! respiration
+is_a: METPO:1000800 ! respiration
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000802
+id: METPO:1000802
 name: Anaerobic respiration
 def: "A respiration in which an organism uses electron acceptors other than oxygen for energy production." [] {IAO:0000119="GO:0009061"}
 synonym: "Anoxic respiration" RELATED []
 synonym: "Dissimilatory respiration (non-O2)" RELATED []
-is_a: metpo:1000800 ! respiration
+is_a: METPO:1000800 ! respiration
 
 [Term]
-id: metpo:1000803
+id: METPO:1000803
 name: Oxidative phosphorylation
 def: "A metabolism that generates ATP through the transfer of electrons from electron donors to electron acceptors via redox reactions, coupled to the pumping of protons across a membrane to create an electrochemical gradient." [] {IAO:0000119="GO:0006119"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1000804
+id: METPO:1000804
 name: Substrate-level phosphorylation
 def: "A metabolism in which ATP is formed directly by transfer of a phosphoryl group from a substrate to ADP." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1000805
+id: METPO:1000805
 name: Electron transfer
 def: "A metabolism in which electrons are transferred from an electron donor to an electron acceptor." [] {IAO:0000119="GO:0009055"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000806
+id: METPO:1000806
 name: Disproportionation
 def: "A metabolism in which a single substrate simultaneously undergoes both oxidation and reduction reactions, with part of the substrate serving as the electron donor and another part serving as the electron acceptor." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000807
+id: METPO:1000807
 name: obsolete Nitrogen compound respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000808
+id: METPO:1000808
 name: obsolete Nitrate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000809
+id: METPO:1000809
 name: obsolete Denitrification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005038
+replaced_by: METPO:1005038
 
 [Term]
-id: metpo:1000810
+id: METPO:1000810
 name: obsolete Dissimilatory nitrate reduction to ammonium
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000811
+id: METPO:1000811
 name: obsolete Nitrite reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000812
+id: METPO:1000812
 name: obsolete Anaerobic ammonium oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000813
+id: METPO:1000813
 name: obsolete Nitric oxide reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000814
+id: METPO:1000814
 name: obsolete Nitrous oxide reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000815
+id: METPO:1000815
 name: obsolete Sulfur and sulfoxide compound respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000816
+id: METPO:1000816
 name: obsolete Sulfate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000817
+id: METPO:1000817
 name: obsolete Sulfur reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000818
+id: METPO:1000818
 name: obsolete Sulfite reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000819
+id: METPO:1000819
 name: obsolete Thiosulfate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000820
+id: METPO:1000820
 name: obsolete Sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000821
+id: METPO:1000821
 name: obsolete Dimethyl sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000822
+id: METPO:1000822
 name: obsolete Methionine sulfoxide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000823
+id: METPO:1000823
 name: obsolete Sulfide oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000824
+id: METPO:1000824
 name: obsolete Thiosulfate oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000825
+id: METPO:1000825
 name: obsolete Sulfite oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000826
+id: METPO:1000826
 name: obsolete Tetrathionate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000827
+id: METPO:1000827
 name: obsolete Polysulfide reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000828
+id: METPO:1000828
 name: obsolete Metal and metalloid respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000829
+id: METPO:1000829
 name: obsolete Iron reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000830
+id: METPO:1000830
 name: obsolete Iron oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000831
+id: METPO:1000831
 name: obsolete Nitrate-dependent Fe(II) oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000832
+id: METPO:1000832
 name: obsolete Manganese reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000833
+id: METPO:1000833
 name: obsolete Manganese oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000834
+id: METPO:1000834
 name: obsolete Uranium reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000835
+id: METPO:1000835
 name: obsolete Vanadium reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000836
+id: METPO:1000836
 name: obsolete Chromium reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000837
+id: METPO:1000837
 name: obsolete Technetium reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000838
+id: METPO:1000838
 name: obsolete Cobalt reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000839
+id: METPO:1000839
 name: obsolete Arsenate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000840
+id: METPO:1000840
 name: obsolete Arsenite oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000841
+id: METPO:1000841
 name: obsolete Selenate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000842
+id: METPO:1000842
 name: obsolete Selenite reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000843
+id: METPO:1000843
 name: obsolete Carbon and organic compound respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000844
+id: METPO:1000844
 name: Methanogenesis
 def: "A metabolism in which methane is produced as the primary end product through the reduction of carbon-containing compounds, formate, methanol, or acetate, exclusively performed by methanogenic archaea under strictly anaerobic conditions." [] {IAO:0000119="GO:0015948"}
 synonym: "Biological methanation" RELATED []
 synonym: "Biomethanation" RELATED []
 synonym: "Carbonate respiration" RELATED []
 synonym: "methanogenesis" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1000845
+id: METPO:1000845
 name: Acetogenesis
 def: "A metabolism that produces acetate as the primary end product through the reduction of carbon dioxide or other carbon compounds using the Wood-Ljungdahl pathway, typically performed by acetogenic bacteria under anaerobic conditions." []
 synonym: "Acetate fermentation" RELATED []
 synonym: "acetogenesis" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1000846
+id: METPO:1000846
 name: Homoacetogenesis
 def: "A metabolism in which acetate is produced as the sole reduced end product from reduction of CO2 via the acetyl-CoA pathway." []
 synonym: "Reductive acetyl-CoA pathway" RELATED []
 synonym: "Wood-Ljungdahl pathway" RELATED []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1000847
+id: METPO:1000847
 name: obsolete Fumarate respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000848
+id: METPO:1000848
 name: obsolete Trimethylamine N-oxide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000849
+id: METPO:1000849
 name: obsolete Humus respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000850
+id: METPO:1000850
 name: obsolete Halogenated compound respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000851
+id: METPO:1000851
 name: obsolete Organohalide respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000852
+id: METPO:1000852
 name: obsolete (Per)chlorate respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000853
+id: METPO:1000853
 name: obsolete Perchlorate respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000854
+id: METPO:1000854
 name: obsolete Chlorate respiration
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000855
+id: METPO:1000855
 name: obsolete Bromate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000856
+id: METPO:1000856
 name: obsolete Iodate reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000857
+id: METPO:1000857
 name: obsolete Nitrite-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000858
+id: METPO:1000858
 name: obsolete Nitrate-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000859
+id: METPO:1000859
 name: obsolete Hydrogen oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000860
+id: METPO:1000860
 name: obsolete Sulfur oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000861
+id: METPO:1000861
 name: obsolete Nitrification
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005001
+replaced_by: METPO:1005001
 
 [Term]
-id: metpo:1000862
+id: METPO:1000862
 name: obsolete Complete ammonia oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000863
+id: METPO:1000863
 name: obsolete Carbon monoxide oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000864
+id: METPO:1000864
 name: obsolete Hydrogenotrophic methanogenesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000865
+id: METPO:1000865
 name: obsolete Acetoclastic methanogenesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000866
+id: METPO:1000866
 name: obsolete Methylotrophic methanogenesis
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000867
+id: METPO:1000867
 name: obsolete Anaerobic methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000868
+id: METPO:1000868
 name: obsolete Lanthanide reduction
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000869
+id: METPO:1000869
 name: obsolete Lanthanide oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1000870
+id: METPO:1000870
 name: sporulation
 def: "A phenotype that is relating to an organism's ability to form dormant, stress-resistant endospores." [] {IAO:0000119="GO:0043934"}
 synonym: "General.keywords" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "Physiology and metabolism.spore formation.spore formation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "sporulation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "sporulation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000871
+id: METPO:1000871
 name: spore forming
 def: "A sporulation in which an organism has the ability to produce endospores." [] {IAO:0000119="GO:0034301", IAO:0000119="https://purl.dsmz.de/schema/SporeFormation", IAO:0000119="OMP:0000017"}
 synonym: "spore" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
 synonym: "yes" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "yes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000870 ! sporulation
+is_a: METPO:1000870 ! sporulation
 
 [Term]
-id: metpo:1000872
+id: METPO:1000872
 name: non-spore forming
 def: "A sporulation in which an organism lacks the ability to produce endospores." [] {IAO:0000119="OMP:0007236", IAO:0000119="OMP:0007434", IAO:0000119="UPHENO:0083394", IAO:0000119="OMP:0000018", IAO:0000119="OMP:0007232"}
 synonym: "no" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "no" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "no_spore" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000870 ! sporulation
+is_a: METPO:1000870 ! sporulation
 
 [Term]
-id: metpo:1000881
+id: METPO:1000881
 name: cell length
 def: "A phenotype that inheres in a cell by virtue of its longer dimension when viewed on a plane." [] {IAO:0000119="OBA:2040145"}
 synonym: "cell length" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000882
+id: METPO:1000882
 name: cell width
 def: "A phenotype that inheres in a cell by virtue of its shorter dimension when viewed on a plane." [] {IAO:0000119="OBA:2040146"}
 synonym: "cell width" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1000883
+id: METPO:1000883
 name: cell length very small
 synonym: "L_<=1.3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "1.3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "1.3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000884
+id: METPO:1000884
 name: cell length small
 synonym: "L_1.3_2" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "2" xsd:string
-property_value: metpo:range_min "1.3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "2" xsd:string
+property_value: METPO:range_min "1.3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000885
+id: METPO:1000885
 name: cell length medium
 synonym: "L_2_3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_max "3" xsd:string
-property_value: metpo:range_min "2" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_max "3" xsd:string
+property_value: METPO:range_min "2" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000886
+id: METPO:1000886
 name: cell length large
 synonym: "L_>3" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000881 ! cell length
-property_value: metpo:range_min "3" xsd:string
+is_a: METPO:1000881 ! cell length
+property_value: METPO:range_min "3" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000887
+id: METPO:1000887
 name: cell width very small
 synonym: "W_<=0.5" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.5" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.5" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000888
+id: METPO:1000888
 name: cell width small
 synonym: "W_0.5_0.65" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.65" xsd:string
-property_value: metpo:range_min "0.5" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.65" xsd:string
+property_value: METPO:range_min "0.5" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000889
+id: METPO:1000889
 name: cell width medium
 synonym: "W_0.65_0.9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_max "0.9" xsd:string
-property_value: metpo:range_min "0.65" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_max "0.9" xsd:string
+property_value: METPO:range_min "0.65" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1000890
+id: METPO:1000890
 name: cell width large
 synonym: "W_>0.9" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1000882 ! cell width
-property_value: metpo:range_min "0.9" xsd:string
+is_a: METPO:1000882 ! cell width
+property_value: METPO:range_min "0.9" xsd:string
 property_value: qudt:ucumCode "um" xsd:string
 
 [Term]
-id: metpo:1001000
+id: METPO:1001000
 name: obsolete observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001001
+id: METPO:1001001
 name: obsolete optimum temperature observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001002
+id: METPO:1001002
 name: obsolete growth temperature observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001003
+id: METPO:1001003
 name: obsolete temperature range observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001004
+id: METPO:1001004
 name: obsolete temperature delta observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001005
+id: METPO:1001005
 name: obsolete culture temperature observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001006
+id: METPO:1001006
 name: obsolete culture NaCl observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001007
+id: METPO:1001007
 name: obsolete growth NaCl observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001008
+id: METPO:1001008
 name: obsolete NaCl delta observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001009
+id: METPO:1001009
 name: obsolete NaCl range observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001010
+id: METPO:1001010
 name: obsolete optimum NaCl observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001011
+id: METPO:1001011
 name: obsolete culture pH observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001012
+id: METPO:1001012
 name: obsolete growth pH observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001013
+id: METPO:1001013
 name: obsolete optimum pH observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001014
+id: METPO:1001014
 name: obsolete pH delta observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001015
+id: METPO:1001015
 name: obsolete pH range observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001016
+id: METPO:1001016
 name: obsolete optimum oxygen observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001017
+id: METPO:1001017
 name: obsolete growth oxygen observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001018
+id: METPO:1001018
 name: obsolete oxygen range observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001019
+id: METPO:1001019
 name: obsolete oxygen delta observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001020
+id: METPO:1001020
 name: obsolete oxygen observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001021
+id: METPO:1001021
 name: obsolete temperature observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001022
+id: METPO:1001022
 name: obsolete NaCl observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001023
+id: METPO:1001023
 name: obsolete pH observation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1001101
+id: METPO:1001101
 name: biosafety level
 def: "A quality that categorizes biological agents according to their hazard level and required containment measures." []
 synonym: "biosafety level" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Safety information.risk assessment.biosafety level" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000188 ! quality
+is_a: METPO:1000188 ! quality
 
 [Term]
-id: metpo:1001102
+id: METPO:1001102
 name: biosafety level 1
 def: "A biosafety level that pose minimal potential hazard to laboratory workers and the environment, requiring only standard microbiological practices." []
 synonym: "1" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1001103
+id: METPO:1001103
 name: biosafety level 2
 def: "A biosafety level that pose moderate risk and are associated with human diseases present in the community." []
 synonym: "2" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1001104
+id: METPO:1001104
 name: biosafety level 3
 def: "A biosafety level that can cause serious or potentially lethal disease through inhalation or other routes, requiring specialized containment facilities with controlled access, directional airflow, and strict safety protocols." []
 synonym: "3" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "3**" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1001105
+id: METPO:1001105
 name: biosafety level 4
 def: "A biosafety level that pose extreme risk of life-threatening disease through aerosol transmission with no available treatment." []
 synonym: "4" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1001106
+id: METPO:1001106
 name: biosafety level 5
 def: "A biosafety level that is proposed as a classification beyond BSL-4 for hypothetical biological agents requiring enhanced containment." []
 synonym: "5" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1001101 ! biosafety level
+is_a: METPO:1001101 ! biosafety level
 
 [Term]
-id: metpo:1002000
+id: METPO:1002000
 name: obsolete Sulfate-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002001
+id: METPO:1002001
 name: obsolete Fe(III)-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002002
+id: METPO:1002002
 name: obsolete Mn(IV)-dependent methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002003
+id: METPO:1002003
 name: Cable bacteria metabolism
 def: "A metabolism in which electrons are transferred over centimeter-scale distances through multicellular filaments." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 
 [Term]
-id: metpo:1002005
+id: METPO:1002005
 name: Fermentation
 def: "A metabolism in which energy is generated through the oxidation of organic compounds without using an external electron acceptor, using organic molecules as both electron donors and final electron acceptors." [] {IAO:0000119="GO:0006113"}
 synonym: "fermentation" RELATED [] {IAO:0000119="https://github.com/jmadin/bacteria_archaea_traits"}
 synonym: "fermentation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1002006
+id: METPO:1002006
 name: Syntrophy
 def: "A metabolism in which the metabolism of one species is thermodynamically dependent on the removal of its products by another species." []
-is_a: metpo:1000060 ! metabolism
+is_a: METPO:1000060 ! metabolism
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1002007
+id: METPO:1002007
 name: obsolete Sulfur disproportionation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1000806
+replaced_by: METPO:1000806
 
 [Term]
-id: metpo:1002008
+id: METPO:1002008
 name: obsolete Nitrogen fixation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1002009
+id: METPO:1002009
 name: obsolete Nitrate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002010
+id: METPO:1002010
 name: obsolete Anaerobic ammonium-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002011
+id: METPO:1002011
 name: obsolete Nitrous oxide-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002012
+id: METPO:1002012
 name: obsolete Sulfate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002013
+id: METPO:1002013
 name: obsolete Sulfur-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002014
+id: METPO:1002014
 name: obsolete Sulfite-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002015
+id: METPO:1002015
 name: obsolete Thiosulfate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002016
+id: METPO:1002016
 name: obsolete Sulfur-disproportionating
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002017
+id: METPO:1002017
 name: obsolete Sulfide-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002018
+id: METPO:1002018
 name: obsolete Thiosulfate-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002019
+id: METPO:1002019
 name: obsolete Sulfite-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002020
+id: METPO:1002020
 name: obsolete Iron-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002021
+id: METPO:1002021
 name: obsolete Iron-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002022
+id: METPO:1002022
 name: obsolete Nitrate-dependent Fe(II)-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002023
+id: METPO:1002023
 name: obsolete Manganese-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002024
+id: METPO:1002024
 name: obsolete Manganese-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002025
+id: METPO:1002025
 name: obsolete Uranium-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002026
+id: METPO:1002026
 name: obsolete Arsenate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002027
+id: METPO:1002027
 name: obsolete Selenate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002028
+id: METPO:1002028
 name: obsolete Selenite-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002029
+id: METPO:1002029
 name: obsolete Perchlorate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002030
+id: METPO:1002030
 name: obsolete Chlorate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002031
+id: METPO:1002031
 name: obsolete Bromate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002032
+id: METPO:1002032
 name: obsolete Iodate-reducing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002033
+id: METPO:1002033
 name: obsolete Hydrogen-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002034
+id: METPO:1002034
 name: obsolete Sulfur-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002035
+id: METPO:1002035
 name: obsolete Ammonia oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002036
+id: METPO:1002036
 name: obsolete Nitrite oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002037
+id: METPO:1002037
 name: obsolete Complete ammonia-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002038
+id: METPO:1002038
 name: obsolete Methane oxidation
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002039
+id: METPO:1002039
 name: obsolete Carbon monoxide-oxidizing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Term]
-id: metpo:1002040
+id: METPO:1002040
 name: obsolete Nitrogen-fixing
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
-replaced_by: metpo:1005039
+replaced_by: METPO:1005039
 
 [Term]
-id: metpo:1003000
+id: METPO:1003000
 name: pH growth preference
 def: "A phenotype that describes how the rate and extent of population growth are affected by environmental pH." [] {IAO:0000119="OMP:0005008"}
 synonym: "pH growth" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1003001
+id: METPO:1003001
 name: neutrophilic
 def: "A pH growth preference characterized by optimal growth at near-neutral pH values, typically between pH 6.5 and 7.5." [] {IAO:0000119="PATO:0070046", IAO:0000119="OMP:0005010"}
 synonym: "neutralophile" EXACT []
 synonym: "neutralophilic" EXACT []
 synonym: "neutrophile" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 
 [Term]
-id: metpo:1003002
+id: METPO:1003002
 name: alkaliphilic
 def: "A pH growth preference in which an organism grows optimally at pH values above 9." [] {IAO:0000119="OMP:0005009", IAO:0000119="MICRO:0001549", IAO:0000119="OMP:0005010", IAO:0000119="ENVO:00002022", IAO:0000119="OMP:0005011"}
 synonym: "alkaliphile" EXACT []
 synonym: "alkaliphilic" EXACT []
 synonym: "alkalophile" EXACT []
 synonym: "alkalophilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003003
+id: METPO:1003003
 name: acidophilic
 def: "A pH growth preference in which an organism grows optimally at pH values below 5." [] {IAO:0000119="OMP:0007945", IAO:0000119="OMP:0005009", IAO:0000119="MICRO:0001549", IAO:0000119="OMP:0005010", IAO:0000119="OMP:0005011"}
 synonym: "acidophil" EXACT []
 synonym: "acidophile" EXACT []
 synonym: "acidophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003004
+id: METPO:1003004
 name: obligately alkaliphilic
 def: "An alkaliphilic phenotype in which an organism requires alkaline conditions (typically pH above 8.5) for growth and cannot grow at neutral or acidic pH." [] {IAO:0000119="OMP:0007947", IAO:0000119="ENVO:00002022", IAO:0000119="MICRO:0001565", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771"}
 synonym: "obligate alkaliphile" EXACT []
 synonym: "obligate alkaphilic" EXACT []
 synonym: "obligately alkaliphilic" EXACT []
-is_a: metpo:1003002 ! alkaliphilic
+is_a: METPO:1003002 ! alkaliphilic
 property_value: IAO:0000117 "Luke Wang" xsd:string
 
 [Term]
-id: metpo:1003005
+id: METPO:1003005
 name: facultatively alkaliphilic
 def: "A pH growth preference in which an organism can grow at alkaline pH but does not require it." [] {IAO:0000119="MICRO:0001558", IAO:0000119="OMP:0005009", IAO:0000119="OMP:0007947", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771"}
 synonym: "facultative alkaliphile" EXACT []
 synonym: "facultative alkaphilic" EXACT []
 synonym: "facultatively alkaliphilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003006
+id: METPO:1003006
 name: obligately acidophilic
 def: "An acidophilic phenotype in which an organism requires acidic environments (pH below 5.5) for growth, with inability to grow at neutral or alkaline pH values." [] {IAO:0000119="MICRO:0001566"}
 synonym: "obligate acidophile" EXACT []
 synonym: "obligately acidophilic" EXACT []
-is_a: metpo:1003003 ! acidophilic
+is_a: METPO:1003003 ! acidophilic
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003007
+id: METPO:1003007
 name: facultatively acidophilic
 def: "A pH growth preference characterized by optimal growth in acidic environments (pH below 5.5) with the capacity to also grow at near-neutral pH values." [] {IAO:0000119="OMP:0007945", IAO:0000119="OMP:0007009", IAO:0000119="MICRO:0001557", IAO:0000119="OMP:0005009", IAO:0000119="OMP:0005010"}
 synonym: "facultative acidophile" EXACT []
 synonym: "facultatively acidophilic" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003008
+id: METPO:1003008
 name: acidotolerant
 def: "A pH growth preference characterized by the ability to tolerate acidic environments (typically pH below 5.5) while maintaining optimal growth near neutral pH." [] {IAO:0000119="MICRO:0001555"}
 synonym: "aciduric" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 property_value: IAO:0000117 "Anthea Guo" xsd:string
 property_value: IAO:0000117 "Jed Dongjin Kim-Ozaeta" xsd:string
 
 [Term]
-id: metpo:1003009
+id: METPO:1003009
 name: alkalotolerant
 def: "A pH growth preference in which an organism can tolerate alkaline pH but grows optimally at neutral pH." [] {IAO:0000119="OMP:0005009", IAO:0000119="OMP:0007947", IAO:0000119="OMP:0005011", IAO:0000119="OMP:0007771", IAO:0000119="OMP:0007011"}
 synonym: "alkalitolerant" EXACT []
-is_a: metpo:1003000 ! pH growth preference
+is_a: METPO:1003000 ! pH growth preference
 
 [Term]
-id: metpo:1003021
+id: METPO:1003021
 name: pigmentation
 def: "A phenotype characterized by the color of pigments produced by a microorganism." [] {IAO:0000119="GO:0043473"}
 synonym: "cell color" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1003022
+id: METPO:1003022
 name: black pigmented
 synonym: "Pigment_black" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003023
+id: METPO:1003023
 name: brown pigmented
 synonym: "Pigment_brown" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003024
+id: METPO:1003024
 name: cream pigmented
 synonym: "Pigment_cream" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003025
+id: METPO:1003025
 name: green pigmented
 synonym: "Pigment_green" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003026
+id: METPO:1003026
 name: orange pigmented
 synonym: "Pigment_orange" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003027
+id: METPO:1003027
 name: pink pigmented
 synonym: "Pigment_pink" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003028
+id: METPO:1003028
 name: red pigmented
 synonym: "Pigment_red" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003029
+id: METPO:1003029
 name: white pigmented
 synonym: "Pigment_white" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003030
+id: METPO:1003030
 name: yellow pigmented
 synonym: "cell color: yellow pigment" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
 synonym: "Pigment_yellow" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1003031
+id: METPO:1003031
 name: carotenoid pigmentation
 synonym: "Pigment_carotenoid" RELATED [] {IAO:0000119="https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv"}
-is_a: metpo:1003021 ! pigmentation
+is_a: METPO:1003021 ! pigmentation
 
 [Term]
-id: metpo:1004000
+id: METPO:1004000
 name: pathogenic to host
 def: "A phenotype where a microbe is a pathogen of of some host organism." [] {IAO:0000119="OMP:0000068", IAO:0000119="OMP:0007284"}
 synonym: "General.keywords" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "Safety information.risk assessment" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1004002
+id: METPO:1004002
 name: animal pathogen
 def: "A pathogen that infects organisms in the kingdom Metazoa." []
 synonym: "animal pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004003
+id: METPO:1004003
 name: plant pathogen
 def: "A pathogen that infects organisms in the kingdom Viridiplantae." []
 synonym: "plant pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004004
+id: METPO:1004004
 name: human pathogen
 def: "A pathogen that infects organisms of the species Homo sapiens." [] {IAO:0000119="IDO:0000639"}
 synonym: "human pathogen" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:1004000 ! pathogenic to host
+is_a: METPO:1004000 ! pathogenic to host
 
 [Term]
-id: metpo:1004005
+id: METPO:1004005
 name: growth medium
 def: "A material entity that provides the nutrients and environmental conditions necessary for the cultivation of microorganisms in vitro. Growth media may be liquid (broth) or solid (agar-based) and are formulated to support the growth of specific types of organisms." [] {IAO:0000119="OBI:0000079"}
 comment: This class is equivalent to OBI:0000079 'culture medium'. It is included in METPO to serve as the range for growth-related object properties.
-is_a: metpo:1000186 ! material entity
+is_a: METPO:1000186 ! material entity
 property_value: skos:broadMatch https://biolink.github.io/biolink-model/ProcessedMaterial
 
 [Term]
-id: metpo:1005001
+id: METPO:1005001
 name: nitrification
 def: "A biological process in which ammonia is oxidized to nitrite (ammonia oxidation) and nitrite is oxidized to nitrate (nitrite oxidation), in two steps." [] {IAO:0000119="GO:0019332", IAO:0000119="GO:0019329"}
 comment: MetaTraits maps to OMIT:0027217 (wrong ontology). Correct GO terms are GO:0019329 (ammonia oxidation) and GO:0019332 (nitrite oxidation).
 synonym: "nitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005010
+id: METPO:1005010
 name: indole test
 def: "An assay that tests the ability of an organism to produce indole from tryptophan." [] {IAO:0000119="MICRO:0000430"}
 synonym: "indole test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005011
+id: METPO:1005011
 name: indole test positive
 def: "A phenotype in which an organism tests positive in the indole test, indicating it produces indole from tryptophan." []
 synonym: "indole test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005010 ! indole test
+is_a: METPO:1005010 ! indole test
 
 [Term]
-id: metpo:1005012
+id: METPO:1005012
 name: indole test negative
 def: "A phenotype in which an organism tests negative in the indole test, indicating it does not produce indole from tryptophan." []
-is_a: metpo:1005010 ! indole test
+is_a: METPO:1005010 ! indole test
 
 [Term]
-id: metpo:1005013
+id: METPO:1005013
 name: methyl red test
 def: "An assay that tests the ability of an organism to produce and maintain stable acid end products from glucose fermentation." [] {IAO:0000119="SNOMED:5894006"}
 synonym: "methyl red test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005014
+id: METPO:1005014
 name: methyl red test positive
 def: "A phenotype in which an organism tests positive in the methyl red test, indicating mixed acid fermentation." []
 synonym: "methyl red test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005013 ! methyl red test
+is_a: METPO:1005013 ! methyl red test
 
 [Term]
-id: metpo:1005015
+id: METPO:1005015
 name: methyl red test negative
 def: "A phenotype in which an organism tests negative in the methyl red test." []
-is_a: metpo:1005013 ! methyl red test
+is_a: METPO:1005013 ! methyl red test
 
 [Term]
-id: metpo:1005016
+id: METPO:1005016
 name: Voges-Proskauer test
 def: "An assay that tests the ability of an organism to produce acetoin from glucose via the butanediol fermentation pathway." [] {IAO:0000119="SNOMED:66592006"}
 synonym: "voges-proskauer test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005017
+id: METPO:1005017
 name: Voges-Proskauer test positive
 def: "A phenotype in which an organism tests positive in the Voges-Proskauer test, indicating acetoin production." []
 synonym: "voges-proskauer test" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1005016 ! Voges-Proskauer test
+is_a: METPO:1005016 ! Voges-Proskauer test
 
 [Term]
-id: metpo:1005018
+id: METPO:1005018
 name: Voges-Proskauer test negative
 def: "A phenotype in which an organism tests negative in the Voges-Proskauer test." []
-is_a: metpo:1005016 ! Voges-Proskauer test
+is_a: METPO:1005016 ! Voges-Proskauer test
 
 [Term]
-id: metpo:1005021
+id: METPO:1005021
 name: capnophilic
 def: "A phenotype describing an organism that requires elevated concentrations of carbon dioxide for growth." [] {IAO:0000119="SNOMED:413748004"}
 synonym: "capnophilic" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000601 ! oxygen preference
+is_a: METPO:1000601 ! oxygen preference
 
 [Term]
-id: metpo:1005025
+id: METPO:1005025
 name: hemolysis
 def: "A phenotype describing the ability of an organism to lyse red blood cells." [] {IAO:0000119="OMP:0005117"}
 synonym: "presence of hemolysis" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1005026
+id: METPO:1005026
 name: hemolytic
 def: "A phenotype in which an organism is capable of lysing red blood cells." []
-is_a: metpo:1005025 ! hemolysis
+is_a: METPO:1005025 ! hemolysis
 
 [Term]
-id: metpo:1005027
+id: METPO:1005027
 name: non-hemolytic
 def: "A phenotype in which an organism does not lyse red blood cells." []
-is_a: metpo:1005025 ! hemolysis
+is_a: METPO:1005025 ! hemolysis
 
 [Term]
-id: metpo:1005031
+id: METPO:1005031
 name: peritrichous flagellation
 def: "A motility phenotype in which flagella are distributed over the entire cell surface." [] {IAO:0000119="OMP:0000078"}
 synonym: "flagellum arrangement" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005032
+id: METPO:1005032
 name: polar flagellation
 def: "A motility phenotype in which one or more flagella are located at one or both poles of the cell." []
 synonym: "flagellum arrangement" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005033
+id: METPO:1005033
 name: amphitrichous flagellation
 def: "A motility phenotype in which a single flagellum is present at each pole of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005034
+id: METPO:1005034
 name: lophotrichous flagellation
 def: "A motility phenotype in which a tuft of flagella is present at one or both poles of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005035
+id: METPO:1005035
 name: monotrichous flagellation
 def: "A motility phenotype in which a single flagellum is present at one pole of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005036
+id: METPO:1005036
 name: lateral flagellation
 def: "A motility phenotype in which flagella emerge from the lateral side of the cell." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005037
+id: METPO:1005037
 name: subpolar flagellation
 def: "A motility phenotype in which flagella are located near but not at the cell pole." []
-is_a: metpo:1000704 ! flagellated
+is_a: METPO:1000704 ! flagellated
 
 [Term]
-id: metpo:1005038
+id: METPO:1005038
 name: denitrification
 def: "A biological process in which nitrate or nitrite is reduced to gaseous nitrogen compounds (NO, N2O, or N2) under anaerobic or microaerobic conditions." [] {IAO:0000119="GO:0019333"}
 synonym: "denitrification pathway" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005039
+id: METPO:1005039
 name: nitrogen fixation
 def: "A biological process in which atmospheric dinitrogen is reduced to ammonia, catalyzed by nitrogenase." [] {IAO:0000119="GO:0009399"}
 synonym: "nitrogen fixation" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000630 ! biological process
+is_a: METPO:1000630 ! biological process
 
 [Term]
-id: metpo:1005040
+id: METPO:1005040
 name: generalist
 def: "A phenotype describing an organism with a broad ecological niche, capable of thriving across diverse environments or utilizing varied resources." [] {IAO:0000119="inbio:000022"}
 synonym: "generalist" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 
 [Term]
-id: metpo:1007005
+id: METPO:1007005
 name: flagellar arrangement
 def: "A phenotype characterized by the arrangement pattern of flagella on a bacterial or archaeal cell (e.g. peritrichous, polar, amphitrichous, lophotrichous, monotrichous, lateral, subpolar)." [] {IAO:0000119="OMP:0000078"}
 comment: subset=metpo_proposal_2026_04; priority=HIGH; xrefs=GO:0001539
 synonym: "flagellation pattern" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007006
+id: METPO:1007006
 name: polytrichous flagellation
 def: "A flagellar arrangement in which multiple flagella (typically a tuft) are present per cell, often combined with polar attachment." [] {IAO:0000119="MICRO:0000271"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; observations=4
 synonym: "polytrichous" EXACT []
-is_a: metpo:1007005 ! flagellar arrangement
+is_a: METPO:1007005 ! flagellar arrangement
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007062
+id: METPO:1007062
 name: colony morphology
 def: "A phenotype characterized by macroscopic colony characteristics such as shape, margin, elevation, surface, colour, and size." [] {IAO:0000119="OMP:0000100"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=PATO:0000052
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007063
+id: METPO:1007063
 name: colony shape
 def: "A colony morphology characterized by the overall macroscopic colony outline as observed on solid medium." [] {IAO:0000119="OMP:0000103"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=PATO:0000052
-is_a: metpo:1007062 ! colony morphology
+is_a: METPO:1007062 ! colony morphology
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007064
+id: METPO:1007064
 name: circular colony
 def: "A colony shape that has a regular round outline." [] {IAO:0000119="OMP:0000166"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=2649
 synonym: "round colony" EXACT []
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007065
+id: METPO:1007065
 name: irregular colony
 def: "A colony shape that has an irregular (non-round, non-rhizoid) outline." [] {IAO:0000119="OMP:0000167"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=148
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007066
+id: METPO:1007066
 name: filamentous colony
 def: "A colony shape that has a thread-like or filamentous outline." [] {IAO:0000119="OMP:0000088"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=16
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007067
+id: METPO:1007067
 name: punctiform colony
 def: "A colony shape that is very small (pinpoint), typically <1 mm in diameter." [] {IAO:0000119="OMP:0000240"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=11
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007068
+id: METPO:1007068
 name: rhizoid colony
 def: "A colony shape that has a branching, root-like outline." [] {IAO:0000119="OMP:0000168"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=8
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007069
+id: METPO:1007069
 name: fried-egg-shaped colony
 def: "A colony shape that has a raised opaque centre and a translucent peripheral zone, resembling a fried egg." [] {IAO:0000119="MICRO:0000349"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; observations=6
 synonym: "fried-egg colony" EXACT []
-is_a: metpo:1007063 ! colony shape
+is_a: METPO:1007063 ! colony shape
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007070
+id: METPO:1007070
 name: pressure tolerance
 def: "A phenotype characterized by the ability to grow under elevated hydrostatic pressure." [] {IAO:0000119="OMP:0005012"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "barophile" EXACT []
 synonym: "piezophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007071
+id: METPO:1007071
 name: barophile phenotype
 def: "A pressure tolerance in which an organism requires or tolerates elevated hydrostatic pressure for growth." [] {IAO:0000119="MICRO:0001359"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
-is_a: metpo:1007070 ! pressure tolerance
+is_a: METPO:1007070 ! pressure tolerance
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007072
+id: METPO:1007072
 name: radiation tolerance
 def: "A phenotype characterized by the ability to withstand ionizing or UV radiation." [] {IAO:0000119="wikidata:Q2353022"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "radioresistant" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007073
+id: METPO:1007073
 name: osmotic tolerance
 def: "A phenotype characterized by the ability to grow under high osmotic pressure (non-NaCl)." [] {IAO:0000119="OMP:0005015"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "osmophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007074
+id: METPO:1007074
 name: metal tolerance
 def: "A phenotype characterized by the ability to grow in the presence of elevated metal concentrations." [] {IAO:0000119="OMP:0007890"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "metallophile" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007076
+id: METPO:1007076
 name: capsule presence
 def: "A phenotype characterized by the presence of an extracellular polysaccharide capsule." [] {IAO:0000119="OMP:0000203"}
 comment: subset=metpo_proposal_2026_04; priority=LOW; xrefs=GO:0042603
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007077
+id: METPO:1007077
 name: biofilm formation capability
 def: "A phenotype characterized by the ability to form surface-attached biofilms." [] {IAO:0000119="OMP:0000176"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0042710
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007080
+id: METPO:1007080
 name: catalase test
 def: "A biochemical test that detects catalase enzyme activity by exposing cells to hydrogen peroxide and observing for visible bubbling. The test outcome (positive or negative) is captured by its child classes; this class itself does not assert that the organism has catalase activity." [] {IAO:0000119="OMP:0000218"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "catalase activity test" EXACT []
 synonym: "catalase assay" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007081
+id: METPO:1007081
 name: oxidase test
 def: "A biochemical test that detects cytochrome c oxidase activity using a redox indicator. The test outcome (positive or negative) is captured by its child classes; this class itself does not assert oxidase activity." [] {IAO:0000119="OMP:0000220"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "cytochrome oxidase test" EXACT []
 synonym: "oxidase activity test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007082
+id: METPO:1007082
 name: urease test
 def: "A biochemical test that detects urease enzyme activity by observing urea hydrolysis (typically via a pH-indicator color change). The test outcome (positive or negative) is captured by its child classes; this class itself does not assert urease activity." [] {IAO:0000119="OMP:0000222"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "urea hydrolysis test" EXACT []
 synonym: "urease activity test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007083
+id: METPO:1007083
 name: catalase positive
 def: "Test-outcome phenotype where the catalase test yields a positive result (visible bubbling on H2O2). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0004096 'catalase activity'." [] {IAO:0000119="OMP:0000194"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0004096
 synonym: "catalase +" EXACT []
 synonym: "catalase test positive" EXACT []
-is_a: metpo:1007080 ! catalase test
+is_a: METPO:1007080 ! catalase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007084
+id: METPO:1007084
 name: catalase negative
 def: "Test-outcome phenotype where the catalase test yields a negative result (no bubbling on H2O2). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0004096 'catalase activity'." [] {IAO:0000119="OMP:0000198"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "catalase -" EXACT []
 synonym: "catalase test negative" EXACT []
-is_a: metpo:1007080 ! catalase test
+is_a: METPO:1007080 ! catalase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007085
+id: METPO:1007085
 name: oxidase positive
 def: "Test-outcome phenotype where the oxidase test yields a positive result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0004129 'cytochrome-c oxidase activity'." [] {IAO:0000119="OMP:0006085"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0004129
 synonym: "oxidase +" EXACT []
 synonym: "oxidase test positive" EXACT []
-is_a: metpo:1007081 ! oxidase test
+is_a: METPO:1007081 ! oxidase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007086
+id: METPO:1007086
 name: oxidase negative
 def: "Test-outcome phenotype where the oxidase test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0004129 'cytochrome-c oxidase activity'." [] {IAO:0000119="OMP:0006084"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "oxidase -" EXACT []
 synonym: "oxidase test negative" EXACT []
-is_a: metpo:1007081 ! oxidase test
+is_a: METPO:1007081 ! oxidase test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007087
+id: METPO:1007087
 name: urease positive
 def: "Test-outcome phenotype where the urease test yields a positive result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' GO:0009039 'urease activity'." [] {IAO:0000119="OMP:0006089"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM; xrefs=GO:0009039
 synonym: "urease +" EXACT []
 synonym: "urease test positive" EXACT []
-is_a: metpo:1007082 ! urease test
+is_a: METPO:1007082 ! urease test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007088
+id: METPO:1007088
 name: urease negative
 def: "Test-outcome phenotype where the urease test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' GO:0009039 'urease activity'." [] {IAO:0000119="OMP:0006090"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "urease -" EXACT []
 synonym: "urease test negative" EXACT []
-is_a: metpo:1007082 ! urease test
+is_a: METPO:1007082 ! urease test
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007089
+id: METPO:1007089
 name: coagulase activity
 def: "A phenotype characterized by coagulase enzyme activity (clotting of blood plasma); a diagnostic marker, e.g. for Staphylococcus aureus." [] {IAO:0000119="MICRO:0000991"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase test" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007090
+id: METPO:1007090
 name: coagulase positive
 def: "Test-outcome phenotype where the coagulase test yields a positive result (plasma clotting). The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000302 'shows activity of' <coagulase enzyme term> once a sufficiently specific enzyme term is selected (no GO/EC term currently exists at the bacteriological coagulase test granularity)." [] {IAO:0000119="wikidata:Q98095684"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase +" EXACT []
 synonym: "coagulase test positive" EXACT []
-is_a: metpo:1007089 ! coagulase activity
+is_a: METPO:1007089 ! coagulase activity
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007091
+id: METPO:1007091
 name: coagulase negative
 def: "Test-outcome phenotype where the coagulase test yields a negative result. The underlying enzyme-organism relation should additionally be asserted via <organism> METPO:2000303 'does not show activity of' <coagulase enzyme term> once a sufficiently specific enzyme term is selected." [] {IAO:0000119="wikidata:Q98095684"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "coagulase -" EXACT []
 synonym: "coagulase test negative" EXACT []
-is_a: metpo:1007089 ! coagulase activity
+is_a: METPO:1007089 ! coagulase activity
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007092
+id: METPO:1007092
 name: xerophilic phenotype
 def: "A phenotype characterized by a microbe that thrives in low water-activity environments (typically aw < 0.85), where the limiting factor is water activity (aw) rather than solute concentration; distinct from halophily and osmotic tolerance." [] {IAO:0000119="wikidata:Q980491"}
 comment: subset=metpo_proposal_2026_04; priority=MEDIUM
 synonym: "xerophile" EXACT []
 synonym: "xerotolerant" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:1007093
+id: METPO:1007093
 name: epibiont phenotype
 def: "A phenotype characterized by a microbe that lives on the external surface of a host organism or substrate, as distinct from endosymbionts (which live inside the host); captures host-association mode, not specific host taxonomy." [] {IAO:0000119="wikidata:Q640114"}
 comment: subset=metpo_proposal_2026_04; priority=LOW
 synonym: "ectosymbiont" EXACT []
 synonym: "epibiont" EXACT []
-is_a: metpo:1000059 ! phenotype
+is_a: METPO:1000059 ! phenotype
 property_value: IAO:0000117 "Marcin Joachimiak" xsd:string
 
 [Term]
-id: metpo:9999999
+id: METPO:9999999
 name: obsolete obsolete
 is_a: oboInOwl:ObsoleteClass ! Obsolete Class
 property_value: IAO:0000231 IAO:0000226
@@ -10881,814 +10881,814 @@ id: oboInOwl:ObsoleteClass
 name: Obsolete Class
 
 [Typedef]
-id: metpo:2000000
+id: METPO:2000000
 name: obsolete has susceptibility profile
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000001
+id: METPO:2000001
 name: organism interacts with chemical
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000002
+id: METPO:2000002
 name: assimilates
 synonym: "assimilation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000003
+id: METPO:2000003
 name: builds acid from
 synonym: "builds acid from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000004
+id: METPO:2000004
 name: builds base from
 synonym: "builds base from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000005
+id: METPO:2000005
 name: builds gas from
 synonym: "builds gas from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000006
+id: METPO:2000006
 name: uses as carbon source
 synonym: "carbon source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000007
+id: METPO:2000007
 name: degrades
 synonym: "degradation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000008
+id: METPO:2000008
 name: uses as electron acceptor
 synonym: "electron acceptor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000009
+id: METPO:2000009
 name: uses as electron donor
 synonym: "electron donor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000010
+id: METPO:2000010
 name: uses as energy source
 synonym: "energy source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000011
+id: METPO:2000011
 name: ferments
 synonym: "fermentation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000012
+id: METPO:2000012
 name: uses for growth
 synonym: "growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000013
+id: METPO:2000013
 name: hydrolyzes
 synonym: "hydrolysis" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000014
+id: METPO:2000014
 name: uses as nitrogen source
 synonym: "nitrogen source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000015
+id: METPO:2000015
 name: uses in other way
 synonym: "other" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "utilizes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000016
+id: METPO:2000016
 name: oxidizes
 synonym: "oxidation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000017
+id: METPO:2000017
 name: reduces
 synonym: "reduction" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000018
+id: METPO:2000018
 name: requires for growth
 synonym: "required for growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000019
+id: METPO:2000019
 name: uses for respiration
 synonym: "respiration" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000020
+id: METPO:2000020
 name: uses as sulfur source
 synonym: "sulfur source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000021
+id: METPO:2000021
 name: does not use for aerobic catabolization
 synonym: "aerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000022
+id: METPO:2000022
 name: does not use for aerobic growth
 synonym: "aerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000023
+id: METPO:2000023
 name: does not use for anaerobic catabolization
 synonym: "anaerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000024
+id: METPO:2000024
 name: does not use for anaerobic growth
 synonym: "anaerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000025
+id: METPO:2000025
 name: does not use for anaerobic growth in the dark
 synonym: "anaerobic growth in the dark" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000026
+id: METPO:2000026
 name: does not use for anaerobic growth with light
 synonym: "anaerobic growth with light" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000027
+id: METPO:2000027
 name: does not assimilate
 synonym: "assimilation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000028
+id: METPO:2000028
 name: does not build acid from
 synonym: "builds acid from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000029
+id: METPO:2000029
 name: does not build base from
 synonym: "builds base from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000030
+id: METPO:2000030
 name: does not build gas from
 synonym: "builds gas from" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000031
+id: METPO:2000031
 name: does not use as carbon source
 synonym: "carbon source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000032
+id: METPO:2000032
 name: uses for aerobic catabolization
 synonym: "aerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000033
+id: METPO:2000033
 name: does not degrade
 synonym: "degradation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000034
+id: METPO:2000034
 name: does not use as electron acceptor
 synonym: "electron acceptor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000035
+id: METPO:2000035
 name: does not use as electron donor
 synonym: "electron donor" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000036
+id: METPO:2000036
 name: does not use as energy source
 synonym: "energy source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000037
+id: METPO:2000037
 name: does not ferment
 synonym: "fermentation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000038
+id: METPO:2000038
 name: does not use for growth
 synonym: "growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000039
+id: METPO:2000039
 name: does not hydrolyze
 synonym: "hydrolysis" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000040
+id: METPO:2000040
 name: does not use as nitrogen source
 synonym: "nitrogen source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000041
+id: METPO:2000041
 name: does not use in other way
 synonym: "other" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
 synonym: "utilizes" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000042
+id: METPO:2000042
 name: does not oxidize
 synonym: "oxidation" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000043
+id: METPO:2000043
 name: uses for aerobic growth
 synonym: "aerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000044
+id: METPO:2000044
 name: does not reduce
 synonym: "reduction" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000045
+id: METPO:2000045
 name: is not required for growth
 synonym: "required for growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000046
+id: METPO:2000046
 name: does not use for respiration
 synonym: "respiration" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000047
+id: METPO:2000047
 name: does not use as sulfur source
 synonym: "sulfur source" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000048
+id: METPO:2000048
 name: uses for anaerobic catabolization
 synonym: "anaerobic catabolization" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000049
+id: METPO:2000049
 name: uses for anaerobic growth
 synonym: "anaerobic growth" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000050
+id: METPO:2000050
 name: uses for anaerobic growth in the dark
 synonym: "anaerobic growth in the dark" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000051
+id: METPO:2000051
 name: uses for anaerobic growth with light
 synonym: "anaerobic growth with light" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000052
+id: METPO:2000052
 name: obsolete has temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000053
+id: METPO:2000053
 name: obsolete has optimum temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000054
+id: METPO:2000054
 name: obsolete has growth temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000055
+id: METPO:2000055
 name: obsolete has range temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000056
+id: METPO:2000056
 name: obsolete has temperature delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000057
+id: METPO:2000057
 name: obsolete has culture temperature observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000064
+id: METPO:2000064
 name: tolerates
 def: "A relation between a microbe and a chemical entity indicating that the microbe's growth is not inhibited by the chemical at the concentration tested. Positive form of the chemical-tolerance pair; the negative form is METPO:2000065 'does not tolerate'." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000065
+id: METPO:2000065
 name: does not tolerate
 def: "A relation between a microbe and a chemical entity indicating that the microbe's growth is inhibited by the chemical at the concentration tested. Negative form of the chemical-tolerance pair; positive form is METPO:2000064 'tolerates'. Equivalent in meaning to 'is susceptible to' and 'is sensitive to'; the canonical label uses the 'does not X' convention so the metatraits pairing logic auto-detects it as the negative member." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
 
 [Typedef]
-id: metpo:2000067
+id: METPO:2000067
 name: isolated from host with quality
 def: "A relation between a microbe and a quality of the host from which the microbe was isolated. Examples: a microbe isolated from a juvenile host has the relation `<microbe> METPO:2000067 PATO:0001190 'juvenile'`; a microbe isolated from a female host has the relation `<microbe> METPO:2000067 PATO:0000383 'female'`. The relation is one-directional: it asserts that the host bore the named quality at isolation time, not that the microbe itself has the quality." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000068
+id: METPO:2000068
 name: isolated from environment with quality
 def: "A relation between a microbe and a quality of the environment from which the microbe was isolated. Examples: a microbe isolated from an acidic environment has the relation `<microbe> METPO:2000068 PATO:0001429 'acidic'`; a microbe isolated from an anaerobic environment has `<microbe> METPO:2000068 PATO:0001456 'anaerobic'`. The relation does not by itself entail that the microbe is acidophilic, anaerobic, etc. as a phenotype; it only records the environment's quality at the time of isolation. Microbe phenotype assertions belong on a separate edge (e.g. METPO:1000615 acidophilic via has_phenotype)." []
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000101
+id: METPO:2000101
 name: has quality
-domain: metpo:1000525 ! microbe
-range: metpo:1000188 ! quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000188 ! quality
 
 [Typedef]
-id: metpo:2000102
+id: METPO:2000102
 name: has phenotype
 property_value: skos:closeMatch has:phenotype
-domain: metpo:1000525 ! microbe
-range: metpo:1000059 ! phenotype
-is_a: metpo:2000101 ! has quality
+domain: METPO:1000525 ! microbe
+range: METPO:1000059 ! phenotype
+is_a: METPO:2000101 ! has quality
 
 [Typedef]
-id: metpo:2000103
+id: METPO:2000103
 name: capable of
 property_value: skos:closeMatch capable:of
-domain: metpo:1000525 ! microbe
-range: metpo:1000630 ! biological process
+domain: METPO:1000525 ! microbe
+range: METPO:1000630 ! biological process
 
 [Typedef]
-id: metpo:2000200
+id: METPO:2000200
 name: disproportionates
 synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000201
+id: METPO:2000201
 name: obsolete lyses
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000202
+id: METPO:2000202
 name: produces
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000203
+id: METPO:2000203
 name: obsolete fixes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000204
+id: METPO:2000204
 name: obsolete catabolizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000205
+id: METPO:2000205
 name: obsolete mineralizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000206
+id: METPO:2000206
 name: obsolete conjugates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000207
+id: METPO:2000207
 name: transports
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000208
+id: METPO:2000208
 name: imports
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000207 ! transports
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000207 ! transports
 
 [Typedef]
-id: metpo:2000209
+id: METPO:2000209
 name: exports
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000207 ! transports
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000207 ! transports
 
 [Typedef]
-id: metpo:2000210
+id: METPO:2000210
 name: accumulates
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000211
+id: METPO:2000211
 name: sequesters
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000210 ! accumulates
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000210 ! accumulates
 
 [Typedef]
-id: metpo:2000212
+id: METPO:2000212
 name: compartmentalizes
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000210 ! accumulates
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000210 ! accumulates
 
 [Typedef]
-id: metpo:2000213
+id: METPO:2000213
 name: obsolete binds
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000214
+id: METPO:2000214
 name: obsolete chelates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000215
+id: METPO:2000215
 name: obsolete precipitates
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000216
+id: METPO:2000216
 name: obsolete solubilizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000217
+id: METPO:2000217
 name: obsolete volatilizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000218
+id: METPO:2000218
 name: obsolete crystallizes
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000219
+id: METPO:2000219
 name: obsolete adsorbs
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000220
+id: METPO:2000220
 name: does not disproportionate
 synonym: "dismutates" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000221
+id: METPO:2000221
 name: obsolete does not lyse
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000222
+id: METPO:2000222
 name: does not produce
 synonym: "produces" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000223
+id: METPO:2000223
 name: obsolete does not fix
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000224
+id: METPO:2000224
 name: obsolete does not catabolize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000225
+id: METPO:2000225
 name: obsolete does not mineralize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000226
+id: METPO:2000226
 name: obsolete does not conjugate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000227
+id: METPO:2000227
 name: does not transport
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000228
+id: METPO:2000228
 name: does not import
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000227 ! does not transport
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000227 ! does not transport
 
 [Typedef]
-id: metpo:2000229
+id: METPO:2000229
 name: does not export
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000227 ! does not transport
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000227 ! does not transport
 
 [Typedef]
-id: metpo:2000230
+id: METPO:2000230
 name: does not accumulate
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000231
+id: METPO:2000231
 name: does not sequester
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000230 ! does not accumulate
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000230 ! does not accumulate
 
 [Typedef]
-id: metpo:2000232
+id: METPO:2000232
 name: does not compartmentalize
-domain: metpo:1000525 ! microbe
-range: metpo:1000526 ! chemical entity
-is_a: metpo:2000230 ! does not accumulate
+domain: METPO:1000525 ! microbe
+range: METPO:1000526 ! chemical entity
+is_a: METPO:2000230 ! does not accumulate
 
 [Typedef]
-id: metpo:2000233
+id: METPO:2000233
 name: obsolete does not bind
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000234
+id: METPO:2000234
 name: obsolete does not chelate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000235
+id: METPO:2000235
 name: obsolete does not precipitate
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000236
+id: METPO:2000236
 name: obsolete does not solubilize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000237
+id: METPO:2000237
 name: obsolete does not volatilize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000238
+id: METPO:2000238
 name: obsolete does not crystallize
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000239
+id: METPO:2000239
 name: obsolete has pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000301
+id: METPO:2000301
 name: enzyme activity analyzed
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
 
 [Typedef]
-id: metpo:2000302
+id: METPO:2000302
 name: shows activity of
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
-is_a: metpo:2000301 ! enzyme activity analyzed
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
+is_a: METPO:2000301 ! enzyme activity analyzed
 
 [Typedef]
-id: metpo:2000303
+id: METPO:2000303
 name: does not show activity of
 synonym: "Physiology and metabolism.enzymes.[].activity" RELATED [] {IAO:0000119="https://bacdive.dsmz.de/"}
-domain: metpo:1000525 ! microbe
-range: metpo:1000527 ! enzyme
-is_a: metpo:2000301 ! enzyme activity analyzed
+domain: METPO:1000525 ! microbe
+range: METPO:1000527 ! enzyme
+is_a: METPO:2000301 ! enzyme activity analyzed
 
 [Typedef]
-id: metpo:2000501
+id: METPO:2000501
 name: obsolete has optimum pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000502
+id: METPO:2000502
 name: obsolete has growth pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000503
+id: METPO:2000503
 name: obsolete has range pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000504
+id: METPO:2000504
 name: obsolete has pH delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000505
+id: METPO:2000505
 name: obsolete has culture pH observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000506
+id: METPO:2000506
 name: obsolete has NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000507
+id: METPO:2000507
 name: obsolete has optimum NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000508
+id: METPO:2000508
 name: obsolete has growth NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000509
+id: METPO:2000509
 name: obsolete has range NaCl observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000510
+id: METPO:2000510
 name: obsolete has NaCl delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000511
+id: METPO:2000511
 name: obsolete has observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000512
+id: METPO:2000512
 name: obsolete has oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000513
+id: METPO:2000513
 name: obsolete has optimum oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000514
+id: METPO:2000514
 name: obsolete has growth oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000515
+id: METPO:2000515
 name: obsolete has range oxygen observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000516
+id: METPO:2000516
 name: obsolete has oxygen delta observation
 property_value: IAO:0000231 IAO:0000226
 is_obsolete: true
 
 [Typedef]
-id: metpo:2000517
+id: METPO:2000517
 name: grows in
 def: "A relation between a microbe and a growth medium indicating that the microbe has been demonstrated to grow in that medium under some set of conditions. This relation represents a generalization from experimental observations reported in the literature or databases; it does not imply that the microbe will grow in the medium under all conditions." []
-domain: metpo:1000525 ! microbe
-range: metpo:1004005 ! growth medium
+domain: METPO:1000525 ! microbe
+range: METPO:1004005 ! growth medium
 
 [Typedef]
-id: metpo:2000518
+id: METPO:2000518
 name: does not grow in
 def: "A relation between a microbe and a growth medium indicating that the microbe has been demonstrated to fail to grow in that medium under some set of conditions. This relation represents a generalization from experimental observations reported in the literature or databases; it does not imply that the microbe cannot grow in the medium under any conditions." []
-domain: metpo:1000525 ! microbe
-range: metpo:1004005 ! growth medium
+domain: METPO:1000525 ! microbe
+range: METPO:1004005 ! growth medium
 
 [Typedef]
-id: metpo:2000601
+id: METPO:2000601
 name: denitrifies
 synonym: "denitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000602
+id: METPO:2000602
 name: does not denitrify
 synonym: "denitrification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000603
+id: METPO:2000603
 name: ammonifies
 synonym: "ammonification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000604
+id: METPO:2000604
 name: does not ammonify
 synonym: "ammonification" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000605
+id: METPO:2000605
 name: oxidizes in darkness
 synonym: "oxidation in darkness" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 
 [Typedef]
-id: metpo:2000606
+id: METPO:2000606
 name: does not oxidize in darkness
 synonym: "oxidation in darkness" RELATED [] {IAO:0000119="https://metatraits.embl.de/"}
-is_a: metpo:2000001 ! organism interacts with chemical
+is_a: METPO:2000001 ! organism interacts with chemical
 

--- a/metpo.owl
+++ b/metpo.owl
@@ -10,7 +10,7 @@
      xmlns:qudt="http://qudt.org/schema/qudt/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-     xmlns:metpo="https://w3id.org/metpo/"
+     xmlns:METPO="https://w3id.org/metpo/"
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="https://w3id.org/metpo/metpo.owl">
@@ -13876,7 +13876,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_&lt;=42.65</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC low</rdfs:label>
-        <metpo:range_max>42.65</metpo:range_max>
+        <METPO:range_max>42.65</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000429"/>
@@ -13916,8 +13916,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_42.65_57.0</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC mid1</rdfs:label>
-        <metpo:range_max>57</metpo:range_max>
-        <metpo:range_min>42.65</metpo:range_min>
+        <METPO:range_max>57</METPO:range_max>
+        <METPO:range_min>42.65</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000430"/>
@@ -13957,8 +13957,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_57.0_66.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC mid2</rdfs:label>
-        <metpo:range_max>66.3</metpo:range_max>
-        <metpo:range_min>57</metpo:range_min>
+        <METPO:range_max>66.3</METPO:range_max>
+        <METPO:range_min>57</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000431"/>
@@ -13995,7 +13995,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000127"/>
         <oboInOwl:hasRelatedSynonym>GC_&gt;66.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>GC high</rdfs:label>
-        <metpo:range_min>66.3</metpo:range_min>
+        <METPO:range_min>66.3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000432"/>
@@ -14130,7 +14130,7 @@
         <oboInOwl:hasExactSynonym>Psychrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_&lt;=10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum very low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
+        <METPO:range_max>10</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000441"/>
@@ -14173,8 +14173,8 @@
         <oboInOwl:hasExactSynonym>Psychrotolerant</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_10_to_22</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum low</rdfs:label>
-        <metpo:range_max>22</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>22</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000442"/>
@@ -14216,8 +14216,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid1</rdfs:label>
-        <metpo:range_max>27</metpo:range_max>
-        <metpo:range_min>22</metpo:range_min>
+        <METPO:range_max>27</METPO:range_max>
+        <METPO:range_min>22</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000443"/>
@@ -14259,8 +14259,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>27</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>27</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000444"/>
@@ -14302,8 +14302,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid3</rdfs:label>
-        <metpo:range_max>34</metpo:range_max>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_max>34</METPO:range_max>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000445"/>
@@ -14345,8 +14345,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum mid4</rdfs:label>
-        <metpo:range_max>40</metpo:range_max>
-        <metpo:range_min>34</metpo:range_min>
+        <METPO:range_max>40</METPO:range_max>
+        <METPO:range_min>34</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000446"/>
@@ -14385,7 +14385,7 @@
         <oboInOwl:hasExactSynonym>Thermophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TO_&gt;40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature optimum high</rdfs:label>
-        <metpo:range_min>40</metpo:range_min>
+        <METPO:range_min>40</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000447"/>
@@ -14424,7 +14424,7 @@
         <oboInOwl:hasExactSynonym>Psychrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_&lt;=10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range very low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
+        <METPO:range_max>10</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000448"/>
@@ -14467,8 +14467,8 @@
         <oboInOwl:hasExactSynonym>Psychrotolerant</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_10_to_22</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range low</rdfs:label>
-        <metpo:range_max>22</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>22</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000449"/>
@@ -14510,8 +14510,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_22_to_27</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid1</rdfs:label>
-        <metpo:range_max>27</metpo:range_max>
-        <metpo:range_min>22</metpo:range_min>
+        <METPO:range_max>27</METPO:range_max>
+        <METPO:range_min>22</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000450"/>
@@ -14553,8 +14553,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_27_to_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>27</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>27</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000451"/>
@@ -14596,8 +14596,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_30_to_34</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid3</rdfs:label>
-        <metpo:range_max>34</metpo:range_max>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_max>34</METPO:range_max>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000452"/>
@@ -14639,8 +14639,8 @@
         <oboInOwl:hasExactSynonym>mesophilic</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_34_to_40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range mid4</rdfs:label>
-        <metpo:range_max>40</metpo:range_max>
-        <metpo:range_min>34</metpo:range_min>
+        <METPO:range_max>40</METPO:range_max>
+        <METPO:range_min>34</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000453"/>
@@ -14679,7 +14679,7 @@
         <oboInOwl:hasExactSynonym>Thermophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>TR_&gt;40</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature range high</rdfs:label>
-        <metpo:range_min>40</metpo:range_min>
+        <METPO:range_min>40</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000454"/>
@@ -14724,8 +14724,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_0_to_6</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum low</rdfs:label>
-        <metpo:range_max>6</metpo:range_max>
-        <metpo:range_min>0</metpo:range_min>
+        <METPO:range_max>6</METPO:range_max>
+        <METPO:range_min>0</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000455"/>
@@ -14767,8 +14767,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_6_to_7</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum mid1</rdfs:label>
-        <metpo:range_max>7</metpo:range_max>
-        <metpo:range_min>6</metpo:range_min>
+        <METPO:range_max>7</METPO:range_max>
+        <METPO:range_min>6</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000456"/>
@@ -14811,8 +14811,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_7_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>7</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>7</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000457"/>
@@ -14855,8 +14855,8 @@
         <oboInOwl:hasExactSynonym>Extreme Alkaliphile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHO_8_to_14</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH optimum high</rdfs:label>
-        <metpo:range_max>14</metpo:range_max>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_max>14</METPO:range_max>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000458"/>
@@ -14901,8 +14901,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_0_to_4</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range very low</rdfs:label>
-        <metpo:range_max>4</metpo:range_max>
-        <metpo:range_min>0</metpo:range_min>
+        <METPO:range_max>4</METPO:range_max>
+        <METPO:range_min>0</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000459"/>
@@ -14946,8 +14946,8 @@
         <oboInOwl:hasExactSynonym>Obligative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_4_to_6</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range low</rdfs:label>
-        <metpo:range_max>6</metpo:range_max>
-        <metpo:range_min>4</metpo:range_min>
+        <METPO:range_max>6</METPO:range_max>
+        <METPO:range_min>4</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000460"/>
@@ -14990,8 +14990,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_6_to_7</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid1</rdfs:label>
-        <metpo:range_max>7</metpo:range_max>
-        <metpo:range_min>6</metpo:range_min>
+        <METPO:range_max>7</METPO:range_max>
+        <METPO:range_min>6</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000461"/>
@@ -15035,8 +15035,8 @@
         <oboInOwl:hasExactSynonym>Neutrophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_7_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>7</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>7</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000462"/>
@@ -15080,8 +15080,8 @@
         <oboInOwl:hasExactSynonym>Facultative acidophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>pHR_8_to_10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range mid3</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_max>10</METPO:range_max>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000463"/>
@@ -15124,8 +15124,8 @@
         <oboInOwl:hasExactSynonym>Extreme Alkaliphile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>10_to_14</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH range high</rdfs:label>
-        <metpo:range_max>14</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>14</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000464"/>
@@ -15165,7 +15165,7 @@
         <oboInOwl:hasExactSynonym>Non-halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000465"/>
@@ -15208,8 +15208,8 @@
         <oboInOwl:hasExactSynonym>Slight halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_1_to_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000466"/>
@@ -15252,8 +15252,8 @@
         <oboInOwl:hasExactSynonym>Moderate halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_3_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000467"/>
@@ -15292,7 +15292,7 @@
         <oboInOwl:hasExactSynonym>Extreme halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaO_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl optimum high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000468"/>
@@ -15332,7 +15332,7 @@
         <oboInOwl:hasExactSynonym>Non-halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000469"/>
@@ -15375,8 +15375,8 @@
         <oboInOwl:hasExactSynonym>Slight halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_1_to_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000470"/>
@@ -15419,8 +15419,8 @@
         <oboInOwl:hasExactSynonym>Moderate halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_3_to_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000471"/>
@@ -15459,7 +15459,7 @@
         <oboInOwl:hasExactSynonym>Extreme halophile</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>NaR_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl range high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000472"/>
@@ -15496,7 +15496,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta very low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000473"/>
@@ -15536,8 +15536,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_1_2</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta low</rdfs:label>
-        <metpo:range_max>2</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>2</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000474"/>
@@ -15577,8 +15577,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_2_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>2</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>2</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000475"/>
@@ -15618,8 +15618,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_3_4</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid2</rdfs:label>
-        <metpo:range_max>4</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>4</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000476"/>
@@ -15659,8 +15659,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_4_5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta mid3</rdfs:label>
-        <metpo:range_max>5</metpo:range_max>
-        <metpo:range_min>4</metpo:range_min>
+        <METPO:range_max>5</METPO:range_max>
+        <METPO:range_min>4</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000477"/>
@@ -15700,8 +15700,8 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/metpo/1000232"/>
         <oboInOwl:hasRelatedSynonym>pHd_5_9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>pH delta high</rdfs:label>
-        <metpo:range_max>9</metpo:range_max>
-        <metpo:range_min>5</metpo:range_min>
+        <METPO:range_max>9</METPO:range_max>
+        <METPO:range_min>5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000478"/>
@@ -15739,7 +15739,7 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_&lt;=1</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta low</rdfs:label>
-        <metpo:range_max>1</metpo:range_max>
+        <METPO:range_max>1</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000479"/>
@@ -15780,8 +15780,8 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_1_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta mid1</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000480"/>
@@ -15822,8 +15822,8 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_3_8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta mid2</rdfs:label>
-        <metpo:range_max>8</metpo:range_max>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_max>8</METPO:range_max>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000481"/>
@@ -15861,7 +15861,7 @@
         <qudt:ucumCode>%</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Nad_&gt;8</oboInOwl:hasRelatedSynonym>
         <rdfs:label>NaCl delta high</rdfs:label>
-        <metpo:range_min>8</metpo:range_min>
+        <METPO:range_min>8</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000482"/>
@@ -15902,8 +15902,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_1_5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta very low</rdfs:label>
-        <metpo:range_max>5</metpo:range_max>
-        <metpo:range_min>1</metpo:range_min>
+        <METPO:range_max>5</METPO:range_max>
+        <METPO:range_min>1</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000483"/>
@@ -15944,8 +15944,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_5_10</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta low</rdfs:label>
-        <metpo:range_max>10</metpo:range_max>
-        <metpo:range_min>5</metpo:range_min>
+        <METPO:range_max>10</METPO:range_max>
+        <METPO:range_min>5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000484"/>
@@ -15986,8 +15986,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_10_20</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta mid1</rdfs:label>
-        <metpo:range_max>20</metpo:range_max>
-        <metpo:range_min>10</metpo:range_min>
+        <METPO:range_max>20</METPO:range_max>
+        <METPO:range_min>10</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000485"/>
@@ -16028,8 +16028,8 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_20_30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta mid2</rdfs:label>
-        <metpo:range_max>30</metpo:range_max>
-        <metpo:range_min>20</metpo:range_min>
+        <METPO:range_max>30</METPO:range_max>
+        <METPO:range_min>20</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000486"/>
@@ -16067,7 +16067,7 @@
         <qudt:ucumCode>Cel</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>Td_&gt;30</oboInOwl:hasRelatedSynonym>
         <rdfs:label>temperature delta high</rdfs:label>
-        <metpo:range_min>30</metpo:range_min>
+        <METPO:range_min>30</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000487"/>
@@ -20603,7 +20603,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_&lt;=1.3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length very small</rdfs:label>
-        <metpo:range_max>1.3</metpo:range_max>
+        <METPO:range_max>1.3</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000883"/>
@@ -20644,8 +20644,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_1.3_2</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length small</rdfs:label>
-        <metpo:range_max>2</metpo:range_max>
-        <metpo:range_min>1.3</metpo:range_min>
+        <METPO:range_max>2</METPO:range_max>
+        <METPO:range_min>1.3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000884"/>
@@ -20686,8 +20686,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_2_3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length medium</rdfs:label>
-        <metpo:range_max>3</metpo:range_max>
-        <metpo:range_min>2</metpo:range_min>
+        <METPO:range_max>3</METPO:range_max>
+        <METPO:range_min>2</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000885"/>
@@ -20725,7 +20725,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>L_&gt;3</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell length large</rdfs:label>
-        <metpo:range_min>3</metpo:range_min>
+        <METPO:range_min>3</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000886"/>
@@ -20763,7 +20763,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_&lt;=0.5</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width very small</rdfs:label>
-        <metpo:range_max>0.5</metpo:range_max>
+        <METPO:range_max>0.5</METPO:range_max>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000887"/>
@@ -20804,8 +20804,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_0.5_0.65</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width small</rdfs:label>
-        <metpo:range_max>0.65</metpo:range_max>
-        <metpo:range_min>0.5</metpo:range_min>
+        <METPO:range_max>0.65</METPO:range_max>
+        <METPO:range_min>0.5</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000888"/>
@@ -20846,8 +20846,8 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_0.65_0.9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width medium</rdfs:label>
-        <metpo:range_max>0.9</metpo:range_max>
-        <metpo:range_min>0.65</metpo:range_min>
+        <METPO:range_max>0.9</METPO:range_max>
+        <METPO:range_min>0.65</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000889"/>
@@ -20885,7 +20885,7 @@
         <qudt:ucumCode>um</qudt:ucumCode>
         <oboInOwl:hasRelatedSynonym>W_&gt;0.9</oboInOwl:hasRelatedSynonym>
         <rdfs:label>cell width large</rdfs:label>
-        <metpo:range_min>0.9</metpo:range_min>
+        <METPO:range_min>0.9</METPO:range_min>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://w3id.org/metpo/1000890"/>

--- a/src/ontology/metpo-edit.owl
+++ b/src/ontology/metpo-edit.owl
@@ -6,6 +6,7 @@ Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 Prefix(dcterms:=<http://purl.org/dc/terms/>)
 Prefix(IAO:=<http://purl.obolibrary.org/obo/IAO_>)
+Prefix(METPO:=<https://w3id.org/metpo/>)
 
 
 Ontology(<https://w3id.org/metpo/metpo.owl>


### PR DESCRIPTION
Closes #557.

The released `.obo` artifacts shipped `idspace: metpo` + `id: metpo:...` (lowercase), which conflicts with the blessed uppercase `METPO:` prefix (#16) and with OBO Foundry's uppercase-idspace convention (GO, CHEBI, PATO).

### Root cause
Nothing in the source declared a prefix for the `https://w3id.org/metpo/` namespace, so ROBOT assigned the lowercase `metpo` during the release merge/reason chain, and `robot convert -f obo` faithfully copied that case. Verified by reproducing the merge chain locally (details in #557).

### Fix
One line in `metpo-edit.owl`: `Prefix(METPO:=<https://w3id.org/metpo/>)`. Declaring the prefix upstream makes ROBOT use `METPO` (no lowercase, no duplicate idspace). No change to the ODK-generated Makefile, and no post-processing. The fix lives in the hand-edited source, so it survives `update_repo`.

### Artifacts
Regenerated with `obolibrary/odkfull:v1.6.1` `prepare_release`, with `TODAY` pinned to the committed version date (2026-06-12) so the only change is the prefix case. All three `.obo` now emit `idspace: METPO` and `id: METPO:` (0 lowercase). Term count unchanged (1455). The `.json` artifacts use full IRIs and are unaffected.

The `artifact-freshness` check should pass since a fresh build now reproduces these.